### PR TITLE
Chore/21 cicd multistage build

### DIFF
--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -201,6 +201,13 @@ jobs:
             git checkout -B develop origin/develop
             git reset --hard origin/develop
 
+            # 동기화 확인
+            echo "📌 현재 브랜치: $(git branch --show-current)"
+            echo "📌 현재 커밋:   $(git rev-parse HEAD)"
+            echo "📌 커밋 메시지: $(git log -1 --pretty=format:'%s')"
+            echo "📌 커밋 시간:   $(git log -1 --pretty=format:'%ci')"
+            echo "📌 커밋 작성자: $(git log -1 --pretty=format:'%an')"
+
             # ── 4. .env 생성 ───────────────────────────────────
             echo "👉🏻[4] Create .env.core"
             cat <<EOF > .env.core

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -2,7 +2,7 @@ name: Deploy travel-core-service
 
 on:
   push:
-    branches: [ "chore/21-cicd-multistage-build" ]
+    branches: [ "develop" ]
     paths:
       - 'services/travel-core-service/**'
       - '.github/workflows/deploy-core.yml'

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -194,6 +194,13 @@ jobs:
               --format='{{.Config.Image}}' 2>/dev/null || echo "")
             echo "📦 PREV_IMAGE: $PREV_IMAGE"
 
+            echo "👉🏻[3.5] Git pull latest code"
+            git reset --hard HEAD
+            git clean -fd
+            git fetch origin develop
+            git checkout -B develop origin/develop
+            git reset --hard origin/develop
+
             # ── 4. .env 생성 ───────────────────────────────────
             echo "👉🏻[4] Create .env.core"
             cat <<EOF > .env.core

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -121,18 +121,18 @@ jobs:
 
             # ── 롤백 함수 ──────────────────────────────────────
             rollback() {
-              echo "[ROLLBACK] 배포 실패 — 롤백 시작"
+              echo "⏱️[ROLLBACK] 배포 실패 — 롤백 시작"
               trap - ERR
 
               # 변수가 설정되지 않은 초기 단계 실패면 롤백할 게 없음
               if [ -z "$TARGET_COLOR" ] || [ -z "$CURRENT_COLOR" ]; then
-                echo "[ROLLBACK] 초기 단계 실패 — 롤백 생략"
+                echo "⏱️[ROLLBACK] 초기 단계 실패 — 롤백 생략"
                 return 0
               fi
 
               # Nginx가 이미 전환됐을 수 있으므로 기존 포트로 되돌림
-              echo "[ROLLBACK] Nginx를 $CURRENT_COLOR($CURRENT_PORT)로 복구"
-              echo "set \$core_url http://127.0.0.1:${CURRENT_PORT};" | \
+              echo "⏱️[ROLLBACK] Nginx를 $CURRENT_COLOR($CURRENT_PORT)로 복구"
+              echo "⏱️set \$core_url http://127.0.0.1:${CURRENT_PORT};" | \
                 sudo tee /etc/nginx/bluegreen/service-url-core.inc
               sudo nginx -s reload
 
@@ -142,21 +142,21 @@ jobs:
 
               # 기존 컨테이너(CURRENT)가 살아있으면 롤백 완료
               if sudo docker inspect core-${CURRENT_COLOR} > /dev/null 2>&1; then
-                echo "[ROLLBACK] 완료 — core-${CURRENT_COLOR}($CURRENT_PORT) 이미 서비스 중"
+                echo "⏱️[ROLLBACK] 완료 — core-${CURRENT_COLOR}($CURRENT_PORT) 이미 서비스 중"
                 return 0
               fi
 
               # 기존 컨테이너가 없을 때만 이전 이미지로 재기동
               if [ -n "$PREV_IMAGE" ]; then
-                echo "[ROLLBACK] core-${CURRENT_COLOR} 재기동 — $PREV_IMAGE"
+                echo "⏱️[ROLLBACK] core-${CURRENT_COLOR} 재기동 — $PREV_IMAGE"
                 export CORE_IMAGE=$PREV_IMAGE
                 export CORE_PORT=$CURRENT_PORT
                 export CORE_CONTAINER_NAME=core-${CURRENT_COLOR}
                 cd "$DEPLOY_PATH"
                 sudo -E docker compose up -d core
-                echo "[ROLLBACK] 완료"
+                echo "⏱️[ROLLBACK] 완료"
               else
-                echo "[ROLLBACK] 이전 이미지 없음 — 수동 복구 필요"
+                echo "⏱️[ROLLBACK] 이전 이미지 없음 — 수동 복구 필요"
               fi
             }
 
