### PR TITLE
Feat/14 schedule

### DIFF
--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
@@ -75,11 +75,12 @@ public class ScheduleController {
     }
 
     // PATCH /api/v1/schedules/items/{itemId}
-    @PatchMapping("/items/{itemId}")
+    @PatchMapping("/schedules/{scheduleId}/items/{itemId}")
     public ResponseEntity<ScheduleItemResponse> updateItem(
+            @PathVariable Long scheduleId,
             @PathVariable Long itemId,
             @RequestBody @Valid ScheduleItemUpdateRequest request) {
-        return ResponseEntity.ok(scheduleService.updateItem(itemId, request));
+        return ResponseEntity.ok(scheduleService.updateItem(scheduleId, itemId, request));
     }
 
     // PATCH /api/v1/schedules/{scheduleId}/items/reorder
@@ -101,21 +102,23 @@ public class ScheduleController {
         return ResponseEntity.noContent().build();
     }
 
-    // DELETE /api/v1/schedules/items/{itemId}
-    @DeleteMapping("/items/{itemId}")
+    // DELETE /schedules/{scheduleId}/items/{itemId}
+    @DeleteMapping("/schedules/{scheduleId}/items/{itemId}")
     public ResponseEntity<Void> deleteItem(
+            @PathVariable Long scheduleId,
             @PathVariable Long itemId) {
-        scheduleService.deleteItem(itemId);
+        scheduleService.deleteItem(scheduleId ,itemId);
         return ResponseEntity.noContent().build();
     }
 
     // ── 딥링크 ──────────────────────────────────────────────
 
