### PR TITLE
[Feat]/13 social login jwt

### DIFF
--- a/services/travel-core-service/Dockerfile
+++ b/services/travel-core-service/Dockerfile
@@ -11,4 +11,4 @@ RUN ./gradlew clean bootJar -x test --no-daemon
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Dspring.config.name=application-core", "-jar", "app.jar"]

--- a/services/travel-core-service/Dockerfile
+++ b/services/travel-core-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM amazoncorretto:21-al2023-jdk
+WORKDIR /app
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/travel-core-service/Dockerfile
+++ b/services/travel-core-service/Dockerfile
@@ -1,5 +1,14 @@
-FROM amazoncorretto:21-al2023-jdk
+FROM eclipse-temurin:21-jdk-alpine AS builder
 WORKDIR /app
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+RUN chmod +x ./gradlew
+RUN ./gradlew clean bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/travel-core-service/build.gradle
+++ b/services/travel-core-service/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 dependencyManagement {

--- a/services/travel-core-service/build.gradle
+++ b/services/travel-core-service/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
+bootRun {
+    systemProperty 'spring.config.name', 'application-core'
+}
+
 group = 'com.sofly'
 version = '0.0.1-SNAPSHOT'
 

--- a/services/travel-core-service/docker-compose.yaml
+++ b/services/travel-core-service/docker-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  app:
+    build: .
+    container_name: ${CONTAINER_NAME}
+    ports:
+      - "${APP_PORT}:8080"
+    env_file:
+      - .env
+    environment:
+      # --- 기존 DB 설정 ---
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+      - SPRING_DATASOURCE_USERNAME=${DB_USER}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
+      
+      # --- Redis 연결 설정 (추가됨) ---
+      # - SPRING_DATA_REDIS_HOST=my-redis
+      # - SPRING_DATA_REDIS_PORT=6379
+      # - SPRING_DATA_REDIS_PASSWORD=${REDIS_PASSWORD}
+      
+      # --- 기타 설정 ---
+      # - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      # - APP_S3_ACCESS_KEY=${APP_S3_ACCESS_KEY}
+      # - APP_S3_SECRET_KEY=${APP_S3_SECRET_KEY}
+      # - APP_S3_BUCKET=${APP_S3_BUCKET}
+      # - APP_S3_REGION=${APP_S3_REGION}
+      
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - KAKAO_CLIENT_ID=${KAKAO_CLIENT_ID}
+      - KAKAO_CLIENT_SECRET=${KAKAO_CLIENT_SECRET}
+      - FRONTEND_REDIRECT_URL=${FRONTEND_REDIRECT_URL}
+    networks:
+      - app-network
+networks:
+  app-network:
+    external: true
+      

--- a/services/travel-core-service/docker-compose.yaml
+++ b/services/travel-core-service/docker-compose.yaml
@@ -13,8 +13,8 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
       
       # --- Redis 연결 설정 (추가됨) ---
-      # - SPRING_DATA_REDIS_HOST=my-redis
-      # - SPRING_DATA_REDIS_PORT=6379
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
       # - SPRING_DATA_REDIS_PASSWORD=${REDIS_PASSWORD}
       
       # --- 기타 설정 ---

--- a/services/travel-core-service/docs/auth-api-docs.md
+++ b/services/travel-core-service/docs/auth-api-docs.md
@@ -1,0 +1,267 @@
+# Sofly Auth API 문서
+
+> **Base URL** `http://localhost:8080`
+> **인증 방식** JWT Bearer Token
+> **Content-Type** `application/json`
+
+---
+
+## 공통 응답 형식
+
+모든 API는 아래 형식으로 응답합니다.
+
+```json
+{
+  "success": true,
+  "message": null,
+  "data": { ... }
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `success` | boolean | 요청 성공 여부 |
+| `message` | string | 실패 시 에러 메시지 (성공 시 null) |
+| `data` | object | 실제 응답 데이터 (실패 시 null) |
+
+---
+
+## 에러 코드
+
+| HTTP | 에러 코드 | 설명 |
+|------|-----------|------|
+| 401 | `UNAUTHORIZED` | 인증 토큰 없음 또는 만료 |
+| 401 | `INVALID_REFRESH_TOKEN` | 유효하지 않은 Refresh Token |
+| 401 | `REFRESH_TOKEN_NOT_FOUND` | Redis에서 Refresh Token을 찾을 수 없음 |
+| 400 | `INVALID_INPUT` | 요청 파라미터 유효성 오류 |
+| 500 | `INTERNAL_SERVER_ERROR` | 서버 내부 오류 |
+
+---
+
+## 1. 소셜 로그인
+
+### 로그인 시작
+
+소셜 로그인은 Spring Security OAuth2가 처리합니다. 아래 URL로 **브라우저 리다이렉트**만 하면 됩니다.
+
+| Provider | URL |
+|----------|-----|
+| Google | `GET /oauth2/authorization/google` |
+| Kakao | `GET /oauth2/authorization/kakao` |
+| Naver | `GET /oauth2/authorization/naver` |
+
+```javascript
+// 예시
+window.location.href = 'http://localhost:8080/oauth2/authorization/google';
+```
+
+### 로그인 콜백
+
+로그인 성공 시 설정된 `OAUTH2_REDIRECT_URI`로 리다이렉트됩니다.
+쿼리 파라미터로 토큰이 전달됩니다.
+
+```
+http://localhost:3000/oauth2/callback
+  ?accessToken=eyJhbGci...
+  &refreshToken=eyJhbGci...
+```
+
+로그인 실패 시
+
+```
+http://localhost:3000/oauth2/callback
+  ?error=에러메시지
+```
+
+#### 프론트 처리 예시
+
+```javascript
+// /oauth2/callback 페이지에서
+const params = new URLSearchParams(window.location.search);
+
+const accessToken  = params.get('accessToken');
+const refreshToken = params.get('refreshToken');
+const error        = params.get('error');
+
+if (error) {
+  console.error('로그인 실패:', error);
+  return;
+}
+
+// 토큰 저장
+localStorage.setItem('accessToken', accessToken);
+localStorage.setItem('refreshToken', refreshToken);
+
+// 메인 페이지로 이동
+window.location.href = '/';
+```
+
+---
+
+## 2. 토큰 재발급
+
+Access Token이 만료되면 Refresh Token으로 재발급합니다.
+
+```
+POST /api/auth/refresh
+```
+
+**Request Body**
+
+```json
+{
+  "refreshToken": "eyJhbGci..."
+}
+```
+
+**Response** `200 OK`
+
+```json
+{
+  "success": true,
+  "message": null,
+  "data": {
+    "accessToken": "eyJhbGci...",
+    "refreshToken": "eyJhbGci..."
+  }
+}
+```
+
+> Refresh Token Rotate 방식 — 재발급 시 Refresh Token도 새로 발급됩니다. 반드시 새 Refresh Token으로 교체하세요.
+
+**Error Response** `401`
+
+```json
+{
+  "success": false,
+  "message": "유효하지 않은 Refresh Token입니다.",
+  "data": null
+}
+```
+
+#### 프론트 처리 예시 (Axios Interceptor)
+
+```javascript
+axios.interceptors.response.use(
+  response => response,
+  async error => {
+    if (error.response?.status === 401) {
+      const refreshToken = localStorage.getItem('refreshToken');
+
+      try {
+        const { data } = await axios.post('/api/auth/refresh', { refreshToken });
+        localStorage.setItem('accessToken',  data.data.accessToken);
+        localStorage.setItem('refreshToken', data.data.refreshToken);
+
+        // 원래 요청 재시도
+        error.config.headers['Authorization'] = 'Bearer ' + data.data.accessToken;
+        return axios(error.config);
+      } catch {
+        // Refresh Token도 만료 → 로그인 페이지로
+        localStorage.clear();
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+```
+
+---
+
+## 3. 로그아웃
+
+```
+POST /api/auth/logout
+Authorization: Bearer {accessToken}
+```
+
+**Response** `200 OK`
+
+```json
+{
+  "success": true,
+  "message": null,
+  "data": null
+}
+```
+
+#### 프론트 처리 예시
+
+```javascript
+async function logout() {
+  await axios.post('/api/auth/logout', null, {
+    headers: { Authorization: `Bearer ${localStorage.getItem('accessToken')}` }
+  });
+
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
+  window.location.href = '/login';
+}
+```
+
+---
+
+## 4. 인증이 필요한 API 요청
+
+모든 인증 API는 `Authorization` 헤더에 Access Token을 담아 보냅니다.
+
+```
+Authorization: Bearer eyJhbGci...
+```
+
+#### Axios 기본 설정 예시
+
+```javascript
+const api = axios.create({
+  baseURL: 'http://localhost:8080',
+});
+
+api.interceptors.request.use(config => {
+  const token = localStorage.getItem('accessToken');
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+```
+
+---
+
+## 5. Token 만료 시간
+
+| 토큰 | 만료 시간 |
+|------|-----------|
+| Access Token | 4시간 |
+| Refresh Token | 14일 |
+
+JWT Payload 예시 (디코딩 후)
+
+```json
+{
+  "sub": "1",
+  "type": "access",
+  "iat": 1700000000,
+  "exp": 1700014400
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `sub` | userId |
+| `type` | `access` or `refresh` |
+| `iat` | 발급 시간 (Unix timestamp) |
+| `exp` | 만료 시간 (Unix timestamp) |
+
+---
+
+## 6. 테스트 페이지
+
+서버 실행 후 아래 URL에서 소셜 로그인을 직접 테스트할 수 있습니다.
+
+| URL | 설명 |
+|-----|------|
+| `http://localhost:8080` | 로그인 테스트 UI |
+| `http://localhost:8080/swagger-ui/core` | Swagger UI |
+| `http://localhost:8080/v3/api-docs/core` | OpenAPI JSON |
+| `http://localhost:8080/actuator/health` | 서버 헬스체크 |

--- a/services/travel-core-service/src/main/java/com/sofly/core/TravelCoreServiceApplication.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/TravelCoreServiceApplication.java
@@ -2,12 +2,14 @@ package com.sofly.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing 
 @EnableFeignClients
+@ConfigurationPropertiesScan 
 public class TravelCoreServiceApplication {
 
 	public static void main(String[] args) {

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/entity/User.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/entity/User.java
@@ -104,7 +104,7 @@ public class User extends BaseTimeEntity {
 
     // ── Enum ────────────────────────────────────────────────
 
-    public enum Provider { GOOGLE, KAKAO }
+    public enum Provider { GOOGLE, KAKAO, NAVER }
 
     public enum Role { USER, ADMIN }
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/repository/UserRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.sofly.core.domain.user.repository;
+
+import com.sofly.core.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderAndProviderId(User.Provider provider, String providerId);
+
+    Optional<User> findByEmail(String email);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/controller/AuthController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/controller/AuthController.java
@@ -1,15 +1,24 @@
 package com.sofly.core.global.auth.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.sofly.core.global.auth.dto.RefreshTokenRequest;
 import com.sofly.core.global.auth.dto.TokenResponse;
 import com.sofly.core.global.auth.service.AuthService;
 import com.sofly.core.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth", description = "인증 관련 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -21,6 +30,11 @@ public class AuthController {
      * Access Token 재발급
      * POST /api/auth/refresh
      */
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재발급 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token")
+    })
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> refresh(
             @Valid @RequestBody RefreshTokenRequest request) {
@@ -33,6 +47,11 @@ public class AuthController {
      * 로그아웃 (Refresh Token 삭제)
      * POST /api/auth/logout
      */
+    @Operation(summary = "로그아웃", description = "Refresh Token을 삭제합니다. Access Token이 필요합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Access Token 없음 또는 만료")
+    })
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal Long userId) {

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/controller/AuthController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/controller/AuthController.java
@@ -1,0 +1,43 @@
+package com.sofly.core.global.auth.controller;
+
+import com.sofly.core.global.auth.dto.RefreshTokenRequest;
+import com.sofly.core.global.auth.dto.TokenResponse;
+import com.sofly.core.global.auth.service.AuthService;
+import com.sofly.core.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * Access Token 재발급
+     * POST /api/auth/refresh
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> refresh(
+            @Valid @RequestBody RefreshTokenRequest request) {
+
+        TokenResponse response = authService.refresh(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 로그아웃 (Refresh Token 삭제)
+     * POST /api/auth/logout
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal Long userId) {
+
+        authService.logout(userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/RefreshTokenRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,7 @@
+package com.sofly.core.global.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+        @NotBlank String refreshToken
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/RefreshTokenRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/RefreshTokenRequest.java
@@ -1,7 +1,9 @@
 package com.sofly.core.global.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record RefreshTokenRequest(
+        @Schema(description = "Refresh Token", example = "eyJhbGci...")
         @NotBlank String refreshToken
 ) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/TokenResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/TokenResponse.java
@@ -1,0 +1,10 @@
+package com.sofly.core.global.auth.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/TokenResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/dto/TokenResponse.java
@@ -1,7 +1,13 @@
 package com.sofly.core.global.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record TokenResponse(
+
+        @Schema(description = "새로 발급된 Access Token")
         String accessToken,
+
+        @Schema(description = "새로 발급된 Refresh Token")
         String refreshToken
 ) {
     public static TokenResponse of(String accessToken, String refreshToken) {

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
@@ -30,12 +30,17 @@ public class AuthService {
             throw new SoflyException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
+        // refresh 메서드 — refreshToken 값으로 userId 꺼내기
+        Long userId = jwtTokenProvider.getUserId(request.refreshToken());
+
         // Redis에서 조회
-        RefreshToken saved = refreshTokenRepository.findById(refreshToken)
-                .orElseThrow(() -> new SoflyException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+        RefreshToken saved = refreshTokenRepository.findById(String.valueOf(userId))
+            .orElseThrow(() -> new SoflyException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
-        Long userId = saved.getUserId();
-
+        // 저장된 토큰값이랑 요청 토큰값 일치 확인
+        if (!saved.getRefreshToken().equals(request.refreshToken())) {
+            throw new SoflyException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
         // 새 토큰 발급
         String newAccessToken  = jwtTokenProvider.generateAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
@@ -44,8 +49,8 @@ public class AuthService {
         refreshTokenRepository.delete(saved);
         refreshTokenRepository.save(
                 RefreshToken.builder()
+                        .id(String.valueOf(userId))
                         .refreshToken(newRefreshToken)
-                        .userId(userId)
                         .expiration(jwtProperties.expiration().refresh() / 1000)
                         .build()
         );
@@ -56,6 +61,6 @@ public class AuthService {
     // ── 로그아웃 ─────────────────────────────────────────
     @Transactional
     public void logout(Long userId) {
-        refreshTokenRepository.deleteByUserId(userId);
+        refreshTokenRepository.deleteById(String.valueOf(userId));
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
@@ -31,14 +31,14 @@ public class AuthService {
         }
 
         // refresh 메서드 — refreshToken 값으로 userId 꺼내기
-        Long userId = jwtTokenProvider.getUserId(request.refreshToken());
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
 
         // Redis에서 조회
         RefreshToken saved = refreshTokenRepository.findById(String.valueOf(userId))
             .orElseThrow(() -> new SoflyException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         // 저장된 토큰값이랑 요청 토큰값 일치 확인
-        if (!saved.getRefreshToken().equals(request.refreshToken())) {
+        if (!saved.getRefreshToken().equals(refreshToken)) {
             throw new SoflyException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
         // 새 토큰 발급

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
@@ -1,0 +1,61 @@
+package com.sofly.core.global.auth.service;
+
+import com.sofly.core.global.auth.dto.RefreshTokenRequest;
+import com.sofly.core.global.auth.dto.TokenResponse;
+import com.sofly.core.global.exception.SoflyException;
+import com.sofly.core.global.exception.ErrorCode;
+import com.sofly.core.global.security.jwt.JwtProperties;
+import com.sofly.core.global.security.jwt.JwtTokenProvider;
+import com.sofly.core.global.security.oauth2.RefreshToken;
+import com.sofly.core.global.security.oauth2.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    // ── Access Token 재발급 ───────────────────────────────
+    @Transactional
+    public TokenResponse refresh(RefreshTokenRequest request) {
+        String refreshToken = request.refreshToken();
+
+        // 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new SoflyException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // Redis에서 조회
+        RefreshToken saved = refreshTokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new SoflyException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        Long userId = saved.getUserId();
+
+        // 새 토큰 발급
+        String newAccessToken  = jwtTokenProvider.generateAccessToken(userId);
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
+
+        // Refresh Token 교체 (Rotate)
+        refreshTokenRepository.delete(saved);
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .refreshToken(newRefreshToken)
+                        .userId(userId)
+                        .expiration(jwtProperties.expiration().refresh() / 1000)
+                        .build()
+        );
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+
+    // ── 로그아웃 ─────────────────────────────────────────
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/ErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/ErrorCode.java
@@ -1,0 +1,45 @@
+package com.sofly.core.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ── Auth ─────────────────────────────────────────────
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Refresh Token을 찾을 수 없습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Access Token입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+
+    // ── User ─────────────────────────────────────────────
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // ── Workspace ────────────────────────────────────────
+    WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "워크스페이스를 찾을 수 없습니다."),
+    WORKSPACE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "워크스페이스에 접근 권한이 없습니다."),
+    WORKSPACE_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "워크스페이스 멤버를 찾을 수 없습니다."),
+    INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 초대 코드입니다."),
+    ALREADY_WORKSPACE_MEMBER(HttpStatus.CONFLICT, "이미 워크스페이스 멤버입니다."),
+
+    // ── Schedule ─────────────────────────────────────────
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
+    SCHEDULE_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "일정 항목을 찾을 수 없습니다."),
+
+    // ── Album ────────────────────────────────────────────
+    ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "앨범을 찾을 수 없습니다."),
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "사진을 찾을 수 없습니다."),
+
+    // ── TravelLog ────────────────────────────────────────
+    TRAVEL_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "여행기를 찾을 수 없습니다."),
+    TRAVEL_LOG_ACCESS_DENIED(HttpStatus.FORBIDDEN, "여행기에 접근 권한이 없습니다."),
+
+    // ── Common ───────────────────────────────────────────
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.sofly.core.global.exception;
+
+import com.sofly.core.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // ── SoflyException (비즈니스 예외) ───────────────────
+    @ExceptionHandler(SoflyException.class)
+    public ResponseEntity<ApiResponse<Void>> handleSoflyException(SoflyException e) {
+        log.warn("SoflyException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getMessage()));
+    }
+
+    // ── @Valid 유효성 검사 실패 ───────────────────────────
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+
+        log.warn("Validation 실패: {}", message);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ApiResponse.fail(message));
+    }
+
+    // ── 그 외 예외 ───────────────────────────────────────
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected error: ", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/SoflyException.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/SoflyException.java
@@ -1,0 +1,19 @@
+package com.sofly.core.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SoflyException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public SoflyException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public SoflyException(ErrorCode errorCode, String detail) {
+        super(detail);
+        this.errorCode = errorCode;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/ApiResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.sofly.core.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+        boolean success,
+        String message,
+        T data
+) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, null, data);
+    }
+
+    public static <T> ApiResponse<T> fail(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -1,0 +1,69 @@
+package com.sofly.core.global.security;
+
+import com.sofly.core.global.security.jwt.JwtAuthenticationFilter;
+import com.sofly.core.global.security.jwt.JwtTokenProvider;
+import com.sofly.core.global.security.oauth2.CustomOAuth2UserService;
+import com.sofly.core.global.security.oauth2.OAuth2AuthenticationFailureHandler;
+import com.sofly.core.global.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            // CSRF 비활성화 (JWT 사용)
+            .csrf(AbstractHttpConfigurer::disable)
+
+            // 폼 로그인 비활성화 (소셜 로그인만 사용)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+
+            // 세션 비활성화 (JWT Stateless)
+            .sessionManagement(session ->
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+            // 요청 권한 설정
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers(
+                            "/login/oauth2/**",
+                            "/oauth2/**",
+                            "/api/auth/**",
+                            "/actuator/health"
+                    ).permitAll()
+                    .anyRequest().authenticated()
+            )
+
+            // OAuth2 로그인 설정
+            .oauth2Login(oauth2 -> oauth2
+                    .userInfoEndpoint(userInfo ->
+                            userInfo.userService(customOAuth2UserService))
+                    .successHandler(oAuth2AuthenticationSuccessHandler)
+                    .failureHandler(oAuth2AuthenticationFailureHandler)
+            )
+
+            // JWT 필터 등록
+            .addFilterBefore(
+                    new JwtAuthenticationFilter(jwtTokenProvider),
+                    UsernamePasswordAuthenticationFilter.class
+            );
+
+        return http.build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -34,6 +34,8 @@ public class SecurityConfig {
             // 폼 로그인 비활성화 (소셜 로그인만 사용)
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
+            .sessionManagement(session ->
+            session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
             // 세션 비활성화 (JWT Stateless)
             .sessionManagement(session ->

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -42,6 +42,8 @@ public class SecurityConfig {
             // 요청 권한 설정
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers(
+                            "/",
+                            "/index.html",
                             "/login/oauth2/**",
                             "/oauth2/**",
                             "/api/auth/**",

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                             "/api/auth/**",
                             "/actuator/health",
                             "/swagger-ui/**",
-                            "/swagger-ui/core",
+                            "/core",
                             "/v3/api-docs/**"     
                     ).permitAll()
                     .anyRequest().authenticated()

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -49,7 +49,10 @@ public class SecurityConfig {
                             "/login/oauth2/**",
                             "/oauth2/**",
                             "/api/auth/**",
-                            "/actuator/health"
+                            "/actuator/health",
+                            "/swagger-ui/**",
+                            "/swagger-ui/core",
+                            "/v3/api-docs/**"     
                     ).permitAll()
                     .anyRequest().authenticated()
             )

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -34,9 +34,6 @@ public class SecurityConfig {
             // 폼 로그인 비활성화 (소셜 로그인만 사용)
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
-            .sessionManagement(session ->
-            session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
             // 세션 비활성화 (JWT Stateless)
             .sessionManagement(session ->
                     session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                             "/api/auth/**",
                             "/actuator/health",
                             "/swagger-ui/**",
-                            "/core",
+                            "/core-docs",
                             "/v3/api-docs/**"     
                     ).permitAll()
                     .anyRequest().authenticated()

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
@@ -28,6 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
+        // TODO: social login jwt PR #16 성능개선 필요 (gemini-code-assist)
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
             Long userId = jwtTokenProvider.getUserId(token);
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.sofly.core.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Long userId = jwtTokenProvider.getUserId(token);
+
+            // SecurityContext에 인증 정보 저장
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                    );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // Authorization: Bearer {token} 에서 토큰 추출
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtProperties.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.sofly.core.global.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt.token")
+public record JwtProperties(
+        String secretKey,
+        Expiration expiration
+) {
+    public record Expiration(
+            long access,
+            long refresh
+    ) {}
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,80 @@
+package com.sofly.core.global.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(
+                jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    // ── Access Token 생성 ────────────────────────────────
+    public String generateAccessToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("type", "access")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration().access()))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // ── Refresh Token 생성 ───────────────────────────────
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("type", "refresh")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration().refresh()))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // ── userId 추출 ──────────────────────────────────────
+    public Long getUserId(String token) {
+        return Long.parseLong(
+                parseClaims(token).getSubject()
+        );
+    }
+
+    // ── 토큰 유효성 검증 ─────────────────────────────────
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원하지 않는 JWT 토큰: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.warn("잘못된 JWT 토큰: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어있음: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    // ── Claims 파싱 ──────────────────────────────────────
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
@@ -16,11 +16,16 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private final JwtProperties jwtProperties;
+    private final SecretKey secretKey;
+
+    public JwtTokenProvider(JwtProperties jwtProperties){
+        this.jwtProperties = jwtProperties;
+        this.secretKey = Keys.hmacShaKeyFor(
+            jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8));
+    }
 
     private SecretKey getSigningKey() {
-        return Keys.hmacShaKeyFor(
-                jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8)
-        );
+        return secretKey;
     }
 
     // ── Access Token 생성 ────────────────────────────────

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2User.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2User.java
@@ -1,0 +1,42 @@
+package com.sofly.core.global.security.oauth2;
+
+import com.sofly.core.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(user.getId());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,67 @@
+package com.sofly.core.global.security.oauth2;
+
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.repository.UserRepository;
+import com.sofly.core.global.security.oauth2.userinfo.GoogleUserInfo;
+import com.sofly.core.global.security.oauth2.userinfo.KakaoUserInfo;
+import com.sofly.core.global.security.oauth2.userinfo.NaverUserInfo;
+import com.sofly.core.global.security.oauth2.userinfo.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // 제공자 구분 (google / kakao / naver)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo userInfo = resolveUserInfo(registrationId, oAuth2User);
+
+        // 신규 가입 or 기존 회원 조회
+        User user = saveOrUpdate(registrationId, userInfo);
+
+        return new CustomOAuth2User(user, oAuth2User.getAttributes());
+    }
+
+    // ── 제공자별 UserInfo 파싱 ───────────────────────────
+    private OAuth2UserInfo resolveUserInfo(String registrationId, OAuth2User oAuth2User) {
+        return switch (registrationId) {
+            case "google" -> new GoogleUserInfo(oAuth2User.getAttributes());
+            case "kakao"  -> new KakaoUserInfo(oAuth2User.getAttributes());
+            case "naver"  -> new NaverUserInfo(oAuth2User.getAttributes());
+            default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인: " + registrationId);
+        };
+    }
+
+    // ── 신규 가입 or 기존 회원 반환 ──────────────────────
+    private User saveOrUpdate(String registrationId, OAuth2UserInfo userInfo) {
+        User.Provider provider = User.Provider.valueOf(registrationId.toUpperCase());
+
+        return userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .email(userInfo.getEmail())
+                                .nickname(userInfo.getNickname())
+                                .profileImageUrl(userInfo.getProfileImageUrl())
+                                .provider(provider)
+                                .providerId(userInfo.getProviderId())
+                                .role(User.Role.USER)
+                                .build()
+                ));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,34 @@
+package com.sofly.core.global.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${sofly.oauth2.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+
+        log.error("OAuth2 로그인 실패: {}", exception.getMessage());
+
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("error", exception.getMessage())
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,60 @@
+package com.sofly.core.global.security.oauth2;
+
+import com.sofly.core.global.security.jwt.JwtProperties;
+import com.sofly.core.global.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${sofly.oauth2.redirect-uri}")
+    private String redirectUri;     // 예: http://localhost:3000/oauth2/callback
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        Long userId = oAuth2User.getUserId();
+
+        // 토큰 발급
+        String accessToken  = jwtTokenProvider.generateAccessToken(userId);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+
+        // Refresh Token Redis 저장 (기존 토큰 삭제 후 저장)
+        refreshTokenRepository.deleteByUserId(userId);
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .refreshToken(refreshToken)
+                        .userId(userId)
+                        .expiration(jwtProperties.expiration().refresh() / 1000) // ms → 초
+                        .build()
+        );
+
+        // 프론트로 redirect (쿼리 파라미터로 토큰 전달)
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        log.info("OAuth2 로그인 성공 - userId: {}", userId);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -38,14 +38,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String accessToken  = jwtTokenProvider.generateAccessToken(userId);
         String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
 
-        // Refresh Token Redis 저장 (기존 토큰 삭제 후 저장)
-        refreshTokenRepository.deleteByUserId(userId);
+        // 저장 시 id를 userId로 고정
+        refreshTokenRepository.deleteById(String.valueOf(userId));
         refreshTokenRepository.save(
-                RefreshToken.builder()
-                        .refreshToken(refreshToken)
-                        .userId(userId)
-                        .expiration(jwtProperties.expiration().refresh() / 1000) // ms → 초
-                        .build()
+            RefreshToken.builder()
+                .id(String.valueOf(userId))        // key: refresh_token:{userId}
+                .refreshToken(refreshToken)
+                .expiration(jwtProperties.expiration().refresh() / 1000)
+                .build()
         );
 
         // 프론트로 redirect (쿼리 파라미터로 토큰 전달)

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshToken.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshToken.java
@@ -13,11 +13,10 @@ import org.springframework.data.redis.core.index.Indexed;
 public class RefreshToken {
 
     @Id
-    private String refreshToken;    // key: refresh_token:{refreshToken}
+    private String id;          // key를 "refresh_token:{userId}" 로 고정
 
-    @Indexed
-    private Long userId;            // userId로 검색 가능
+    private String refreshToken; // 실제 토큰 값
 
     @TimeToLive
-    private Long expiration;        // TTL (초 단위) — JwtProperties.expiration.refresh / 1000
+    private Long expiration;    // TTL (초)
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshToken.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshToken.java
@@ -1,0 +1,23 @@
+package com.sofly.core.global.security.oauth2;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Builder
+@RedisHash("refresh_token")
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;    // key: refresh_token:{refreshToken}
+
+    @Indexed
+    private Long userId;            // userId로 검색 가능
+
+    @TimeToLive
+    private Long expiration;        // TTL (초 단위) — JwtProperties.expiration.refresh / 1000
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshTokenRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshTokenRepository.java
@@ -5,8 +5,5 @@ import org.springframework.data.repository.CrudRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-
-    Optional<RefreshToken> findByUserId(Long userId);
-
-    void deleteByUserId(Long userId);
+    // findByUserId 제거 — userId를 @Id로 쓰므로 findById로 조회
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshTokenRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.sofly.core.global.security.oauth2;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+    Optional<RefreshToken> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/GoogleUserInfo.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/GoogleUserInfo.java
@@ -1,0 +1,32 @@
+package com.sofly.core.global.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getProfileImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/KakaoUserInfo.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/KakaoUserInfo.java
@@ -1,0 +1,38 @@
+package com.sofly.core.global.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
+
+    @SuppressWarnings("unchecked")
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = (Map<String, Object>) kakaoAccount.get("profile");
+    }
+
+    @Override
+    public String getProviderId() {
+        // user-name-attribute: id → attributes의 최상단에 있음
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) kakaoAccount.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getProfileImageUrl() {
+        return (String) profile.get("profile_image_url");
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/NaverUserInfo.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/NaverUserInfo.java
@@ -14,21 +14,21 @@ public class NaverUserInfo implements OAuth2UserInfo {
 
     @Override
     public String getProviderId() {
-        return (String) response.get("id");
+        return response != null ? (String) response.get("id") : null;
     }
 
     @Override
     public String getEmail() {
-        return (String) response.get("email");
+        return response != null ? (String) response.get("email") : null;
     }
 
     @Override
     public String getNickname() {
-        return (String) response.get("name");
+        return response != null ? (String) response.get("name") : null;
     }
 
     @Override
     public String getProfileImageUrl() {
-        return (String) response.get("profile_image");
+        return response != null ? (String) response.get("profile_image") : null;
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/NaverUserInfo.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/NaverUserInfo.java
@@ -1,0 +1,34 @@
+package com.sofly.core.global.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class NaverUserInfo implements OAuth2UserInfo {
+
+    // user-name-attribute: response → attributes 안에 "response" 키로 실제 데이터가 있음
+    private final Map<String, Object> response;
+
+    @SuppressWarnings("unchecked")
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.response = (Map<String, Object>) attributes.get("response");
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) response.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) response.get("name");
+    }
+
+    @Override
+    public String getProfileImageUrl() {
+        return (String) response.get("profile_image");
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/OAuth2UserInfo.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,12 @@
+package com.sofly.core.global.security.oauth2.userinfo;
+
+public interface OAuth2UserInfo {
+
+    String getProviderId();
+
+    String getEmail();
+
+    String getNickname();
+
+    String getProfileImageUrl();
+}

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  forward-headers-strategy: framework
 
 spring:
   application:

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -87,7 +87,7 @@ sofly:
 
 springdoc:
   swagger-ui:
-    path: /core
+    path: /core-docs
   api-docs:
     path: /v3/api-docs/core
 

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -81,7 +81,8 @@ jwt:
 
 sofly:
   oauth2:
-    redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}
+    redirect-uri: http://localhost:8080
+    # redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}
 
 springdoc:
   swagger-ui:
@@ -90,5 +91,4 @@ springdoc:
     path: /v3/api-docs/core
 
 logging:
-  level:
-    com.sofly: DEBUG
+  exception-conversion-word: "%wEx{0}"

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -82,7 +82,7 @@ jwt:
 
 sofly:
   oauth2:
-    redirect-uri: http://localhost:8080
+    redirect-uri: ${FRONTEND_REDIRECT_URL:http://localhost:8080}
     # redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}
 
 springdoc:

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -20,10 +20,68 @@ spring:
         format_sql: true
         highlight_sql: true
     open-in-view: false
-  
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   output:
     ansi:
       enabled: ALWAYS
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Kakao
+            scope:
+              - account_email
+              - profile_nickname
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-name: Naver
+            scope:
+              - name
+              - email
+              - profile_image
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+jwt:
+  token:
+    secretKey: ${JWT_SECRET_KEY}
+    expiration:
+      access: 14400000       # 4시간
+      refresh: 1209600000    # 14일
+
+sofly:
+  oauth2:
+    redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}
 
 springdoc:
   swagger-ui:
@@ -32,4 +90,5 @@ springdoc:
     path: /v3/api-docs/core
 
 logging:
-  exception-conversion-word: "%wEx{0}"
+  level:
+    com.sofly: DEBUG

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -87,7 +87,7 @@ sofly:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui/core
+    path: /core
   api-docs:
     path: /v3/api-docs/core
 

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -27,9 +27,9 @@ spring:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui/service
+    path: /swagger-ui/core
   api-docs:
-    path: /v3/api-docs/service
+    path: /v3/api-docs/core
 
 logging:
   exception-conversion-word: "%wEx{0}"

--- a/services/travel-core-service/src/main/resources/application.yaml
+++ b/services/travel-core-service/src/main/resources/application.yaml
@@ -6,9 +6,9 @@ spring:
     name: travel-core-service
 
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:sofly_db}
-    username: ${DB_USER:sofly_user}
-    password: ${DB_PASSWORD:sofly_password}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/sofly_db}
+    username: ${SPRING_DATASOURCE_USERNAME:sofly_user}
+    password: ${SPRING_DATASOURCE_PASSWORD:sofly_password}
     driver-class-name: org.postgresql.Driver
 
   jpa:

--- a/services/travel-core-service/src/main/resources/application.yaml
+++ b/services/travel-core-service/src/main/resources/application.yaml
@@ -3,9 +3,9 @@ spring:
     name: travel-core-service
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/sofly_db}
-    username: ${SPRING_DATASOURCE_USERNAME:sofly_user}
-    password: ${SPRING_DATASOURCE_PASSWORD:sofly_password}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:sofly_db}
+    username: ${DB_USER:sofly_user}
+    password: ${DB_PASSWORD:sofly_password}
     driver-class-name: org.postgresql.Driver
 
   jpa:

--- a/services/travel-core-service/src/main/resources/application.yaml
+++ b/services/travel-core-service/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 8080
+
 spring:
   application:
     name: travel-core-service
@@ -21,3 +24,12 @@ spring:
   output:
     ansi:
       enabled: ALWAYS
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui/service
+  api-docs:
+    path: /v3/api-docs/service
+
+logging:
+  exception-conversion-word: "%wEx{0}"

--- a/services/travel-core-service/src/main/resources/static/index.html
+++ b/services/travel-core-service/src/main/resources/static/index.html
@@ -1,0 +1,852 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sofly — Auth Test</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Mono:wght@300;400&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0a0a0f;
+      --surface: #13131a;
+      --border: #222230;
+      --accent: #6c63ff;
+      --accent2: #ff6584;
+      --text: #e8e8f0;
+      --muted: #6b6b80;
+      --success: #4ade80;
+      --warning: #fbbf24;
+      --danger: #f87171;
+      --mono: 'DM Mono', monospace;
+      --sans: 'Syne', sans-serif;
+    }
+
+    html, body { height: 100%; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+      display: grid;
+      grid-template-columns: 260px 1fr;
+      grid-template-rows: 56px 1fr;
+      min-height: 100vh;
+    }
+
+    /* ── 헤더 ── */
+    header {
+      grid-column: 1 / -1;
+      display: flex;
+      align-items: center;
+      padding: 0 24px;
+      border-bottom: 1px solid var(--border);
+      gap: 12px;
+    }
+
+    .logo {
+      font-size: 18px;
+      font-weight: 800;
+      letter-spacing: -0.5px;
+      color: var(--text);
+    }
+
+    .logo span { color: var(--accent); }
+
+    .badge {
+      font-family: var(--mono);
+      font-size: 10px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: #6c63ff22;
+      color: var(--accent);
+      border: 1px solid #6c63ff44;
+    }
+
+    .header-right {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .status-dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--success);
+      box-shadow: 0 0 6px var(--success);
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+
+    .status-text {
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--muted);
+    }
+
+    /* ── 사이드바 ── */
+    aside {
+      border-right: 1px solid var(--border);
+      padding: 24px 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      overflow-y: auto;
+    }
+
+    .nav-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      color: var(--muted);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      padding: 0 8px;
+      margin: 12px 0 4px;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 10px;
+      border-radius: 6px;
+      font-size: 13px;
+      cursor: pointer;
+      color: var(--muted);
+      transition: all 0.15s;
+      border: 1px solid transparent;
+    }
+
+    .nav-item:hover { background: var(--surface); color: var(--text); }
+
+    .nav-item.active {
+      background: #6c63ff18;
+      color: var(--accent);
+      border-color: #6c63ff33;
+    }
+
+    .nav-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: currentColor;
+      flex-shrink: 0;
+    }
+
+    /* ── 메인 ── */
+    main {
+      padding: 32px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .page { display: none; flex-direction: column; gap: 24px; }
+    .page.active { display: flex; }
+
+    .page-title {
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: -0.5px;
+    }
+
+    .page-title .dim { color: var(--muted); font-weight: 400; }
+
+    /* ── 카드 ── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px 24px;
+    }
+
+    .card-title {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+
+    /* ── 소셜 로그인 버튼 ── */
+    .login-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+    }
+
+    .social-btn {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      padding: 20px 16px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text);
+      font-family: var(--sans);
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-decoration: none;
+    }
+
+    .social-btn:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent);
+      background: #6c63ff0d;
+    }
+
+    .social-btn svg { width: 28px; height: 28px; }
+
+    .social-btn.google:hover { border-color: #4285f4; background: #4285f40d; }
+    .social-btn.kakao:hover  { border-color: #fee500; background: #fee5000d; color: #fee500; }
+    .social-btn.naver:hover  { border-color: #03c75a; background: #03c75a0d; color: #03c75a; }
+
+    /* ── 토큰 표시 ── */
+    .token-row {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .token-label {
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--muted);
+    }
+
+    .token-box {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 14px;
+    }
+
+    .token-value {
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--accent);
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .token-value.empty { color: var(--muted); }
+
+    .copy-btn {
+      background: none;
+      border: none;
+      color: var(--muted);
+      cursor: pointer;
+      font-family: var(--mono);
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      transition: all 0.15s;
+      flex-shrink: 0;
+    }
+
+    .copy-btn:hover { background: var(--border); color: var(--text); }
+
+    /* ── API 테스트 ── */
+    .api-row {
+      display: grid;
+      grid-template-columns: 80px 1fr auto;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .api-row:last-child { border-bottom: none; }
+
+    .method {
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 400;
+      padding: 3px 8px;
+      border-radius: 4px;
+      text-align: center;
+    }
+
+    .method.post { background: #6c63ff22; color: var(--accent); border: 1px solid #6c63ff44; }
+    .method.get  { background: #4ade8022; color: var(--success); border: 1px solid #4ade8044; }
+
+    .api-path {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text);
+    }
+
+    .api-desc {
+      font-size: 11px;
+      color: var(--muted);
+      margin-top: 2px;
+    }
+
+    .run-btn {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 11px;
+      padding: 5px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.15s;
+      white-space: nowrap;
+    }
+
+    .run-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+    /* ── 응답 패널 ── */
+    .response-panel {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+      font-family: var(--mono);
+      font-size: 11px;
+      line-height: 1.6;
+      min-height: 80px;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .response-panel.success { color: var(--success); border-color: #4ade8033; }
+    .response-panel.error   { color: var(--danger);  border-color: #f8717133; }
+    .response-panel.idle    { color: var(--muted); }
+
+    /* ── 유저 정보 ── */
+    .user-card {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 16px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+    }
+
+    .avatar {
+      width: 48px; height: 48px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, var(--accent), var(--accent2));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+
+    .user-info .name { font-size: 15px; font-weight: 600; }
+    .user-info .email { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+    .provider-badge {
+      margin-left: auto;
+      font-family: var(--mono);
+      font-size: 10px;
+      padding: 3px 10px;
+      border-radius: 20px;
+    }
+
+    .provider-badge.google { background: #4285f422; color: #4285f4; }
+    .provider-badge.kakao  { background: #fee50022; color: #fee500; }
+    .provider-badge.naver  { background: #03c75a22; color: #03c75a; }
+
+    /* ── 알림 토스트 ── */
+    #toast {
+      position: fixed;
+      bottom: 24px; right: 24px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 16px;
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text);
+      opacity: 0;
+      transform: translateY(8px);
+      transition: all 0.2s;
+      pointer-events: none;
+      z-index: 999;
+    }
+
+    #toast.show { opacity: 1; transform: translateY(0); }
+
+    /* ── URL 파라미터 입력 ── */
+    .input-row {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    input[type="text"] {
+      flex: 1;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 12px;
+      padding: 8px 12px;
+      border-radius: 6px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    input[type="text"]:focus { border-color: var(--accent); }
+    input[type="text"]::placeholder { color: var(--muted); }
+
+    .send-btn {
+      background: var(--accent);
+      border: none;
+      color: #fff;
+      font-family: var(--sans);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    .send-btn:hover { opacity: 0.85; }
+
+    /* 애니메이션 */
+    .page.active > * {
+      animation: fadeUp 0.25s ease both;
+    }
+    .page.active > *:nth-child(1) { animation-delay: 0s; }
+    .page.active > *:nth-child(2) { animation-delay: 0.05s; }
+    .page.active > *:nth-child(3) { animation-delay: 0.1s; }
+
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(10px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+  </style>
+</head>
+<body>
+
+<!-- 헤더 -->
+<header>
+  <span class="logo">so<span>fly</span></span>
+  <span class="badge">Auth Test</span>
+  <div class="header-right">
+    <div class="status-dot" id="serverDot"></div>
+    <span class="status-text" id="serverStatus">connecting...</span>
+  </div>
+</header>
+
+<!-- 사이드바 -->
+<aside>
+  <span class="nav-label">Auth</span>
+  <div class="nav-item active" onclick="showPage('login')">
+    <span class="nav-dot"></span> 소셜 로그인
+  </div>
+  <div class="nav-item" onclick="showPage('token')">
+    <span class="nav-dot"></span> 토큰 관리
+  </div>
+  <div class="nav-item" onclick="showPage('api')">
+    <span class="nav-dot"></span> API 테스트
+  </div>
+  <div class="nav-item" onclick="showPage('user')">
+    <span class="nav-dot"></span> 유저 정보
+  </div>
+  <span class="nav-label">Docs</span>
+  <div class="nav-item" onclick="window.open('/swagger-ui/core','_blank')">
+    <span class="nav-dot"></span> Swagger UI ↗
+  </div>
+  <div class="nav-item" onclick="window.open('/v3/api-docs/core','_blank')">
+    <span class="nav-dot"></span> API Docs ↗
+  </div>
+</aside>
+
+<!-- 메인 -->
+<main>
+
+  <!-- 소셜 로그인 -->
+  <div class="page active" id="page-login">
+    <div class="page-title">소셜 로그인 <span class="dim">/ OAuth2</span></div>
+
+    <div class="card">
+      <div class="card-title">Provider 선택</div>
+      <div class="login-grid">
+        <a class="social-btn google" href="/oauth2/authorization/google">
+          <svg viewBox="0 0 24 24" fill="none">
+            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
+            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+          </svg>
+          Google
+        </a>
+        <a class="social-btn kakao" href="/oauth2/authorization/kakao">
+          <svg viewBox="0 0 24 24" fill="#3C1E1E">
+            <path d="M12 3C6.48 3 2 6.69 2 11.25c0 2.88 1.87 5.41 4.7 6.87l-.94 3.47 4.05-2.67c.69.1 1.42.16 2.19.16 5.52 0 10-3.69 10-8.25S17.52 3 12 3z" fill="currentColor"/>
+          </svg>
+          Kakao
+        </a>
+        <a class="social-btn naver" href="/oauth2/authorization/naver">
+          <svg viewBox="0 0 24 24">
+            <path d="M16.27 12.96L7.5 1H1v22h7.73L17.5 12v11H23V1h-6.73z" fill="#03C75A"/>
+          </svg>
+          Naver
+        </a>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">URL 파라미터 토큰 파싱</div>
+      <p style="font-size:12px; color:var(--muted); margin-bottom:12px;">
+        로그인 성공 후 <code style="color:var(--accent)">?accessToken=...&refreshToken=...</code> 파라미터가 자동으로 파싱됩니다.
+      </p>
+      <div id="parseResult" class="response-panel idle">대기 중...</div>
+    </div>
+  </div>
+
+  <!-- 토큰 관리 -->
+  <div class="page" id="page-token">
+    <div class="page-title">토큰 관리 <span class="dim">/ JWT</span></div>
+
+    <div class="card">
+      <div class="card-title">저장된 토큰</div>
+      <div class="token-row" style="gap:16px;">
+        <div>
+          <div class="token-label">ACCESS TOKEN</div>
+          <div class="token-box">
+            <span class="token-value" id="displayAccess">없음</span>
+            <button class="copy-btn" onclick="copyToken('access')">copy</button>
+          </div>
+        </div>
+        <div>
+          <div class="token-label">REFRESH TOKEN</div>
+          <div class="token-box">
+            <span class="token-value" id="displayRefresh">없음</span>
+            <button class="copy-btn" onclick="copyToken('refresh')">copy</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">토큰 재발급 — POST /api/auth/refresh</div>
+      <button class="send-btn" onclick="refreshToken()" style="margin-bottom:12px;">Refresh 실행</button>
+      <div id="refreshResult" class="response-panel idle">대기 중...</div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">로그아웃 — POST /api/auth/logout</div>
+      <button class="send-btn" onclick="logout()" style="background:#f8717133; color:var(--danger); border:1px solid #f8717133; margin-bottom:12px;">Logout 실행</button>
+      <div id="logoutResult" class="response-panel idle">대기 중...</div>
+    </div>
+  </div>
+
+  <!-- API 테스트 -->
+  <div class="page" id="page-api">
+    <div class="page-title">API 테스트 <span class="dim">/ Request</span></div>
+
+    <div class="card">
+      <div class="card-title">Custom Request</div>
+      <div class="input-row">
+        <input type="text" id="customPath" placeholder="/api/..." value="/api/auth/refresh">
+        <select id="customMethod" style="background:var(--bg);border:1px solid var(--border);color:var(--text);font-family:var(--mono);font-size:12px;padding:8px 12px;border-radius:6px;outline:none;">
+          <option>GET</option>
+          <option selected>POST</option>
+        </select>
+        <button class="send-btn" onclick="runCustom()">Send</button>
+      </div>
+      <div id="customResult" class="response-panel idle">대기 중...</div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">빠른 실행</div>
+      <div class="api-row">
+        <span class="method get">GET</span>
+        <div>
+          <div class="api-path">/actuator/health</div>
+          <div class="api-desc">서버 헬스체크</div>
+        </div>
+        <button class="run-btn" onclick="runApi('GET','/actuator/health','health')">Run</button>
+      </div>
+      <div id="result-health" class="response-panel idle" style="display:none;margin-top:8px;"></div>
+
+      <div class="api-row">
+        <span class="method post">POST</span>
+        <div>
+          <div class="api-path">/api/auth/logout</div>
+          <div class="api-desc">로그아웃 (토큰 필요)</div>
+        </div>
+        <button class="run-btn" onclick="runApi('POST','/api/auth/logout','logout2')">Run</button>
+      </div>
+      <div id="result-logout2" class="response-panel idle" style="display:none;margin-top:8px;"></div>
+    </div>
+  </div>
+
+  <!-- 유저 정보 -->
+  <div class="page" id="page-user">
+    <div class="page-title">유저 정보 <span class="dim">/ Profile</span></div>
+
+    <div class="card">
+      <div class="card-title">현재 로그인 상태</div>
+      <div id="userCard">
+        <p style="font-size:13px; color:var(--muted);">로그인 정보가 없습니다. 소셜 로그인 후 토큰이 저장되면 표시됩니다.</p>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">JWT Payload 디코딩</div>
+      <div id="jwtPayload" class="response-panel idle">Access Token을 저장하면 자동으로 디코딩됩니다.</div>
+    </div>
+  </div>
+
+</main>
+
+<!-- 토스트 -->
+<div id="toast"></div>
+
+<script>
+  // ── 상태 ──────────────────────────────────────────────
+  let tokens = {
+    access: localStorage.getItem('sofly_access') || '',
+    refresh: localStorage.getItem('sofly_refresh') || ''
+  };
+
+  // ── URL 파라미터 파싱 (로그인 콜백) ──────────────────
+  (function parseUrlTokens() {
+    const params = new URLSearchParams(window.location.search);
+    const access  = params.get('accessToken');
+    const refresh = params.get('refreshToken');
+    const error   = params.get('error');
+    const panel   = document.getElementById('parseResult');
+
+    if (error) {
+      panel.className = 'response-panel error';
+      panel.textContent = '로그인 실패: ' + error;
+      return;
+    }
+
+    if (access && refresh) {
+      tokens.access  = access;
+      tokens.refresh = refresh;
+      localStorage.setItem('sofly_access', access);
+      localStorage.setItem('sofly_refresh', refresh);
+      panel.className = 'response-panel success';
+      panel.textContent = '토큰 저장 완료!\naccess:  ' + access.slice(0,40) + '...\nrefresh: ' + refresh.slice(0,40) + '...';
+      window.history.replaceState({}, '', '/');
+      updateDisplay();
+      return;
+    }
+
+    if (!access && !refresh) {
+      panel.className = 'response-panel idle';
+      panel.textContent = '소셜 로그인 버튼을 클릭하면 여기에 결과가 표시됩니다.';
+    }
+  })();
+
+  // ── 디스플레이 업데이트 ───────────────────────────────
+  function updateDisplay() {
+    const aEl = document.getElementById('displayAccess');
+    const rEl = document.getElementById('displayRefresh');
+
+    if (tokens.access) {
+      aEl.textContent = tokens.access;
+      aEl.classList.remove('empty');
+    } else {
+      aEl.textContent = '없음';
+      aEl.classList.add('empty');
+    }
+
+    if (tokens.refresh) {
+      rEl.textContent = tokens.refresh;
+      rEl.classList.remove('empty');
+    } else {
+      rEl.textContent = '없음';
+      rEl.classList.add('empty');
+    }
+
+    decodeJwt();
+    updateUserCard();
+  }
+
+  updateDisplay();
+
+  // ── JWT 디코딩 ────────────────────────────────────────
+  function decodeJwt() {
+    const el = document.getElementById('jwtPayload');
+    if (!tokens.access) return;
+    try {
+      const payload = JSON.parse(atob(tokens.access.split('.')[1]));
+      payload._exp_readable = new Date(payload.exp * 1000).toLocaleString('ko-KR');
+      el.className = 'response-panel success';
+      el.textContent = JSON.stringify(payload, null, 2);
+    } catch(e) {
+      el.className = 'response-panel error';
+      el.textContent = '디코딩 실패: ' + e.message;
+    }
+  }
+
+  // ── 유저 카드 ─────────────────────────────────────────
+  function updateUserCard() {
+    if (!tokens.access) return;
+    try {
+      const payload = JSON.parse(atob(tokens.access.split('.')[1]));
+      const userId = payload.sub;
+      const el = document.getElementById('userCard');
+      el.innerHTML = `
+        <div class="user-card">
+          <div class="avatar">${userId ? userId.toString().slice(-2) : '?'}</div>
+          <div class="user-info">
+            <div class="name">User ID: ${userId}</div>
+            <div class="email">type: ${payload.type || 'access'}</div>
+          </div>
+          <span class="provider-badge google">JWT</span>
+        </div>`;
+    } catch(e) {}
+  }
+
+  // ── 페이지 전환 ───────────────────────────────────────
+  function showPage(name) {
+    document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.nav-item').forEach(n => n.classList.remove('active'));
+    document.getElementById('page-' + name).classList.add('active');
+    event.currentTarget.classList.add('active');
+  }
+
+  // ── 토큰 복사 ─────────────────────────────────────────
+  function copyToken(type) {
+    const val = type === 'access' ? tokens.access : tokens.refresh;
+    if (!val) { toast('저장된 토큰이 없습니다'); return; }
+    navigator.clipboard.writeText(val).then(() => toast('복사 완료!'));
+  }
+
+  // ── Refresh ───────────────────────────────────────────
+  async function refreshToken() {
+    const el = document.getElementById('refreshResult');
+    if (!tokens.refresh) { el.className='response-panel error'; el.textContent='Refresh Token이 없습니다.'; return; }
+    el.className='response-panel idle'; el.textContent='요청 중...';
+    try {
+      const res = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken: tokens.refresh })
+      });
+      const data = await res.json();
+      if (data.success) {
+        tokens.access  = data.data.accessToken;
+        tokens.refresh = data.data.refreshToken;
+        localStorage.setItem('sofly_access', tokens.access);
+        localStorage.setItem('sofly_refresh', tokens.refresh);
+        updateDisplay();
+        el.className='response-panel success';
+      } else {
+        el.className='response-panel error';
+      }
+      el.textContent = JSON.stringify(data, null, 2);
+    } catch(e) {
+      el.className='response-panel error';
+      el.textContent = '요청 실패: ' + e.message;
+    }
+  }
+
+  // ── Logout ────────────────────────────────────────────
+  async function logout() {
+    const el = document.getElementById('logoutResult');
+    if (!tokens.access) { el.className='response-panel error'; el.textContent='Access Token이 없습니다.'; return; }
+    el.className='response-panel idle'; el.textContent='요청 중...';
+    try {
+      const res = await fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer ' + tokens.access }
+      });
+      const data = await res.json();
+      tokens.access = ''; tokens.refresh = '';
+      localStorage.removeItem('sofly_access');
+      localStorage.removeItem('sofly_refresh');
+      updateDisplay();
+      el.className = res.ok ? 'response-panel success' : 'response-panel error';
+      el.textContent = JSON.stringify(data, null, 2);
+    } catch(e) {
+      el.className='response-panel error';
+      el.textContent = '요청 실패: ' + e.message;
+    }
+  }
+
+  // ── 빠른 API 실행 ─────────────────────────────────────
+  async function runApi(method, path, id) {
+    const el = document.getElementById('result-' + id);
+    el.style.display = 'block';
+    el.className = 'response-panel idle';
+    el.textContent = '요청 중...';
+    try {
+      const headers = { 'Content-Type': 'application/json' };
+      if (tokens.access) headers['Authorization'] = 'Bearer ' + tokens.access;
+      const res = await fetch(path, { method, headers });
+      const text = await res.text();
+      let pretty;
+      try { pretty = JSON.stringify(JSON.parse(text), null, 2); } catch { pretty = text; }
+      el.className = res.ok ? 'response-panel success' : 'response-panel error';
+      el.textContent = `HTTP ${res.status}\n\n${pretty}`;
+    } catch(e) {
+      el.className = 'response-panel error';
+      el.textContent = '요청 실패: ' + e.message;
+    }
+  }
+
+  // ── Custom Request ────────────────────────────────────
+  async function runCustom() {
+    const path   = document.getElementById('customPath').value;
+    const method = document.getElementById('customMethod').value;
+    await runApi(method, path, 'custom');
+    document.getElementById('customResult').style.display = 'block';
+  }
+
+  // ── 서버 헬스체크 ─────────────────────────────────────
+  async function checkServer() {
+    try {
+      const res = await fetch('/actuator/health');
+      const dot = document.getElementById('serverDot');
+      const txt = document.getElementById('serverStatus');
+      if (res.ok) {
+        dot.style.background = 'var(--success)';
+        dot.style.boxShadow  = '0 0 6px var(--success)';
+        txt.textContent = 'server online';
+      } else {
+        dot.style.background = 'var(--warning)';
+        txt.textContent = 'server error';
+      }
+    } catch {
+      document.getElementById('serverDot').style.background = 'var(--danger)';
+      document.getElementById('serverStatus').textContent = 'server offline';
+    }
+  }
+
+  checkServer();
+  setInterval(checkServer, 30000);
+
+  // ── 토스트 ────────────────────────────────────────────
+  function toast(msg) {
+    const el = document.getElementById('toast');
+    el.textContent = msg;
+    el.classList.add('show');
+    setTimeout(() => el.classList.remove('show'), 2000);
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약
소셜 로그인(Google / Kakao / Naver) OAuth2 인증 및 JWT 기반 토큰 관리를 구현했습니다.
로그인 성공 시 Access Token / Refresh Token을 발급하고, Redis에 Refresh Token을 저장하는 전체 인증 흐름을 완성했습니다.

## 🔧 변경 사항
- **소셜 로그인 3종 구현** — Google / Kakao / Naver OAuth2 로그인 지원, 제공자별 UserInfo 파싱 처리
- **JWT 토큰 발급** — Access Token(4시간) / Refresh Token(14일) 발급 및 검증
- **Refresh Token Redis 저장 구조 개선** — `@Indexed` 제거로 보조 인덱스 SET 무한 생성 문제 수정, userId를 `@Id`로 사용해 유저당 키 1개로 고정
- **Refresh Token Rotate 전략 적용** — 재발급 시 Refresh Token도 교체하여 탈취 토큰 재사용 차단
- **전역 예외 처리** — `SoflyException`, `ErrorCode`, `GlobalExceptionHandler` 구현
- **공통 응답 래퍼** — `ApiResponse<T>` 구현
- **Swagger 설정** — springdoc 2.8.6 적용, JWT Bearer 인증 스키마 등록, `SwaggerConfig` 추가
- **Auth API 2종** — `POST /api/auth/refresh`, `POST /api/auth/logout`
- **로그인 테스트 UI** — `src/main/resources/static/index.html` 추가

## 📋 작업 상세 내용
- [x] `JwtProperties`, `JwtTokenProvider`, `JwtAuthenticationFilter` 구현
- [x] `OAuth2UserInfo` 인터페이스 및 Google / Kakao / Naver 구현체 작성
- [x] `CustomOAuth2UserService` — 소셜 로그인 신규 가입 / 기존 회원 조회
- [x] `OAuth2AuthenticationSuccessHandler` — JWT 발급 후 프론트 redirect
- [x] `OAuth2AuthenticationFailureHandler` — 로그인 실패 처리
- [x] `SecurityConfig` — JWT Stateless, OAuth2 로그인, 경로별 권한 설정
- [x] `RefreshToken` Redis 엔티티 설계 개선 (`@Indexed` 제거, userId를 `@Id`로 변경)
- [x] `RefreshTokenRepository` — `findByUserId` 제거, `findById` / `deleteById` 사용
- [x] `AuthController` — refresh, logout API 구현 및 Swagger `@Operation` 적용
- [x] `AuthService` — 토큰 재발급 (Rotate), 로그아웃 구현
- [x] `UserRepository` — `findByProviderAndProviderId` 구현
- [x] `ErrorCode`, `SoflyException`, `GlobalExceptionHandler` 구현
- [x] `ApiResponse<T>` 공통 응답 래퍼 구현
- [x] `SwaggerConfig` — OpenAPI 설정, Bearer JWT 인증 스키마 등록
- [x] `application-core.yaml` — Redis, OAuth2, JWT, Swagger, redirect-uri 설정
- [x] `SoflyCoreApplication` — `@EnableJpaAuditing`, `@EnableFeignClients`, `@ConfigurationPropertiesScan` 추가
- [x] `static/index.html` — 소셜 로그인 테스트 UI 추가

## 🔗 관련 이슈
closed #13 

## 📝 기타
- `sofly.oauth2.redirect-uri`는 현재 `http://localhost:8080`으로 설정되어 있습니다. 프론트 개발 시 `http://localhost:3000/oauth2/callback`으로 변경 필요합니다.
- Refresh Token은 Redis에 `refresh_token:{userId}` 키로 저장되며 TTL 14일입니다. 기존 더티 데이터가 있다면 `redis-cli FLUSHDB`로 초기화해주세요.
- Swagger UI 접속: `http://localhost:8080/swagger-ui/core-docs`