@@ -252,7 +252,9 @@ jobs:
               sudo docker logs core-${TARGET_COLOR} --tail=50
               # sudo docker stop core-${TARGET_COLOR} || true
               # sudo docker rm core-${TARGET_COLOR} || true
-            sudo docker compose -p "core-$TARGET_COLOR" down
+              echo "🛑 core-${TARGET_COLOR} 종료"
+              sudo docker compose -p "core-$TARGET_COLOR" down
+              rollback
               exit 1
             fi
 
@@ -260,7 +262,23 @@ jobs:
             echo "👉🏻[8] Switch Nginx Traffic"
             echo "set \$core_url http://127.0.0.1:${TARGET_PORT};" | \
               sudo tee /etc/nginx/bluegreen/service-url-core.inc
+
+            # 설정 파일 내용 확인
+            echo "📄 service-url-core.inc 내용:"
+            cat /etc/nginx/bluegreen/service-url-core.inc
+
+            # Nginx 문법 검사
+            echo "🔍 Nginx 설정 문법 검사..."
+            sudo nginx -t
+
+            # reload
             sudo nginx -s reload
+
+            echo "🔍 Nginx 전환 후 헬스체크 확인..."
+            sleep 2
+            code=$(curl -s -o /dev/null -w "%{http_code}" https://api.sofly.co.kr/actuator/health || echo "000")
+            echo "📡 https://api.sofly.co.kr/actuator/health → HTTP $code"
+
             echo "✅ Nginx → core-${TARGET_COLOR}:${TARGET_PORT} 전환 완료"
 
             # ── 9. 이전 컨테이너 종료 ────────────────────────

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -2,7 +2,7 @@ name: Deploy travel-core-service
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "chore/21-cicd-multistage-build" ]
     paths:
       - 'services/travel-core-service/**'
       - '.github/workflows/deploy-core.yml'
@@ -18,21 +18,6 @@ jobs:
     steps:
       - name: ✅ Checkout repository
         uses: actions/checkout@v4
-
-      - name: ☕ Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-          cache: 'gradle'
-
-      - name: 🔧 Grant Gradle permission
-        run: chmod +x services/travel-core-service/gradlew
-
-      - name: 🔄 Build without tests
-        run: |
-          cd services/travel-core-service
-          ./gradlew clean bootJar -x test --no-daemon
 
       - name: 🔧 Set image tag
         id: meta