-    // POST /api/v1/schedules/items/{itemId}/deeplink-click
-    @PostMapping("/items/{itemId}/deeplink-click")
+    // POST /schedules/{scheduleId}/items/{itemId}/deeplink-click
+    @PostMapping("/schedules/{scheduleId}/items/{itemId}/deeplink-click")
     public ResponseEntity<Void> trackDeepLinkClick(
+            @PathVariable Long scheduleId,
             @PathVariable Long itemId) {
-        scheduleService.trackDeepLinkClick(itemId);
+        scheduleService.trackDeepLinkClick(scheduleId, itemId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
@@ -1,4 +1,121 @@
 package com.sofly.core.domain.schedule.controller;
 
+import com.sofly.core.domain.schedule.dto.*;
+import com.sofly.core.domain.schedule.service.ScheduleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
 public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    // ── 조회 ────────────────────────────────────────────────
+
+    // GET /api/v1/schedules?workspaceId=1
+    @GetMapping
+    public ResponseEntity<List<ScheduleSummaryResponse>> getSchedules(
+            @RequestParam Long workspaceId) {
+        return ResponseEntity.ok(scheduleService.getSchedulesByWorkspace(workspaceId));
+    }
+
+    // GET /api/v1/schedules/{scheduleId}
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleResponse> getSchedule(
+            @PathVariable Long scheduleId) {
+        return ResponseEntity.ok(scheduleService.getSchedule(scheduleId));
+    }
+
+    // GET /api/v1/schedules/latest?workspaceId=1
+    @GetMapping("/latest")
+    public ResponseEntity<ScheduleResponse> getLatestSchedule(
+            @RequestParam Long workspaceId) {
+        return ResponseEntity.ok(scheduleService.getLatestSchedule(workspaceId));
+    }
+
+    // ── 생성 ────────────────────────────────────────────────
+
+    // POST /api/v1/schedules
+    @PostMapping
+    public ResponseEntity<ScheduleResponse> createSchedule(
+            @RequestBody @Valid ScheduleCreateRequest request) {
+        return ResponseEntity.ok(scheduleService.createSchedule(request));
+    }
+
+    // POST /api/v1/schedules/{scheduleId}/fork
+    @PostMapping("/{scheduleId}/fork")
+    public ResponseEntity<ScheduleResponse> forkSchedule(
+            @PathVariable Long scheduleId,
+            @RequestParam(required = false) String title) {
+        return ResponseEntity.ok(scheduleService.forkSchedule(scheduleId, title));
+    }
+
+    // ── 수정 ────────────────────────────────────────────────
+
+    // PATCH /api/v1/schedules/{scheduleId}/title
+    @PatchMapping("/{scheduleId}/title")
+    public ResponseEntity<ScheduleResponse> updateTitle(
+            @PathVariable Long scheduleId,
+            @RequestParam String title) {
+        return ResponseEntity.ok(scheduleService.updateScheduleTitle(scheduleId, title));
+    }
+
+    // POST /api/v1/schedules/{scheduleId}/items
+    @PostMapping("/{scheduleId}/items")
+    public ResponseEntity<ScheduleItemResponse> addItem(
+            @PathVariable Long scheduleId,
+            @RequestBody @Valid ScheduleItemCreateRequest request) {
+        return ResponseEntity.ok(scheduleService.addItem(scheduleId, request));
+    }
+
+    // PATCH /api/v1/schedules/items/{itemId}
+    @PatchMapping("/items/{itemId}")
+    public ResponseEntity<ScheduleItemResponse> updateItem(
+            @PathVariable Long itemId,
+            @RequestBody @Valid ScheduleItemUpdateRequest request) {
+        return ResponseEntity.ok(scheduleService.updateItem(itemId, request));
+    }
+
+    // PATCH /api/v1/schedules/{scheduleId}/items/reorder
+    @PatchMapping("/{scheduleId}/items/reorder")
+    public ResponseEntity<Void> reorderItems(
+            @PathVariable Long scheduleId,
+            @RequestBody @Valid ScheduleItemReorderRequest request) {
+        scheduleService.reorderItems(scheduleId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 삭제 ────────────────────────────────────────────────
+
+    // DELETE /api/v1/schedules/{scheduleId}
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> deleteSchedule(
+            @PathVariable Long scheduleId) {
+        scheduleService.deleteSchedule(scheduleId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // DELETE /api/v1/schedules/items/{itemId}
+    @DeleteMapping("/items/{itemId}")
+    public ResponseEntity<Void> deleteItem(
+            @PathVariable Long itemId) {
+        scheduleService.deleteItem(itemId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 딥링크 ──────────────────────────────────────────────
+
+    // POST /api/v1/schedules/items/{itemId}/deeplink-click
+    @PostMapping("/items/{itemId}/deeplink-click")
+    public ResponseEntity<Void> trackDeepLinkClick(
+            @PathVariable Long itemId) {
+        scheduleService.trackDeepLinkClick(itemId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.schedule.controller;
+
+public class ScheduleController {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/controller/ScheduleController.java
@@ -2,6 +2,11 @@ package com.sofly.core.domain.schedule.controller;
 
 import com.sofly.core.domain.schedule.dto.*;
 import com.sofly.core.domain.schedule.service.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Schedule", description = "일정 관리 API")
 @RestController
 @RequestMapping("/api/v1/schedules")
 @RequiredArgsConstructor
@@ -18,75 +24,107 @@ public class ScheduleController {
 
     // ── 조회 ────────────────────────────────────────────────
 
-    // GET /api/v1/schedules?workspaceId=1
+    @Operation(summary = "워크스페이스의 일정 목록 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
     public ResponseEntity<List<ScheduleSummaryResponse>> getSchedules(
-            @RequestParam Long workspaceId) {
+            @Parameter(description = "워크스페이스 ID", required = true) @RequestParam Long workspaceId) {
         return ResponseEntity.ok(scheduleService.getSchedulesByWorkspace(workspaceId));
     }
 
-    // GET /api/v1/schedules/{scheduleId}
+    @Operation(summary = "일정 상세 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 없음")
+    })
     @GetMapping("/{scheduleId}")
     public ResponseEntity<ScheduleResponse> getSchedule(
-            @PathVariable Long scheduleId) {
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId) {
         return ResponseEntity.ok(scheduleService.getSchedule(scheduleId));
     }
 
-    // GET /api/v1/schedules/latest?workspaceId=1
+    @Operation(summary = "워크스페이스의 최신 일정 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 없음")
+    })
     @GetMapping("/latest")
     public ResponseEntity<ScheduleResponse> getLatestSchedule(
-            @RequestParam Long workspaceId) {
+            @Parameter(description = "워크스페이스 ID", required = true) @RequestParam Long workspaceId) {
         return ResponseEntity.ok(scheduleService.getLatestSchedule(workspaceId));
     }
 
     // ── 생성 ────────────────────────────────────────────────
 
-    // POST /api/v1/schedules
+    @Operation(summary = "일정 생성")
+    @ApiResponse(responseCode = "200", description = "생성 성공")
     @PostMapping
     public ResponseEntity<ScheduleResponse> createSchedule(
             @RequestBody @Valid ScheduleCreateRequest request) {
         return ResponseEntity.ok(scheduleService.createSchedule(request));
     }
 
-    // POST /api/v1/schedules/{scheduleId}/fork
+    @Operation(summary = "일정 포크 (복사)", description = "기존 일정을 복사하여 새 일정을 생성합니다. title 미입력 시 원본 제목을 사용합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "포크 성공"),
+            @ApiResponse(responseCode = "404", description = "원본 일정 없음")
+    })
     @PostMapping("/{scheduleId}/fork")
     public ResponseEntity<ScheduleResponse> forkSchedule(
-            @PathVariable Long scheduleId,
-            @RequestParam(required = false) String title) {
+            @Parameter(description = "원본 일정 ID", required = true) @PathVariable Long scheduleId,
+            @Parameter(description = "새 일정 제목 (선택)") @RequestParam(required = false) String title) {
         return ResponseEntity.ok(scheduleService.forkSchedule(scheduleId, title));
     }
 
     // ── 수정 ────────────────────────────────────────────────
 
-    // PATCH /api/v1/schedules/{scheduleId}/title
+    @Operation(summary = "일정 제목 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 없음")
+    })
     @PatchMapping("/{scheduleId}/title")
     public ResponseEntity<ScheduleResponse> updateTitle(
-            @PathVariable Long scheduleId,
-            @RequestParam String title) {
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId,
+            @Parameter(description = "변경할 제목", required = true) @RequestParam String title) {
         return ResponseEntity.ok(scheduleService.updateScheduleTitle(scheduleId, title));
     }
 
-    // POST /api/v1/schedules/{scheduleId}/items
+    @Operation(summary = "일정 아이템 추가")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "추가 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 없음")
+    })
     @PostMapping("/{scheduleId}/items")
     public ResponseEntity<ScheduleItemResponse> addItem(
-            @PathVariable Long scheduleId,
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId,
             @RequestBody @Valid ScheduleItemCreateRequest request) {
         return ResponseEntity.ok(scheduleService.addItem(scheduleId, request));
     }
 
-    // PATCH /api/v1/schedules/items/{itemId}
+    @Operation(summary = "일정 아이템 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "다른 일정의 아이템"),
+            @ApiResponse(responseCode = "404", description = "아이템 없음")
+    })
     @PatchMapping("/schedules/{scheduleId}/items/{itemId}")
     public ResponseEntity<ScheduleItemResponse> updateItem(
-            @PathVariable Long scheduleId,
-            @PathVariable Long itemId,
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId,
+            @Parameter(description = "아이템 ID", required = true) @PathVariable Long itemId,
             @RequestBody @Valid ScheduleItemUpdateRequest request) {
         return ResponseEntity.ok(scheduleService.updateItem(scheduleId, itemId, request));
     }
 
-    // PATCH /api/v1/schedules/{scheduleId}/items/reorder
+    @Operation(summary = "일정 아이템 순서 변경 (D&D)", description = "변경된 전체 순서 목록을 한 번에 전송합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "순서 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "다른 일정의 아이템 포함"),
+            @ApiResponse(responseCode = "404", description = "아이템 없음")
+    })
     @PatchMapping("/{scheduleId}/items/reorder")
     public ResponseEntity<Void> reorderItems(
-            @PathVariable Long scheduleId,
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId,
             @RequestBody @Valid ScheduleItemReorderRequest request) {
         scheduleService.reorderItems(scheduleId, request);
         return ResponseEntity.noContent().build();
@@ -94,30 +132,40 @@ public class ScheduleController {
 
     // ── 삭제 ────────────────────────────────────────────────
 
-    // DELETE /api/v1/schedules/{scheduleId}
+    @Operation(summary = "일정 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "일정 없음")
+    })
     @DeleteMapping("/{scheduleId}")
     public ResponseEntity<Void> deleteSchedule(
-            @PathVariable Long scheduleId) {
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId) {
         scheduleService.deleteSchedule(scheduleId);
         return ResponseEntity.noContent().build();
     }
 
-    // DELETE /schedules/{scheduleId}/items/{itemId}
+    @Operation(summary = "일정 아이템 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "다른 일정의 아이템"),
+            @ApiResponse(responseCode = "404", description = "아이템 없음")
+    })
     @DeleteMapping("/schedules/{scheduleId}/items/{itemId}")
     public ResponseEntity<Void> deleteItem(
-            @PathVariable Long scheduleId,
-            @PathVariable Long itemId) {
-        scheduleService.deleteItem(scheduleId ,itemId);
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId,
+            @Parameter(description = "아이템 ID", required = true) @PathVariable Long itemId) {
+        scheduleService.deleteItem(scheduleId, itemId);
         return ResponseEntity.noContent().build();
     }
 
     // ── 딥링크 ──────────────────────────────────────────────
 
