### PR TITLE
Feat/9 hotel supplier plugin

### DIFF
--- a/services/travel-supply-service/.env
+++ b/services/travel-supply-service/.env
@@ -1,0 +1,7 @@
+# Amadeus API
+AMADEUS_CLIENT_ID=qMZOsl5CVt18nNaBDU4fAUg7Hmo9tgtA
+AMADEUS_CLIENT_SECRET=jret8AmcL6MzCYpt
+AMADEUS_BASE_URL=https://test.api.amadeus.com
+
+# Google Places API
+GOOGLE_PLACES_API_KEY=AIzaSyD0r8LY_gRa8E2r0ZwwczkWa2F_EnNXCc4

--- a/services/travel-supply-service/.gitignore
+++ b/services/travel-supply-service/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment ###
+.env

--- a/services/travel-supply-service/CLAUDE.md
+++ b/services/travel-supply-service/CLAUDE.md
@@ -35,7 +35,7 @@ bootstrap/                   ← SupplierRegistry (auto-discovers supplier imple
 
 ### Supplier System
 
-New flight/hotel suppliers are added by implementing `FlightSupplierPort` or `HotelSupplierPort` and registering them. `SupplierRegistry` auto-discovers all port implementations at startup. `SupplierRouter` routes requests to the correct supplier by key (configurable default: `amadeus`).
+New flight/hotel suppliers are added by implementing `FlightSupplierPort` or `HotelSupplierPort` and registering them. `SupplierRegistry` auto-discovers all port implementations at startup and maintains separate maps for flight and hotel suppliers. `SupplierRouter` routes requests to the correct supplier by key via `selectFlightSupplier(key)` / `selectHotelSupplier(key)` (configurable default: `amadeus`). Both `/supply/flights/offers` and `/supply/hotels/offers` accept an optional `supplier` query parameter for runtime supplier selection.
 
 ### Amadeus Integration
 

--- a/services/travel-supply-service/TODO.md
+++ b/services/travel-supply-service/TODO.md
@@ -1,3 +1,3 @@
 # TODO
 
-- [ ] hotel search 부분 amadeus 제외 다른 api를 사용할 수 있으니, 다른 api 가져와서 adapter만 추가하면 바로 사용할 수 있도록 변경 필요
+- [ ] 

--- a/services/travel-supply-service/build.gradle
+++ b/services/travel-supply-service/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'   // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
@@ -23,9 +23,10 @@ public class HotelSearchController {
             @RequestParam java.time.LocalDate checkIn,
             @RequestParam java.time.LocalDate checkOut,
             @RequestParam(defaultValue = "1") int adults,
-            @RequestParam(defaultValue = "1") int roomQuantity
+            @RequestParam(defaultValue = "1") int roomQuantity,
+            @RequestParam(required = false) String supplier
     ) {
-        return hotelSearchService.search(cityCode, checkIn, checkOut, adults, roomQuantity);
+        return hotelSearchService.search(supplier, cityCode, checkIn, checkOut, adults, roomQuantity);
     }
 
     @GetMapping("/place-info")

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.adapter.outbound.google.GooglePlacesClient;
 import com.sofly.supply.adapter.outbound.google.PlaceInfo;
 import com.sofly.supply.application.dto.HotelSearchResult;
-import com.sofly.supply.application.port.outbound.HotelSupplierPort;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -13,16 +12,16 @@ import java.util.List;
 @Service
 public class HotelSearchService {
 
-    private final HotelSupplierPort hotelSupplierPort;
+    private final SupplierRouter router;
     private final GooglePlacesClient googlePlacesClient;
 
-    public HotelSearchService(HotelSupplierPort hotelSupplierPort, GooglePlacesClient googlePlacesClient) {
-        this.hotelSupplierPort = hotelSupplierPort;
+    public HotelSearchService(SupplierRouter router, GooglePlacesClient googlePlacesClient) {
+        this.router = router;
         this.googlePlacesClient = googlePlacesClient;
     }
 
-    public List<HotelSearchResult> search(String cityCode, java.time.LocalDate checkIn, java.time.LocalDate checkOut, int adults, int roomQuantity) {
-        JsonNode amadeusResponse = hotelSupplierPort.searchHotelsByCity(cityCode, checkIn, checkOut, adults, roomQuantity);
+    public List<HotelSearchResult> search(String supplier, String cityCode, java.time.LocalDate checkIn, java.time.LocalDate checkOut, int adults, int roomQuantity) {
+        JsonNode amadeusResponse = router.selectHotelSupplier(supplier).searchHotelsByCity(cityCode, checkIn, checkOut, adults, roomQuantity);
 
         List<HotelSearchResult> results = new ArrayList<>();
 

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/SupplierRouter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/SupplierRouter.java
@@ -1,6 +1,7 @@
 package com.sofly.supply.application.service;
 
 import com.sofly.supply.application.port.outbound.FlightSupplierPort;
+import com.sofly.supply.application.port.outbound.HotelSupplierPort;
 import com.sofly.supply.bootstrap.SupplierRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -22,5 +23,12 @@ public class SupplierRouter {
                 ? defaultSupplier
                 : requestedSupplier;
         return registry.getFlightSupplier(key);
+    }
+
+    public HotelSupplierPort selectHotelSupplier(String requestedSupplier) {
+        String key = (requestedSupplier == null || requestedSupplier.isBlank())
+                ? defaultSupplier
+                : requestedSupplier;
+        return registry.getHotelSupplier(key);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/SupplierRouter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/SupplierRouter.java
@@ -6,6 +6,8 @@ import com.sofly.supply.bootstrap.SupplierRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.function.Function;
+
 @Component
 public class SupplierRouter {
 
@@ -19,16 +21,17 @@ public class SupplierRouter {
     }
 
     public FlightSupplierPort selectFlightSupplier(String requestedSupplier) {
-        String key = (requestedSupplier == null || requestedSupplier.isBlank())
-                ? defaultSupplier
-                : requestedSupplier;
-        return registry.getFlightSupplier(key);
+        return select(requestedSupplier, registry::getFlightSupplier);
     }
 
     public HotelSupplierPort selectHotelSupplier(String requestedSupplier) {
+        return select(requestedSupplier, registry::getHotelSupplier);
+    }
+
+    private <T> T select(String requestedSupplier, Function<String, T> getter) {
         String key = (requestedSupplier == null || requestedSupplier.isBlank())
                 ? defaultSupplier
                 : requestedSupplier;
-        return registry.getHotelSupplier(key);
+        return getter.apply(key);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/bootstrap/SupplierRegistry.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/bootstrap/SupplierRegistry.java
@@ -1,6 +1,7 @@
 package com.sofly.supply.bootstrap;
 
 import com.sofly.supply.application.port.outbound.FlightSupplierPort;
+import com.sofly.supply.application.port.outbound.HotelSupplierPort;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -12,9 +13,16 @@ import java.util.stream.Collectors;
 public class SupplierRegistry {
 
     private final Map<String, FlightSupplierPort> flightSuppliers;
+    private final Map<String, HotelSupplierPort> hotelSuppliers;
 
-    public SupplierRegistry(List<FlightSupplierPort> suppliers) {
-        this.flightSuppliers = suppliers.stream()
+    public SupplierRegistry(List<FlightSupplierPort> flightSuppliers,
+                            List<HotelSupplierPort> hotelSuppliers) {
+        this.flightSuppliers = flightSuppliers.stream()
+                .collect(Collectors.toUnmodifiableMap(
+                        s -> s.supplierKey().toLowerCase(),
+                        Function.identity()
+                ));
+        this.hotelSuppliers = hotelSuppliers.stream()
                 .collect(Collectors.toUnmodifiableMap(
                         s -> s.supplierKey().toLowerCase(),
                         Function.identity()
@@ -31,5 +39,17 @@ public class SupplierRegistry {
 
     public Map<String, FlightSupplierPort> allFlightSuppliers() {
         return flightSuppliers;
+    }
+
+    public HotelSupplierPort getHotelSupplier(String supplierKey) {
+        HotelSupplierPort supplier = hotelSuppliers.get(supplierKey.toLowerCase());
+        if (supplier == null) {
+            throw new IllegalArgumentException("Unknown hotel supplier: " + supplierKey);
+        }
+        return supplier;
+    }
+
+    public Map<String, HotelSupplierPort> allHotelSuppliers() {
+        return hotelSuppliers;
     }
 }


### PR DESCRIPTION
## 📌 PR 요약        
  호텔 공급사도 항공편과 동일한 `HotelSupplierPort` 기반 플러그인 구조로 전환합니다.
  `SupplierRegistry`가 호텔 공급사 구현체를 자동 발견하고, `SupplierRouter`를 통해 런타임에 공급사를 선택할 수 있도록 합니다.

 ## 🔧 변경 사항                                                                                                                                                                                                                   
  - **HotelSupplierPort 인터페이스 도입**: 호텔 공급사를 플러그인으로 관리하기 위한 포트 인터페이스 정의. 향후 다른 호텔 공급사 추가 시 코드 변경 없이 구현체만 추가하면 됨                                                         
  - **AmadeusHotelAdapter 분리**: 기존 호텔 로직을 `HotelSupplierPort` 구현체로 분리하여 Amadeus 의존성 격리                                                                                                                        
  - **SupplierRegistry 확장**: 항공편에 이어 호텔 공급사도 Spring 빈 자동 발견으로 등록되도록 확장                                                                                                                                  
  - **SupplierRouter 확장**: `selectHotelSupplier(key)` 추가로 `/supply/hotels/offers`에서 `supplier` 쿼리 파라미터를 통한 런타임 공급사 선택 지원                                                                                  
  - **.env 파일 추가**: 환경변수(`AMADEUS_CLIENT_ID`, `AMADEUS_CLIENT_SECRET`, `GOOGLE_PLACES_API_KEY`) 관리 체계 구성                                                                                                              
                                                                                                                                                                                                                                    
  ## 📋 작업 상세 내용                                                                                                                                                                                                              
  - [x] `HotelSupplierPort` 인터페이스 정의                                                                                                                                                                                         
  - [x] `AmadeusHotelAdapter`를 `HotelSupplierPort` 구현체로 분리                                                                                                                                                                   
  - [x] `SupplierRegistry`에 호텔 공급사 자동 발견 로직 추가
  - [x] `SupplierRouter`에 `selectHotelSupplier(key)` 메서드 추가                                                                                                                                                                   
  - [x] `/supply/hotels/offers`에 `supplier` 쿼리 파라미터 지원
  - [x] `.env` 파일 추가 및 `.gitignore` 등록                                                                                                                                                                                       
                  
  ## 🔗 관련 이슈                                                                                                                                                                                                                   
  - closed #9     