--- a/.github/workflows/deploy-supply.yml
+++ b/.github/workflows/deploy-supply.yml
@@ -113,18 +113,18 @@ jobs:
 
             # ── 롤백 함수 ──────────────────────────────────────
             rollback() {
-              echo "[ROLLBACK] 배포 실패 — 롤백 시작"
+              echo "⏱️[ROLLBACK] 배포 실패 — 롤백 시작"
               trap - ERR
 
               # 변수가 설정되지 않은 초기 단계 실패면 롤백할 게 없음
               if [ -z "$TARGET_COLOR" ] || [ -z "$CURRENT_COLOR" ]; then
-                echo "[ROLLBACK] 초기 단계 실패 — 롤백 생략"
+                echo "⏱️[ROLLBACK] 초기 단계 실패 — 롤백 생략"
                 return 0
               fi
 
               # Nginx가 이미 전환됐을 수 있으므로 기존 포트로 되돌림
-              echo "[ROLLBACK] Nginx를 $CURRENT_COLOR($CURRENT_PORT)로 복구"
-              echo "set \$supply_url http://127.0.0.1:${CURRENT_PORT};" | \
+              echo "⏱️[ROLLBACK] Nginx를 $CURRENT_COLOR($CURRENT_PORT)로 복구"
+              echo "⏱️set \$supply_url http://127.0.0.1:${CURRENT_PORT};" | \
                 sudo tee /etc/nginx/bluegreen/service-url-supply.inc
               sudo nginx -s reload
 
@@ -134,21 +134,21 @@ jobs:
 
               # 기존 컨테이너(CURRENT)가 살아있으면 롤백 완료
               if sudo docker inspect supply-${CURRENT_COLOR} > /dev/null 2>&1; then
-                echo "[ROLLBACK] 완료 — supply-${CURRENT_COLOR}($CURRENT_PORT) 이미 서비스 중"
+                echo "⏱️[ROLLBACK] 완료 — supply-${CURRENT_COLOR}($CURRENT_PORT) 이미 서비스 중"
                 return 0
               fi
 
               # 기존 컨테이너가 없을 때만 이전 이미지로 재기동
               if [ -n "$PREV_IMAGE" ]; then
-                echo "[ROLLBACK] supply-${CURRENT_COLOR} 재기동 — $PREV_IMAGE"
+                echo "⏱️[ROLLBACK] supply-${CURRENT_COLOR} 재기동 — $PREV_IMAGE"
                 export SUPPLY_IMAGE=$PREV_IMAGE
                 export SUPPLY_PORT=$CURRENT_PORT
                 export SUPPLY_CONTAINER_NAME=supply-${CURRENT_COLOR}
                 cd "$DEPLOY_PATH"
                 sudo -E docker compose up -d supply
-                echo "[ROLLBACK] 완료"
+                echo "⏱️[ROLLBACK] 완료"
               else
-                echo "[ROLLBACK] 이전 이미지 없음 — 수동 복구 필요"
+                echo "⏱️[ROLLBACK] 이전 이미지 없음 — 수동 복구 필요"
               fi
             }
 
@@ -236,7 +236,9 @@ jobs:
               sudo docker logs supply-${TARGET_COLOR} --tail=50
               # sudo docker stop supply-${TARGET_COLOR} || true
               # sudo docker rm supply-${TARGET_COLOR} || true
-            sudo docker compose -p "supply-$TARGET_COLOR" down
+              echo "🛑 supply-${TARGET_COLOR} 종료"
+              sudo docker compose -p "supply-$TARGET_COLOR" down
+              rollback
               exit 1
             fi
 
@@ -244,7 +246,23 @@ jobs:
             echo "👉🏻[8] Switch Nginx Traffic"
             echo "set \$supply_url http://127.0.0.1:${TARGET_PORT};" | \
               sudo tee /etc/nginx/bluegreen/service-url-supply.inc
+
+            # 설정 파일 내용 확인
+            echo "📄 service-url-supply.inc 내용:"
+            cat /etc/nginx/bluegreen/service-url-supply.inc
+
+            # Nginx 문법 검사
+            echo "🔍 Nginx 설정 문법 검사..."
+            sudo nginx -t
+
+            # reload
             sudo nginx -s reload