-    // POST /schedules/{scheduleId}/items/{itemId}/deeplink-click
+    @Operation(summary = "딥링크 클릭 추적", description = "아이템의 딥링크 클릭 이벤트를 기록합니다.")
+    @ApiResponse(responseCode = "204", description = "기록 성공")
     @PostMapping("/schedules/{scheduleId}/items/{itemId}/deeplink-click")
     public ResponseEntity<Void> trackDeepLinkClick(
-            @PathVariable Long scheduleId,
-            @PathVariable Long itemId) {
+            @Parameter(description = "일정 ID", required = true) @PathVariable Long scheduleId,
+            @Parameter(description = "아이템 ID", required = true) @PathVariable Long itemId) {
         scheduleService.trackDeepLinkClick(scheduleId, itemId);
         return ResponseEntity.noContent().build();
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleCreateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleCreateRequest.java
@@ -1,4 +1,21 @@
 package com.sofly.core.domain.schedule.dto;
 
-public class ScheduleCreateRequest {
-}
+import com.sofly.core.domain.schedule.entity.ScheduleItem.Category;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+import java.util.List;
+
+// 일정 최초 생성 (AI가 만들어준 결과를 저장)
+public record ScheduleCreateRequest(
+
+        @NotNull
+        Long workspaceId,
+
+        String title,
+
+        String aiChatSessionId,
+
+        @NotNull @Valid
+        List<ScheduleItemCreateRequest> items
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleCreateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleCreateRequest.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.schedule.dto;
+
+public class ScheduleCreateRequest {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemCreateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemCreateRequest.java
@@ -1,0 +1,31 @@
+package com.sofly.core.domain.schedule.dto;
+
+import com.sofly.core.domain.schedule.entity.ScheduleItem.Category;
+import jakarta.validation.constraints.*;
+
+// 일정 아이템 생성 (ScheduleCreateRequest 내부에서 사용)
+public record ScheduleItemCreateRequest(
+
+        @NotNull @Min(1)
+        Integer day,
+
+        @NotNull @Min(0)
+        Integer orderIndex,
+
+        String visitTime,           // "HH:mm"
+
+        @NotNull
+        Category category,
+
+        @NotBlank
+        String name,
+
+        String address,
+
+        Double latitude,
+        Double longitude,
+
+        String memo,
+        String deepLinkUrl,
+        Integer estimatedCost
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemReorderRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemReorderRequest.java
@@ -1,0 +1,18 @@
+package com.sofly.core.domain.schedule.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+
+// D&D 순서 변경 - 여러 아이템을 한 번에 받아서 처리
+public record ScheduleItemReorderRequest(
+
+        @NotNull
+        List<ItemOrder> orders
+) {
+    public record ItemOrder(
+            @NotNull Long itemId,
+            @NotNull @Min(1) Integer day,
+            @NotNull @Min(0) Integer orderIndex
+    ) {}
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemResponse.java
@@ -1,4 +1,46 @@
 package com.sofly.core.domain.schedule.dto;
 
-public class ScheduleItemResponse {
+import com.sofly.core.domain.schedule.entity.ScheduleItem;
+import com.sofly.core.domain.schedule.entity.ScheduleItem.Category;
+
+import java.time.LocalDateTime;
+
+// 아이템 단건 응답
+public record ScheduleItemResponse(
+
+        Long id,
+        Integer day,
+        Integer orderIndex,
+        String visitTime,
+        Category category,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude,
+        String memo,
+        String deepLinkUrl,
+        Integer estimatedCost,
+        Integer deepLinkClickCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ScheduleItemResponse from(ScheduleItem item) {
+        return new ScheduleItemResponse(
+                item.getId(),
+                item.getDay(),
+                item.getOrderIndex(),
+                item.getVisitTime(),
+                item.getCategory(),
+                item.getName(),
+                item.getAddress(),
+                item.getLatitude(),
+                item.getLongitude(),
+                item.getMemo(),
+                item.getDeepLinkUrl(),
+                item.getEstimatedCost(),
+                item.getDeepLinkClickCount(),
+                item.getCreatedAt(),
+                item.getUpdatedAt()
+        );
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemResponse.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.schedule.dto;
+
+public class ScheduleItemResponse {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemUpdateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleItemUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.sofly.core.domain.schedule.dto;
+
+import com.sofly.core.domain.schedule.entity.ScheduleItem.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+// 아이템 단건 수정 (visitTime, memo, category)
+public record ScheduleItemUpdateRequest(
+
+        String visitTime,
+
+        String memo,
+
+        @NotNull
+        Category category
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleResponse.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.schedule.dto;
+
+public class ScheduleResponse {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleResponse.java
@@ -1,4 +1,38 @@
 package com.sofly.core.domain.schedule.dto;
 
-public class ScheduleResponse {
+import com.sofly.core.domain.schedule.entity.Schedule;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// 일정 단건 응답 (아이템 포함, day별로 그룹핑)
+public record ScheduleResponse(
+
+        Long id,
+        Long workspaceId,
+        String title,
+        Integer version,
+        String aiChatSessionId,
+        Map<Integer, List<ScheduleItemResponse>> itemsByDay,  // { 1: [...], 2: [...] }
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ScheduleResponse from(Schedule schedule) {
+        Map<Integer, List<ScheduleItemResponse>> itemsByDay = schedule.getItems().stream()
+                .map(ScheduleItemResponse::from)
+                .collect(Collectors.groupingBy(ScheduleItemResponse::day));
+
+        return new ScheduleResponse(
+                schedule.getId(),
+                schedule.getWorkspace().getId(),
+                schedule.getTitle(),
+                schedule.getVersion(),
+                schedule.getAiChatSessionId(),
+                itemsByDay,
+                schedule.getCreatedAt(),
+                schedule.getUpdatedAt()
+        );
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleSummaryResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/dto/ScheduleSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.sofly.core.domain.schedule.dto;
+
+import com.sofly.core.domain.schedule.entity.Schedule;
+
+import java.time.LocalDateTime;
+
+// 일정 목록 응답 (아이템 미포함, 버전 리스트용)
+public record ScheduleSummaryResponse(
+
+        Long id,
+        String title,
+        Integer version,
+        int itemCount,
+        LocalDateTime createdAt
+) {
+    public static ScheduleSummaryResponse from(Schedule schedule) {
+        return new ScheduleSummaryResponse(
+                schedule.getId(),
+                schedule.getTitle(),
+                schedule.getVersion(),
+                schedule.getItems().size(),
+                schedule.getCreatedAt()
+        );
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/entity/Schedule.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/entity/Schedule.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "schedules")
+@Table(name = "schedules", uniqueConstraints = @UniqueConstraint(columnNames = {"workspace_id", "version"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/entity/ScheduleItem.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/entity/ScheduleItem.java
@@ -73,4 +73,8 @@ public class ScheduleItem extends BaseTimeEntity {
         ATTRACTION,     // 관광지
         TRANSPORT       // 교통
     }
+
+    public void moveToDay(Integer day) {
+        this.day = day;
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleItemRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleItemRepository.java
@@ -1,0 +1,43 @@
+package com.sofly.core.domain.schedule.repository;
+
+import com.sofly.core.domain.schedule.entity.ScheduleItem.Category;
+import com.sofly.core.domain.schedule.entity.ScheduleItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ScheduleItemRepository extends JpaRepository<ScheduleItem, Long> {
+    // 특정 일정의 모든 아이템 (day, orderIndex 정렬)
+    List<ScheduleItem> findByScheduleIdOrderByDayAscOrderIndexAsc(Long scheduleId);
+
+    // 특정 일차의 아이템만
+    List<ScheduleItem> findByScheduleIdAndDayOrderByOrderIndexAsc(Long scheduleId, Integer day);
+
+    // 특정 일차의 최대 orderIndex (새 아이템 추가 시 맨 뒤에 넣기)
+    @Query("SELECT COALESCE(MAX(i.orderIndex), 0) FROM ScheduleItem i WHERE i.schedule.id = :scheduleId AND i.day = :day")
+    Integer findMaxOrderIndexByScheduleIdAndDay(@Param("scheduleId") Long scheduleId, @Param("day") Integer day);
+
+    // D&D 순서 변경: 특정 범위의 orderIndex를 일괄 +1 or -1
+    @Modifying
+    @Query("UPDATE ScheduleItem i SET i.orderIndex = i.orderIndex + :delta " +
+            "WHERE i.schedule.id = :scheduleId AND i.day = :day " +
+            "AND i.orderIndex BETWEEN :from AND :to")
+    void shiftOrderIndex(@Param("scheduleId") Long scheduleId,
+                         @Param("day") Integer day,
+                         @Param("from") Integer from,
+                         @Param("to") Integer to,
+                         @Param("delta") int delta);
+
+    // 카테고리별 필터링
+    List<ScheduleItem> findByScheduleIdAndCategoryOrderByDayAscOrderIndexAsc(Long scheduleId, Category category);
+
+    // 딥링크 클릭 수 TOP N (통계용)
+    @Query("SELECT i FROM ScheduleItem i WHERE i.schedule.id = :scheduleId AND i.deepLinkUrl IS NOT NULL ORDER BY i.deepLinkClickCount DESC LIMIT :limit")
+    List<ScheduleItem> findTopDeepLinkItems(@Param("scheduleId") Long scheduleId, @Param("limit") int limit);
+
+    // 일정 삭제 시 벌크 삭제 (orphanRemoval 대신 명시적으로 쓸 때)
+    void deleteAllByScheduleId(Long scheduleId);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleItemRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleItemRepository.java
@@ -8,8 +8,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleItemRepository extends JpaRepository<ScheduleItem, Long> {
+
+    //itemId과 scheduleId로 items 찾기
+    Optional<ScheduleItem> findByIdAndScheduleId(Long id, Long scheduleId);
+
     // 특정 일정의 모든 아이템 (day, orderIndex 정렬)
     List<ScheduleItem> findByScheduleIdOrderByDayAscOrderIndexAsc(Long scheduleId);
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,31 @@
+package com.sofly.core.domain.schedule.repository;
+
+import com.sofly.core.domain.schedule.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    //워크스페이스별 일정 목록
+    List<Schedule> findByWorkspaceIdOrderByVersionDesc(Long workspaceId);
+
+    //워크스페이스의 최신 버전 일정
+    Optional<Schedule> findTopByWorkspaceIdOrderByVersionDesc(Long workspaceId);
+
+    // 워크스페이스의 최대 버전 번호 (새 버전 생성 시 사용)
+    @Query("SELECT COALESCE(MAX(s.version), 0) FROM Schedule s WHERE s.workspace.id = :workspaceId")
+    Integer findMaxVersionByWorkspaceId(@Param("workspaceId") Long workspaceId);
+
+    // items 패치 조인 (N+1 방지)
+    @Query("SELECT s FROM Schedule s LEFT JOIN FETCH s.items WHERE s.id = :scheduleId")
+    Optional<Schedule> findByIdWithItems(@Param("scheduleId") Long scheduleId);
+
+    // AI 채팅 세션으로 일정 조회
+    Optional<Schedule> findByAiChatSessionId(String aiChatSessionId);
+
+    // 워크스페이스에 일정이 존재하는지 확인
+    boolean existsByWorkspaceId(Long workspaceId);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/repository/ScheduleRepository.java
@@ -1,5 +1,6 @@
 package com.sofly.core.domain.schedule.repository;
 
+import com.sofly.core.domain.schedule.dto.ScheduleSummaryResponse;
 import com.sofly.core.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -28,4 +29,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     // 워크스페이스에 일정이 존재하는지 확인
     boolean existsByWorkspaceId(Long workspaceId);
+
+    // workspaceId로 scheduleSummary 가져오기
+    @Query("SELECT new com.sofly.core.domain.schedule.dto.ScheduleSummaryResponse(s.id, s.title, s.version, size(s.items), s.createdAt) FROM Schedule s WHERE s.workspace.id = :workspaceId ORDER BY s.version DESC")
+    List<ScheduleSummaryResponse> findSummariesByWorkspaceId(@Param("workspaceId") Long workspaceId);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
@@ -27,10 +27,7 @@ public class ScheduleService {
 
     // 워크스페이스 일정 버전 목록
     public List<ScheduleSummaryResponse> getSchedulesByWorkspace(Long workspaceId) {
-        return scheduleRepository.findByWorkspaceIdOrderByVersionDesc(workspaceId)
-                .stream()
-                .map(ScheduleSummaryResponse::from)
-                .toList();
+        return scheduleRepository.findSummariesByWorkspaceId(workspaceId);
     }
 
     // 일정 단건 상세 (아이템 포함)

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
@@ -129,8 +129,8 @@ public class ScheduleService {
 
     // 아이템 단건 수정 (visitTime, memo, category)
     @Transactional
-    public ScheduleItemResponse updateItem(Long itemId, ScheduleItemUpdateRequest request) {
-        ScheduleItem item = scheduleItemRepository.findById(itemId)
+    public ScheduleItemResponse updateItem(Long scheduleId, Long itemId, ScheduleItemUpdateRequest request) {
+        ScheduleItem item = scheduleItemRepository.findByIdAndScheduleId(scheduleId, itemId)
                 .orElseThrow(() -> new EntityNotFoundException("ScheduleItem not found: " + itemId));
         item.update(request.visitTime(), request.memo(), request.category());
         return ScheduleItemResponse.from(item);
@@ -203,8 +203,8 @@ public class ScheduleService {
 
     // 아이템 단건 삭제
     @Transactional
-    public void deleteItem(Long itemId) {
-        ScheduleItem item = scheduleItemRepository.findById(itemId)
+    public void deleteItem(Long scheduleId, Long itemId) {
+        ScheduleItem item = scheduleItemRepository.findByIdAndScheduleId(scheduleId, itemId)
                 .orElseThrow(() -> new EntityNotFoundException("ScheduleItem not found: " + itemId));
         scheduleItemRepository.delete(item);
     }
@@ -220,8 +220,8 @@ public class ScheduleService {
     // ── 딥링크 ──────────────────────────────────────────────
 
     @Transactional
-    public void trackDeepLinkClick(Long itemId) {
-        ScheduleItem item = scheduleItemRepository.findById(itemId)
+    public void trackDeepLinkClick(Long scheduleId, Long itemId) {
+        ScheduleItem item = scheduleItemRepository.findByIdAndScheduleId(scheduleId, itemId)
                 .orElseThrow(() -> new EntityNotFoundException("ScheduleItem not found: " + itemId));
         item.incrementDeepLinkClick();
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -183,11 +185,11 @@ public class ScheduleService {
         }
 
         // 순서 업데이트 (더티 체킹)
+        Map<Long, ScheduleItem> itemMap = items.stream()
+                .collect(Collectors.toMap(ScheduleItem::getId, i -> i));
+
         request.orders().forEach(order -> {
-            ScheduleItem item = items.stream()
-                    .filter(i -> i.getId().equals(order.itemId()))
-                    .findFirst()
-                    .orElseThrow();
+            ScheduleItem item = itemMap.get(order.itemId());
             item.updateOrder(order.orderIndex());
             // day 변경도 지원 (다른 일차로 이동)
             if (!item.getDay().equals(order.day())) {

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
@@ -1,4 +1,247 @@
 package com.sofly.core.domain.schedule.service;
 
+import com.sofly.core.domain.schedule.dto.*;
+import com.sofly.core.domain.schedule.entity.Schedule;
+import com.sofly.core.domain.schedule.entity.ScheduleItem;
+import com.sofly.core.domain.schedule.repository.ScheduleItemRepository;
+import com.sofly.core.domain.schedule.repository.ScheduleRepository;
+import com.sofly.core.domain.workspace.entity.Workspace;
+import com.sofly.core.domain.workspace.repository.WorkspaceRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleItemRepository scheduleItemRepository;
+    private final WorkspaceRepository workspaceRepository;
+
+    // ── 조회 ────────────────────────────────────────────────
+
+    // 워크스페이스 일정 버전 목록
+    public List<ScheduleSummaryResponse> getSchedulesByWorkspace(Long workspaceId) {
+        return scheduleRepository.findByWorkspaceIdOrderByVersionDesc(workspaceId)
+                .stream()
+                .map(ScheduleSummaryResponse::from)
+                .toList();
+    }
+
+    // 일정 단건 상세 (아이템 포함)
+    public ScheduleResponse getSchedule(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findByIdWithItems(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("Schedule not found: " + scheduleId));
+        return ScheduleResponse.from(schedule);
+    }
+
+    // 워크스페이스 최신 버전 일정
+    public ScheduleResponse getLatestSchedule(Long workspaceId) {
+        Schedule schedule = scheduleRepository.findTopByWorkspaceIdOrderByVersionDesc(workspaceId)
+                .orElseThrow(() -> new EntityNotFoundException("No schedule found for workspace: " + workspaceId));
+        // items 패치 (findTop은 items 미포함)
+        return getSchedule(schedule.getId());
+    }
+
+    // ── 생성 ────────────────────────────────────────────────
+
+    // 새 일정 생성 (AI 결과 저장 또는 수동 생성)
+    @Transactional
+    public ScheduleResponse createSchedule(ScheduleCreateRequest request) {
+        Workspace workspace = workspaceRepository.findById(request.workspaceId())
+                .orElseThrow(() -> new EntityNotFoundException("Workspace not found: " + request.workspaceId()));
+
+        int nextVersion = scheduleRepository.findMaxVersionByWorkspaceId(request.workspaceId()) + 1;
+
+        Schedule schedule = Schedule.builder()
+                .workspace(workspace)
+                .title(request.title() != null ? request.title() : nextVersion + "차 일정")
+                .version(nextVersion)
+                .aiChatSessionId(request.aiChatSessionId())
+                .build();
+
+        // 아이템 생성 후 연관관계 설정
+        List<ScheduleItem> items = request.items().stream()
+                .map(itemReq -> buildScheduleItem(itemReq, schedule))
+                .toList();
+
+        // Schedule 저장 (cascade로 items도 함께 저장)
+        schedule.getItems().addAll(items);
+        scheduleRepository.save(schedule);
+
+        return ScheduleResponse.from(schedule);
+    }
+
+    // 기존 일정을 복사해서 새 버전 생성 (수정본 만들기)
+    @Transactional
+    public ScheduleResponse forkSchedule(Long scheduleId, String newTitle) {
+        Schedule origin = scheduleRepository.findByIdWithItems(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("Schedule not found: " + scheduleId));
+
+        int nextVersion = scheduleRepository.findMaxVersionByWorkspaceId(
+                origin.getWorkspace().getId()) + 1;
+
+        Schedule forked = Schedule.builder()
+                .workspace(origin.getWorkspace())
+                .title(newTitle != null ? newTitle : nextVersion + "차 일정")
+                .version(nextVersion)
+                .aiChatSessionId(origin.getAiChatSessionId())
+                .build();
+
+        List<ScheduleItem> copiedItems = origin.getItems().stream()
+                .map(item -> ScheduleItem.builder()
+                        .schedule(forked)
+                        .day(item.getDay())
+                        .orderIndex(item.getOrderIndex())
+                        .visitTime(item.getVisitTime())
+                        .category(item.getCategory())
+                        .name(item.getName())
+                        .address(item.getAddress())
+                        .latitude(item.getLatitude())
+                        .longitude(item.getLongitude())
+                        .memo(item.getMemo())
+                        .deepLinkUrl(item.getDeepLinkUrl())
+                        .estimatedCost(item.getEstimatedCost())
+                        .build())
+                .toList();
+
+        forked.getItems().addAll(copiedItems);
+        scheduleRepository.save(forked);
+
+        return ScheduleResponse.from(forked);
+    }
+
+    // ── 수정 ────────────────────────────────────────────────
+
+    // 일정 제목 수정
+    @Transactional
+    public ScheduleResponse updateScheduleTitle(Long scheduleId, String title) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("Schedule not found: " + scheduleId));
+        schedule.updateTitle(title);
+        return getSchedule(scheduleId);
+    }
+
+    // 아이템 단건 수정 (visitTime, memo, category)
+    @Transactional
+    public ScheduleItemResponse updateItem(Long itemId, ScheduleItemUpdateRequest request) {
+        ScheduleItem item = scheduleItemRepository.findById(itemId)
+                .orElseThrow(() -> new EntityNotFoundException("ScheduleItem not found: " + itemId));
+        item.update(request.visitTime(), request.memo(), request.category());
+        return ScheduleItemResponse.from(item);
+    }
+
+    // 아이템 추가 (일정에 장소 하나 추가)
+    @Transactional
+    public ScheduleItemResponse addItem(Long scheduleId, ScheduleItemCreateRequest request) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("Schedule not found: " + scheduleId));
+
+        // 해당 일차의 맨 마지막 순서로 추가
+        int nextOrder = scheduleItemRepository
+                .findMaxOrderIndexByScheduleIdAndDay(scheduleId, request.day()) + 1;
+
+        ScheduleItem item = ScheduleItem.builder()
+                .schedule(schedule)
+                .day(request.day())
+                .orderIndex(nextOrder)
+                .visitTime(request.visitTime())
+                .category(request.category())
+                .name(request.name())
+                .address(request.address())
+                .latitude(request.latitude())
+                .longitude(request.longitude())
+                .memo(request.memo())
+                .deepLinkUrl(request.deepLinkUrl())
+                .estimatedCost(request.estimatedCost())
+                .build();
+
+        scheduleItemRepository.save(item);
+        return ScheduleItemResponse.from(item);
+    }
+
+    // D&D 순서 변경 (프론트에서 변경된 전체 순서를 한 번에 전송)
+    @Transactional
+    public void reorderItems(Long scheduleId, ScheduleItemReorderRequest request) {
+        // 해당 일정 소속 아이템인지 검증
+        List<Long> itemIds = request.orders().stream()
+                .map(ScheduleItemReorderRequest.ItemOrder::itemId)
+                .toList();
+
+        List<ScheduleItem> items = scheduleItemRepository.findAllById(itemIds);
+
+        if (items.size() != itemIds.size()) {
+            throw new EntityNotFoundException("일부 아이템을 찾을 수 없습니다.");
+        }
+
+        boolean hasUnauthorized = items.stream()
+                .anyMatch(item -> !item.getSchedule().getId().equals(scheduleId));
+        if (hasUnauthorized) {
+            throw new IllegalArgumentException("다른 일정의 아이템이 포함되어 있습니다.");
+        }
+
+        // 순서 업데이트 (더티 체킹)
+        request.orders().forEach(order -> {
+            ScheduleItem item = items.stream()
+                    .filter(i -> i.getId().equals(order.itemId()))
+                    .findFirst()
+                    .orElseThrow();
+            item.updateOrder(order.orderIndex());
+            // day 변경도 지원 (다른 일차로 이동)
+            if (!item.getDay().equals(order.day())) {
+                item.moveToDay(order.day());
+            }
+        });
+    }
+
+    // ── 삭제 ────────────────────────────────────────────────
+
+    // 아이템 단건 삭제
+    @Transactional
+    public void deleteItem(Long itemId) {
+        ScheduleItem item = scheduleItemRepository.findById(itemId)
+                .orElseThrow(() -> new EntityNotFoundException("ScheduleItem not found: " + itemId));
+        scheduleItemRepository.delete(item);
+    }
+
+    // 일정 전체 삭제
+    @Transactional
+    public void deleteSchedule(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("Schedule not found: " + scheduleId));
+        scheduleRepository.delete(schedule);  // orphanRemoval로 items도 cascade 삭제
+    }
+
+    // ── 딥링크 ──────────────────────────────────────────────
+
+    @Transactional
+    public void trackDeepLinkClick(Long itemId) {
+        ScheduleItem item = scheduleItemRepository.findById(itemId)
+                .orElseThrow(() -> new EntityNotFoundException("ScheduleItem not found: " + itemId));
+        item.incrementDeepLinkClick();
+    }
+
+    // ── 내부 헬퍼 ───────────────────────────────────────────
+
+    private ScheduleItem buildScheduleItem(ScheduleItemCreateRequest req, Schedule schedule) {
+        return ScheduleItem.builder()
+                .schedule(schedule)
+                .day(req.day())
+                .orderIndex(req.orderIndex())
+                .visitTime(req.visitTime())
+                .category(req.category())
+                .name(req.name())
+                .address(req.address())
+                .latitude(req.latitude())
+                .longitude(req.longitude())
+                .memo(req.memo())
+                .deepLinkUrl(req.deepLinkUrl())
+                .estimatedCost(req.estimatedCost())
+                .build();
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/schedule/service/ScheduleService.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.schedule.service;
+
+public class ScheduleService {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
@@ -1,8 +1,8 @@
 package com.sofly.core.domain.workspace.repository;
 
 import com.sofly.core.domain.workspace.entity.Workspace;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WorkspaceRepository extends CrudRepository<Workspace, Long> {
+public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
 
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
@@ -1,0 +1,8 @@
+package com.sofly.core.domain.workspace.repository;
+
+import com.sofly.core.domain.workspace.entity.Workspace;
+import org.springframework.data.repository.CrudRepository;
+
+public interface WorkspaceRepository extends CrudRepository<Workspace, Long> {
+
+}


### PR DESCRIPTION
## 📌 PR 요약 
  `travel-core-service`에 Schedule 도메인 전 계층(Entity → Repository → Service → Controller)을 구현합니다.
  AI가 생성한 일정 또는 수동으로 작성한 일정을 저장·관리할 수 있는 기반을 마련합니다. 
## 🔧 변경 사항                                                                                                                                                       
  - **Schedule 버전 관리**: `version` 필드를 통해 같은 워크스페이스에서 여러 버전의 일정 관리                                                                           
  - **일정 복사(fork)**: 기존 일정을 deep copy하여 새 버전(수정본)을 생성하는 기능 추가                                                                                 
  - **D&D 순서 변경**: `ScheduleItem`의 `orderIndex` + `day` 필드로 아이템 순서 변경 및 일차 이동 지원                                                                  
  - **딥링크 클릭 통계**: 숙소/교통 예약 딥링크 클릭 수를 추적하는 기능 추가                                                                                            
  - **WorkspaceRepository 추가**: Schedule 생성 시 Workspace 조회를 위해 신규 생성
## 📋 작업 상세 내용                                                                                                                                                  
  - [x] `Schedule`, `ScheduleItem`, `AiChatMessage` Entity 설계                                                                                                         
  - [x] `ScheduleRepository`, `ScheduleItemRepository`, `WorkspaceRepository` 구현                                                                                      
  - [x] `ScheduleService` 구현 (조회 / 생성 / 수정 / 삭제 / fork / reorder / deeplink 통계)
  - [x] `ScheduleController` REST API 구현 (엔드포인트 11개)                                                                                                               
❯ - [x] Request/Response DTO 구현 (`ScheduleCreateRequest`, `ScheduleItemCreateRequest`, `ScheduleItemReorderRequest`, `ScheduleResponse`, `ScheduleItemResponse`,
  `ScheduleSummaryResponse`, `ScheduleItemUpdateRequest`)
## 🔗 관련 이슈                                                                                                                                                       
  - closed #14    

## 📝 기타
  - `CascadeType.ALL + orphanRemoval` 조합으로 Schedule 삭제 시 하위 ScheduleItem 자동 삭제됩니다.
  - reorder는 dirty checking으로 처리하므로 별도 `save()` 호출 없이 동작합니다.                                                                                         
  - `ScheduleItem.Category` enum: `ACCOMMODATION`, `RESTAURANT`, `CAFE`, `ATTRACTION`, `TRANSPORT` 