+
+            echo "🔍 Nginx 전환 후 헬스체크 확인..."
+            sleep 2
+            code=$(curl -s -o /dev/null -w "%{http_code}" https://api.sofly.co.kr/actuator/health || echo "000")
+            echo "📡 https://api.sofly.co.kr/actuator/health → HTTP $code"
+
             echo "✅ Nginx → supply-${TARGET_COLOR}:${TARGET_PORT} 전환 완료"
 
             # ── 9. 이전 컨테이너 종료 ────────────────────────

--- a/.github/workflows/deploy-supply.yml
+++ b/.github/workflows/deploy-supply.yml
@@ -193,6 +193,13 @@ jobs:
             git checkout -B develop origin/develop
             git reset --hard origin/develop
 
+            # 동기화 확인
+            echo "📌 현재 브랜치: $(git branch --show-current)"
+            echo "📌 현재 커밋:   $(git rev-parse HEAD)"
+            echo "📌 커밋 메시지: $(git log -1 --pretty=format:'%s')"
+            echo "📌 커밋 시간:   $(git log -1 --pretty=format:'%ci')"
+            echo "📌 커밋 작성자: $(git log -1 --pretty=format:'%an')"
+
             # ── 4. .env 생성 ───────────────────────────────────
             echo "👉🏻[4] Create .env.supply"
             cat <<EOF > .env.supply

--- a/.github/workflows/deploy-supply.yml
+++ b/.github/workflows/deploy-supply.yml
@@ -19,21 +19,6 @@ jobs:
       - name: ✅ Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-          cache: 'gradle'
-
-      - name: 🔧 Grant Gradle permission
-        run: chmod +x services/travel-supply-service/gradlew
-
-      - name: 🔄 Build without tests
-        run: |
-          cd services/travel-supply-service
-          ./gradlew clean build -x test --no-daemon
-
       - name: 🔧 Set image tag
         id: meta
         run: echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
@@ -200,6 +185,13 @@ jobs:
             PREV_IMAGE=$(docker inspect supply-${CURRENT_COLOR} \
               --format='{{.Config.Image}}' 2>/dev/null || echo "")
             echo "📦 PREV_IMAGE: $PREV_IMAGE"
+
+            echo "👉🏻[3.5] Git pull latest code"
+            git reset --hard HEAD
+            git clean -fd
+            git fetch origin develop
+            git checkout -B develop origin/develop
+            git reset --hard origin/develop
 
             # ── 4. .env 생성 ───────────────────────────────────
             echo "👉🏻[4] Create .env.supply"

--- a/docs/cicd-build-pipeline.md
+++ b/docs/cicd-build-pipeline.md
@@ -192,8 +192,6 @@ rollback() {
   sudo docker stop core-${TARGET_COLOR}
   sudo docker rm core-${TARGET_COLOR}
 
-  # 3. 기존 컨테이너(CURRENT)가 살아있으면 종료
-  #    없으면 이전 이미지(PREV_IMAGE)로 재기동
 }
 ```
 

--- a/docs/cicd-build-pipeline.md
+++ b/docs/cicd-build-pipeline.md
@@ -1,0 +1,288 @@
+# CI/CD 빌드 파이프라인 문서
+
+## 개요
+
+GitHub Actions + Docker Hub + 멀티스테이지 Dockerfile을 활용한 빌드 및 배포 파이프라인입니다.
+빌드는 GitHub Actions 서버에서 처리하고, Lightsail 서버는 Docker Hub에서 이미지를 pull해서 실행만 해요.
+
+---
+
+## 전체 흐름
+
+```
+개발자 (develop 브랜치 push)
+  ↓
+GitHub Actions 서버 (ubuntu-latest)
+  ├── 코드 clone
+  ├── Docker 이미지 빌드 (멀티스테이지 Dockerfile)
+  │     ├── 1단계: JDK + gradlew bootJar → JAR 생성
+  │     └── 2단계: JAR만 복사 → 경량 실행 이미지
+  └── Docker Hub push
+        ↓
+  sm010422/sofly-core:{github.sha}
+        ↓
+Lightsail 서버 (SSH)
+  ├── docker pull
+  ├── 새 컨테이너 실행 (Blue/Green)
+  ├── 헬스체크
+  ├── Nginx 트래픽 전환
+  └── 이전 컨테이너 종료
+```
+
+---
+
+## 왜 멀티스테이지 Dockerfile을 쓰냐
+
+### 기존 방식 (비효율적)
+
+```
+GitHub Actions
+  ├── JDK 설치
+  ├── gradlew bootJar    ← 1번째 빌드
+  └── docker build       ← Dockerfile 안에서 또 gradlew 실행 (2번째 빌드)
+        └── docker push
+```
+
+JAR 빌드가 두 번 일어나서 시간 낭비예요.
+
+### 현재 방식 (멀티스테이지)
+
+```
+GitHub Actions
+  └── docker build       ← Dockerfile 안에서 빌드 한 번만
+        └── docker push
+```
+
+GitHub Actions에서 JDK 설치, gradlew 빌드 step이 전부 필요 없어요.
+
+---
+
+## Dockerfile 설명
+
+```dockerfile
+# ── 1단계: 빌드 ──────────────────────────────────────
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+
+# 의존성 파일 먼저 복사 (캐시 레이어 분리)
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+RUN chmod +x ./gradlew && \
+    ./gradlew dependencies --no-daemon   # 의존성만 먼저 캐시
+
+# 소스 복사 후 빌드 (src 바뀔 때만 여기서부터 재실행)
+COPY src src
+RUN ./gradlew clean bootJar -x test --no-daemon
+
+# ── 2단계: 실행 ──────────────────────────────────────
+FROM eclipse-temurin:21-jre-alpine      # JDK 아닌 JRE만 (경량)
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-Dspring.config.name=application-core", "-jar", "app.jar"]
+```
+
+### 캐시 레이어 동작 방식
+
+```
+첫 번째 빌드
+  → 의존성 다운로드 (시간 걸림)
+  → JAR 빌드
+
+두 번째 빌드 (src만 변경)
+  → 의존성 캐시 재사용 ✅
+  → JAR 빌드만 재실행 (빠름)
+
+두 번째 빌드 (build.gradle 변경)
+  → 의존성부터 다시 다운로드
+  → JAR 빌드
+```
+
+`build.gradle`이나 `gradle` 폴더가 바뀌지 않으면 의존성 레이어는 캐시를 써서
+빌드 시간이 크게 단축돼요.
+
+---
+
+## GitHub Actions 워크플로우 설명
+
+### 트리거 조건
+
+```yaml
+on:
+  push:
+    branches: [ "develop" ]
+    paths:
+      - 'services/travel-core-service/**'   # core 코드 변경
+      - '.github/workflows/deploy-core.yml' # 배포 스크립트 변경
+      - 'docker-compose.yml'                # docker 설정 변경
+```
+
+세 경로 중 하나라도 변경되면 실행돼요.
+
+---
+
+### build-and-push job
+
+```yaml
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest   # GitHub 클라우드 서버에서 실행
+```
+
+**Step별 설명**
+
+| Step | 설명 |
+|------|------|
+| `Checkout` | GitHub Actions 서버에 리포 코드 clone |
+| `Set image tag` | `github.sha`(커밋 해시)를 output으로 저장 |
+| `Login to Docker Hub` | Docker Hub 인증 |
+| `Build & Push` | Dockerfile 실행 → 이미지 빌드 → Docker Hub push |
+| `PR 코멘트` | PR일 때 빌드 성공/실패 코멘트 자동 작성 |
+
+**이미지 태그 규칙**
+
+```
+{DOCKERHUB_USERNAME}/sofly-core:{github.sha}
+
+예시:
+sm010422/sofly-core:abc1234def5678...
+```
+
+커밋마다 고유한 이미지가 만들어져요. 특정 버전으로 롤백할 때 유용해요.
+
+---
+
+### deploy job
+
+```yaml
+deploy:
+  needs: build-and-push   # build-and-push 성공 후 실행
+```
+
+**Step별 설명**
+
+| 단계 | 설명 |
+|------|------|
+| 1 | 배포 경로 이동 |
+| 2 | 현재 nginx 포트 확인 → Blue/Green 타겟 결정 |
+| 3 | 이전 이미지 태그 저장 (롤백용) |
+| 4 | `.env.core` 파일 생성 |
+| 5 | Docker Hub에서 새 이미지 pull |
+| 6 | 새 컨테이너 실행 (green) |
+| 7 | 헬스체크 (`/actuator/health` → 200 확인) |
+| 8 | Nginx 트래픽 전환 (`nginx -s reload`) |
+| 9 | 이전 컨테이너(blue) 종료 |
+| 10 | 미사용 이미지 정리 |
+
+---
+
+## 롤백 전략
+
+헬스체크 실패 시 자동으로 롤백이 실행돼요.
+
+```bash
+rollback() {
+  # 1. Nginx를 이전 포트(CURRENT)로 복구
+  echo "set $core_url http://127.0.0.1:${CURRENT_PORT};" | \
+    sudo tee /etc/nginx/bluegreen/service-url-core.inc
+  sudo nginx -s reload
+
+  # 2. 실패한 새 컨테이너(TARGET) 정리
+  sudo docker stop core-${TARGET_COLOR}
+  sudo docker rm core-${TARGET_COLOR}
+
+  # 3. 기존 컨테이너(CURRENT)가 살아있으면 종료
+  #    없으면 이전 이미지(PREV_IMAGE)로 재기동
+}
+```
+
+### 롤백 시나리오
+
+```
+정상 배포
+  blue(8080) 서비스 중
+  green(8081) 새 컨테이너 실행
+  헬스체크 통과
+  Nginx → green으로 전환
+  blue 종료
+
+롤백 발생
+  blue(8080) 서비스 중
+  green(8081) 새 컨테이너 실행
+  헬스체크 실패
+  Nginx → blue(8080)로 복구
+  green 컨테이너 정리
+  서비스 중단 없음
+```
+
+---
+
+## 필요한 GitHub Secrets
+
+### build-and-push job
+
+| Secret | 설명 |
+|--------|------|
+| `DOCKERHUB_USERNAME` | Docker Hub 아이디 |
+| `DOCKERHUB_TOKEN` | Docker Hub Access Token |
+
+### deploy job
+
+| Secret | 설명 |
+|--------|------|
+| `LIGHTSAIL_HOST` | 서버 IP |
+| `LIGHTSAIL_USER` | SSH 유저 |
+| `LIGHTSAIL_SSH_KEY` | SSH 개인키 |
+| `DEPLOY_PATH` | 서버 배포 경로 |
+| `CORE_DATASOURCE_URL` | PostgreSQL URL |
+| `CORE_DATASOURCE_USERNAME` | DB 유저 |
+| `CORE_DATASOURCE_PASSWORD` | DB 비밀번호 |
+| `REDIS_HOST` | Redis 호스트 |
+| `REDIS_PORT` | Redis 포트 |
+| `JWT_SECRET_KEY` | JWT 서명 키 |
+| `GOOGLE_CLIENT_ID` | Google OAuth2 |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth2 |
+| `KAKAO_CLIENT_ID` | Kakao OAuth2 |
+| `KAKAO_CLIENT_SECRET` | Kakao OAuth2 |
+| `NAVER_CLIENT_ID` | Naver OAuth2 |
+| `NAVER_CLIENT_SECRET` | Naver OAuth2 |
+| `OAUTH2_REDIRECT_URI` | 로그인 성공 redirect URI |
+| `SUPPLY_SERVICE_URL` | supply 서비스 URL |
+| `GEMINI_API_KEY` | Gemini API 키 |
+
+---
+
+## Docker Hub Access Token 발급
+
+```
+Docker Hub 로그인 (hub.docker.com)
+  → 우측 상단 프로필
+  → Account Settings
+  → Security
+  → New Access Token
+  → 이름: sofly-github-actions
+  → Access permissions: Read & Write
+  → Generate
+  → 발급된 토큰 복사 (창 닫으면 다시 못 봄)
+```
+
+GitHub Secrets에 등록:
+
+```
+DOCKERHUB_USERNAME = sm010422
+DOCKERHUB_TOKEN    = 발급된 토큰
+```
+
+---
+
+## 이전 방식 vs 현재 방식
+
+| 항목 | 이전 | 현재 |
+|------|------|------|
+| 빌드 방식 | GitHub Actions gradlew + Docker 패키징 | 멀티스테이지 Dockerfile |
+| 빌드 횟수 | 2번 (중복) | 1번 |
+| JDK 설치 | GitHub Actions에 필요 | 불필요 |
+| 빌드 속도 | 느림 | 빠름 |
+| Dockerfile 복잡도 | 단순 | 약간 복잡 |
+| Lightsail 서버 부하 | 없음 | 없음 |

--- a/services/travel-core-service/Dockerfile
+++ b/services/travel-core-service/Dockerfile
@@ -4,8 +4,7 @@ COPY gradlew .
 COPY gradle gradle
 COPY build.gradle .
 COPY settings.gradle .
-RUN chmod +x ./gradlew
-RUN ./gradlew dependencies --no-daemon 
+RUN chmod +x ./gradlew && ./gradlew dependencies --no-daemon
 
 COPY src src
 RUN ./gradlew clean bootJar -x test --no-daemon

--- a/services/travel-core-service/Dockerfile
+++ b/services/travel-core-service/Dockerfile
@@ -4,8 +4,10 @@ COPY gradlew .
 COPY gradle gradle
 COPY build.gradle .
 COPY settings.gradle .
-COPY src src
 RUN chmod +x ./gradlew
+RUN ./gradlew dependencies --no-daemon 
+
+COPY src src
 RUN ./gradlew clean bootJar -x test --no-daemon
 
 FROM eclipse-temurin:21-jre-alpine

--- a/services/travel-supply-service/Dockerfile
+++ b/services/travel-supply-service/Dockerfile
@@ -4,8 +4,7 @@ COPY gradlew .
 COPY gradle gradle
 COPY build.gradle .
 COPY settings.gradle .
-RUN chmod +x ./gradlew
-RUN ./gradlew dependencies --no-daemon 
+RUN chmod +x ./gradlew && ./gradlew dependencies --no-daemon
 
 COPY src src
 RUN ./gradlew clean bootJar -x test --no-daemon

--- a/services/travel-supply-service/Dockerfile
+++ b/services/travel-supply-service/Dockerfile
@@ -4,8 +4,10 @@ COPY gradlew .
 COPY gradle gradle
 COPY build.gradle .
 COPY settings.gradle .
-COPY src src
 RUN chmod +x ./gradlew
+RUN ./gradlew dependencies --no-daemon 
+
+COPY src src
 RUN ./gradlew clean bootJar -x test --no-daemon
 
 FROM eclipse-temurin:21-jre-alpine


### PR DESCRIPTION
## 📌 PR 요약
CI/CD 파이프라인에서 Gradle 빌드 중복 실행 문제를 해결했습니다.
기존에 GitHub Actions에서 JDK 설치 + Gradle 빌드 후 Docker 이미지 빌드 시 Dockerfile 내부에서 Gradle 빌드가 한 번 더 실행되는 비효율을 제거하고, 멀티스테이지 Dockerfile로 빌드 책임을 일원화했습니다.

## 🔧 변경 사항
- **GitHub Actions step 3개 제거** — `Set up JDK 21`, `Grant Gradle permission`, `Build without tests` 제거. Dockerfile 멀티스테이지 빌드가 이미 동일한 역할을 하고 있어 중복이었음
- **빌드 단일화** — `Build & Push Docker image` step 하나로 빌드 + push 통합. GitHub Actions 서버에서 불필요한 JDK 설치 및 Gradle 실행이 사라짐
- **Gradle 의존성 레이어 캐시 최적화** — `src` 복사 전에 의존성 파일만 먼저 복사하여 Docker 레이어 캐시 활용. `src` 코드만 변경되면 의존성 다운로드 없이 빌드 가능
- **deploy 스크립트 개선** — git 최신 코드 동기화 확인 echo 추가, Nginx 전환 후 헬스체크 확인 및 문법 검사(`nginx -t`) 추가

## 📋 작업 상세 내용
- [x] `deploy-core.yml` — `Set up JDK 21`, `Grant Gradle permission`, `Build without tests` step 제거
- [x] `deploy-supply.yml` — 동일하게 3개 step 제거
- [x] `Dockerfile` (core) — 의존성 레이어 분리 (`./gradlew dependencies` 선행 실행)
- [x] `Dockerfile` (supply) — 동일하게 의존성 레이어 분리
- [x] deploy 스크립트 — git 동기화 후 현재 커밋 정보 echo 추가
- [x] deploy 스크립트 — Nginx 전환 전 `nginx -t` 문법 검사 추가
- [x] deploy 스크립트 — Nginx 전환 후 실제 도메인 헬스체크 확인 추가
- [x] 변경 후 파이프라인 정상 동작 검증

## 🔗 관련 이슈
closed #21

## 📝 기타
- `cache: 'gradle'` (GitHub Actions Gradle 캐시)는 Docker 레이어 캐시로 대체됩니다. `build.gradle`과 `gradle` 폴더가 변경되지 않으면 의존성 레이어가 캐시되어 빌드 시간이 단축됩니다.
- BuildKit 캐시 마운트(`--mount=type=cache,target=/root/.gradle`) 적용은 추후 검토 예정입니다.