### PR TITLE
Feat/22 security access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ out/
 .env.core
 .env.supply
 /services/travel-supply-service/.env
+
+### postman ###
+.postman
+/postman/

--- a/services/travel-core-service/docs/auth-architecture.md
+++ b/services/travel-core-service/docs/auth-architecture.md
@@ -1,0 +1,333 @@
+# 인증/보안 아키텍처 문서
+
+> `global/auth` 및 `global/security` 패키지에 속한 파일들의 역할과 흐름을 정리한 문서입니다.
+
+---
+
+## 전체 흐름 요약
+
+```
+[소셜 로그인 (Google/Kakao/Naver)]
+        ↓
+CustomOAuth2UserService       ← OAuth2 사용자 정보 수신 및 DB 저장/갱신
+        ↓
+OAuth2AuthenticationSuccessHandler  ← JWT 발급 + Redis에 Refresh Token 저장
+        ↓
+클라이언트 (프론트엔드로 토큰과 함께 리다이렉트)
+
+[이후 API 요청]
+        ↓
+JwtAuthenticationFilter       ← Bearer 토큰 검증 → SecurityContext 설정
+        ↓
+컨트롤러 (인증된 사용자로 요청 처리)
+
+[토큰 만료 시]
+        ↓
+POST /api/auth/refresh         ← Refresh Token으로 Access Token 재발급
+        ↓
+AuthService                    ← Redis에서 Refresh Token 검증 + 토큰 로테이션
+```
+
+---
+
+## `global/auth` 패키지
+
+인증 관련 HTTP 엔드포인트, 비즈니스 로직, DTO, 예외 코드를 담당합니다.
+
+---
+
+### `AuthController.java`
+
+**역할:** 토큰 재발급 및 로그아웃 HTTP 엔드포인트 제공
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| `POST` | `/api/auth/refresh` | Refresh Token으로 새 Access/Refresh Token 발급 |
+| `POST` | `/api/auth/logout` | Redis에서 Refresh Token 삭제 (로그아웃 처리) |
+
+---
+
+### `AuthService.java`
+
+**역할:** 토큰 재발급(Token Rotation) 및 로그아웃 비즈니스 로직
+
+- **토큰 재발급 흐름:**
+  1. 클라이언트가 보낸 Refresh Token을 `JwtTokenProvider`로 검증
+  2. Redis에서 해당 userId의 Refresh Token과 일치 여부 확인
+  3. 새 Access Token + Refresh Token 발급 (Token Rotation — 보안 강화)
+  4. Redis의 Refresh Token을 새 토큰으로 교체
+- **로그아웃:** Redis에서 해당 userId의 Refresh Token 삭제
+
+---
+
+### `RefreshTokenRequest.java`
+
+**역할:** `/api/auth/refresh` 요청 DTO
+
+```java
+record RefreshTokenRequest(
+    @NotBlank String refreshToken
+)
+```
+
+---
+
+### `TokenResponse.java`
+
+**역할:** 토큰 재발급 응답 DTO
+
+```java
+record TokenResponse(
+    String accessToken,
+    String refreshToken
+)
+```
+
+팩토리 메서드 `TokenResponse.of(accessToken, refreshToken)`으로 생성합니다.
+
+---
+
+### `AuthErrorCode.java`
+
+**역할:** 인증 관련 에러 코드 정의 (enum)
+
+| 코드 | 설명 |
+|------|------|
+| `INCORRECT_PASSWORD` | 비밀번호 불일치 |
+| `TOKEN_EXPIRED` | 액세스 토큰 만료 |
+| `INVALID_TOKEN` | 유효하지 않은 토큰 |
+| `INVALID_REFRESH_TOKEN` | 유효하지 않은 Refresh Token |
+| `REFRESH_TOKEN_EXPIRED` | Refresh Token 만료 |
+| `DUPLICATE_LOGIN_ID` | 중복된 로그인 ID |
+| `EMPTY_AUTHENTICATION` | 인증 정보 없음 |
+| `MEMBER_NOT_FOUND` | 사용자 없음 |
+
+---
+
+### `AuthSuccessCode.java`
+
+**역할:** 인증 관련 성공 코드 정의 (enum)
+
+| 코드 | 설명 |
+|------|------|
+| `LOGIN_SUCCESS` | 로그인 성공 |
+| `SIGNUP_SUCCESS` | 회원가입 성공 |
+| `LOGOUT_SUCCESS` | 로그아웃 성공 |
+| `REISSUE_SUCCESS` | 토큰 재발급 성공 |
+
+---
+
+### `AuthException.java`
+
+**역할:** 인증 도메인 전용 커스텀 예외
+
+`GeneralException`을 상속하며, `AuthErrorCode`를 받아 예외를 생성합니다.
+
+---
+
+### `CustomUserDetailsService.java`
+
+**역할:** (현재 미사용) UserDetailsService 레거시 구현체 자리
+
+현재 모든 코드가 주석 처리되어 있으며, 소셜 로그인 기반 OAuth2 방식을 사용하므로 실제로는 동작하지 않습니다.
+
+---
+
+## `global/security` 패키지
+
+JWT 처리, OAuth2 소셜 로그인 연동, Spring Security 설정을 담당합니다.
+
+---
+
+### `SecurityConfig.java`
+
+**역할:** Spring Security 전체 보안 정책 설정
+
+핵심 설정 내용:
+- **세션 비활성화:** `STATELESS` 정책으로 JWT 기반 무상태 인증
+- **OAuth2 로그인:** `/oauth2/authorization/**` 진입점, 성공/실패 핸들러 연결
+- **JWT 필터 등록:** `JwtAuthenticationFilter`를 `UsernamePasswordAuthenticationFilter` 앞에 위치
+- **공개 엔드포인트:** `/api/auth/**`, `/oauth2/**`, Swagger(`/core-docs/**`), 헬스체크는 인증 없이 허용
+- **그 외 모든 요청:** 인증 필요 (미인증 시 401 반환)
+
+---
+
+### `JwtAuthenticationFilter.java`
+
+**역할:** 모든 HTTP 요청에서 JWT를 검증하고 SecurityContext를 설정하는 필터
+
+**처리 흐름:**
+1. `Authorization: Bearer <token>` 헤더에서 토큰 추출
+2. `JwtTokenProvider`로 토큰 유효성 검증
+3. 유효하면 userId와 `ROLE_USER` 권한으로 `UsernamePasswordAuthenticationToken` 생성
+4. `SecurityContextHolder`에 인증 정보 저장
+
+공개 경로(auth, oauth2, swagger)는 필터 자체를 통과시킵니다.
+
+---
+
+### `JwtTokenProvider.java`
+
+**역할:** JWT 생성, 검증, 파싱의 핵심 컴포넌트
+
+- **`generateAccessToken(userId)`** — 짧은 만료 시간의 Access Token 발급
+- **`generateRefreshToken(userId)`** — 긴 만료 시간의 Refresh Token 발급
+- **`validateToken(token)`** — 서명 및 만료 여부 검증 (boolean 반환)
+- **`getUserId(token)`** — 토큰 클레임에서 userId 추출
+- **서명 알고리즘:** HMAC-SHA (secret key 기반)
+
+---
+
+### `JwtProperties.java`
+
+**역할:** JWT 관련 설정값을 `application-core.yaml`에서 바인딩하는 Properties 클래스
+
+```yaml
+# application-core.yaml 예시
+jwt:
+  secret-key: "..."
+  access-token-expiration: 3600000    # 1시간 (ms)
+  refresh-token-expiration: 604800000 # 7일 (ms)
+```
+
+`@ConfigurationProperties`로 타입 안전하게 주입됩니다.
+
+---
+
+### OAuth2 소셜 로그인 관련 파일들
+
+#### `CustomOAuth2UserService.java`
+
+**역할:** 소셜 로그인 성공 후 OAuth2 사용자 정보를 받아 처리하는 서비스
+
+**처리 흐름:**
+1. Spring OAuth2 Client가 소셜 플랫폼으로부터 사용자 정보 수신
+2. provider(google/kakao/naver)에 따라 적절한 `OAuth2UserInfo` 구현체로 파싱
+3. DB에서 해당 이메일의 User 조회
+   - 없으면 신규 생성
+   - 있으면 닉네임/프로필 이미지 갱신
+4. `CustomOAuth2User` 객체 반환 (이후 핸들러에서 사용)
+
+---
+
+#### `CustomOAuth2User.java`
+
+**역할:** Spring Security의 `OAuth2User` 인터페이스 구현체
+
+`User` 엔티티를 감싸서 OAuth2 인증 객체로 변환합니다. `getUserId()` 메서드로 내부 userId에 접근할 수 있습니다.
+
+---
+
+#### `OAuth2UserInfo.java` (인터페이스)
+
+**역할:** 소셜 플랫폼별 사용자 정보 추출의 공통 계약 정의
+
+```java
+interface OAuth2UserInfo {
+    String getProviderId();       // 플랫폼 고유 ID
+    String getEmail();
+    String getNickname();
+    String getProfileImageUrl();
+}
+```
+
+---
+
+#### `GoogleUserInfo.java` / `KakaoUserInfo.java` / `NaverUserInfo.java`
+
+**역할:** 각 소셜 플랫폼의 응답 구조에 맞게 `OAuth2UserInfo`를 구현하는 클래스들
+
+| 파일 | 특이사항 |
+|------|---------|
+| `GoogleUserInfo` | `sub` 필드를 providerId로 사용, 플랫 구조 |
+| `KakaoUserInfo` | `kakao_account.profile` 중첩 구조에서 데이터 추출 |
+| `NaverUserInfo` | `response` 중첩 객체에서 데이터 추출 |
+
+---
+
+#### `OAuth2AuthenticationSuccessHandler.java`
+
+**역할:** OAuth2 로그인 성공 시 JWT 발급 및 프론트엔드 리다이렉트
+
+**처리 흐름:**
+1. `CustomOAuth2User`에서 userId 추출
+2. Access Token + Refresh Token 발급 (`JwtTokenProvider`)
+3. Refresh Token을 Redis에 TTL과 함께 저장 (`RefreshTokenRepository`)
+4. 프론트엔드 URL로 토큰을 쿼리 파라미터로 붙여 리다이렉트
+
+```
+FRONTEND_REDIRECT_URL?accessToken=xxx&refreshToken=yyy
+```
+
+---
+
+#### `OAuth2AuthenticationFailureHandler.java`
+
+**역할:** OAuth2 로그인 실패 시 에러와 함께 프론트엔드로 리다이렉트
+
+```
+FRONTEND_REDIRECT_URL?error=<에러메시지>
+```
+
+---
+
+### Redis 토큰 저장소
+
+#### `RefreshToken.java`
+
+**역할:** Redis에 저장되는 Refresh Token 엔티티
+
+```java
+@RedisHash("refresh_token")
+class RefreshToken {
+    @Id String userId;   // userId를 키로 사용
+    String token;
+    @TimeToLive long ttl; // 자동 만료
+}
+```
+
+---
+
+#### `RefreshTokenRepository.java`
+
+**역할:** `RefreshToken` Redis CRUD 인터페이스
+
+`CrudRepository<RefreshToken, String>`을 상속하여 `save`, `findById`, `deleteById` 등을 제공합니다.
+
+---
+
+### 유틸리티
+
+#### `FilterResponseUtils.java`
+
+**역할:** 필터 레이어에서 JSON 형태의 에러 응답을 직접 내려주는 유틸리티
+
+일반적으로 Spring MVC의 `@ExceptionHandler`는 필터 단계에서는 동작하지 않습니다.
+`JwtAuthenticationFilter`에서 인증 실패 시 이 유틸리티로 직접 `HttpServletResponse`에 JSON을 작성합니다.
+
+---
+
+#### `SwaggerConfig.java`
+
+**역할:** Swagger(OpenAPI) 설정 + JWT Bearer 인증 스킴 추가
+
+Swagger UI(`http://localhost:8080/core-docs`)에서 `Authorize` 버튼으로 JWT 토큰을 입력하면 인증이 필요한 API를 직접 테스트할 수 있습니다.
+
+---
+
+## 파일 의존 관계 요약
+
+```
+SecurityConfig
+  ├── JwtAuthenticationFilter → JwtTokenProvider → JwtProperties
+  ├── CustomOAuth2UserService → OAuth2UserInfo 구현체들 (Google/Kakao/Naver)
+  │                          → CustomOAuth2User
+  ├── OAuth2AuthenticationSuccessHandler → JwtTokenProvider
+  │                                      → RefreshTokenRepository → RefreshToken
+  └── OAuth2AuthenticationFailureHandler
+
+AuthController → AuthService → JwtTokenProvider
+                              → RefreshTokenRepository
+
+FilterResponseUtils (JwtAuthenticationFilter에서 사용)
+```

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
@@ -1,0 +1,24 @@
+package com.sofly.core.domain.user.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+
+    LOGIN_ID_REQUIRED(HttpStatus.BAD_REQUEST,"LOGIN_ID_REQUIRED","로그인 ID는 필수 입력값입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 사용자를 찾지 못했습니다."),
+    LOGIN_ID_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ID_ALREADY_EXIST","이미 존재하는 ID입니다"),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST,"INVALID_REQUEST","요청이 유효하지 않습니다")
+    ;
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserSuccessCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserSuccessCode.java
@@ -1,0 +1,20 @@
+package com.sofly.core.domain.user.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofly.core.global.response.code.BaseSuccessCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserSuccessCode implements BaseSuccessCode {
+
+    FOUND(HttpStatus.OK, "MEMBER_FOUND", "성공적으로 사용자를 조회했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/AuthException.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.sofly.core.global.auth.exception;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+import com.sofly.core.global.response.exception.GeneralException;
+
+public class AuthException extends GeneralException {
+    public AuthException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthErrorCode.java
@@ -1,0 +1,30 @@
+package com.sofly.core.global.auth.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED,"INCORRECT_PASSWORD", "비밀번호가 틀렸습니다"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_EXPIRED", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"INVALID_REFRESH_TOKEN","유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED,"REFRESH_TOKEN_EXPIRED","리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요.")
+    ,
+    // 회원가입 시 중복된 아이디가 있을 경우
+    DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "DUPLICATE_LOGIN_ID", "이미 존재하는 아이디입니다."),
+    EMPTY_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "EMPTY_AUTHENTICATION", "인증 정보가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 사용자를 찾지 못했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthErrorCode.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseErrorCode {
 
-
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED,"INCORRECT_PASSWORD", "비밀번호가 틀렸습니다"),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN_EXPIRED", "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
@@ -21,8 +20,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     // 회원가입 시 중복된 아이디가 있을 경우
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "DUPLICATE_LOGIN_ID", "이미 존재하는 아이디입니다."),
     EMPTY_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "EMPTY_AUTHENTICATION", "인증 정보가 존재하지 않습니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 사용자를 찾지 못했습니다.")
-    ;
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 사용자를 찾지 못했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthSuccessCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthSuccessCode.java
@@ -1,0 +1,22 @@
+
+package com.sofly.core.global.auth.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofly.core.global.response.code.BaseSuccessCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthSuccessCode implements BaseSuccessCode {
+    LOGIN_SUCCESS(HttpStatus.OK, "LOGIN_SUCCESS", "로그인에 성공하였습니다."),
+    SIGNUP_SUCCESS(HttpStatus.CREATED, "SIGNUP_SUCCESS", "회원가입이 완료되었습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK,"LOGOUT_SUCCESS","로그아웃에 성공하였습니다."),
+    REISSUE_SUCCESS(HttpStatus.CREATED, "REISSUE_SUCCESS", "재발급에 성공하였습니다.")
+;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
@@ -51,7 +51,7 @@ public class AuthService {
                 RefreshToken.builder()
                         .id(String.valueOf(userId))
                         .refreshToken(newRefreshToken)
-                        .expiration(jwtProperties.expiration().refresh() / 1000)
+                        .expiration(jwtProperties.expiration().refresh().getSeconds())
                         .build()
         );
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/ApiResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/ApiResponse.java
@@ -1,18 +1,40 @@
 package com.sofly.core.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.sofly.core.global.response.code.BaseErrorCode;
+import com.sofly.core.global.response.code.BaseSuccessCode;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"success", "code", "message", "data"})
 public record ApiResponse<T>(
         boolean success,
+        String code,
         String message,
         T data
 ) {
+    // 성공 1: 데이터만
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, null, data);
+        return new ApiResponse<>(true, null, null, data);
     }
 
+    // 성공 2: enum 코드 + 데이터
+    public static <T> ApiResponse<T> success(BaseSuccessCode code, T data) {
+        return new ApiResponse<>(true, null, code.getMessage(), data);
+    }
+
+    // 실패 1: 메시지만 (빠른 사용용)
     public static <T> ApiResponse<T> fail(String message) {
-        return new ApiResponse<>(false, message, null);
+        return new ApiResponse<>(false, null, message, null);
+    }
+
+    // 실패 2: ErrorStatus enum 사용 (권장)
+    public static <T> ApiResponse<T> fail(BaseErrorCode code) {
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), null);
+    }
+
+    // 실패 3: ErrorStatus enum + 커스텀 메시지
+    public static <T> ApiResponse<T> fail(BaseErrorCode code, String customMessage) {
+        return new ApiResponse<>(false, code.getCode(), customMessage, null);
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/BaseErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package com.sofly.core.global.response.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/BaseSuccessCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/BaseSuccessCode.java
@@ -1,0 +1,9 @@
+package com.sofly.core.global.response.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/ErrorStatus.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/ErrorStatus.java
@@ -12,13 +12,8 @@ public enum ErrorStatus implements BaseErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_001", "서버 오류가 발생했습니다."),
 
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_002", "잘못된 요청입니다."),
-
     // 인증
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
-
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 토큰입니다."),
-    
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_003", "만료된 토큰입니다."),
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_004", "Refresh Token을 찾을 수 없습니다."),
 
@@ -26,9 +21,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 400 Bad Request: 클라이언트의 요청이 잘못됨
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
-
-    // 401 Unauthorized: 인증이 필요한 서비스에서 인증이 안 됨
-    // UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
 
     // 403 Forbidden: 인증은 됐으나 해당 리소스에 권한이 없음
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "제한된 접근입니다."),
@@ -38,9 +30,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 409 Conflict: 서버의 현재 상태와 요청이 충돌함
     CONFLICT(HttpStatus.CONFLICT, "COMMON409", "데이터 충돌이 발생했습니다.");
-
-    // 500 Internal Server Error: 서버 내부 에러
-    // INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "예기치 않은 서버 에러가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/ErrorStatus.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/ErrorStatus.java
@@ -1,0 +1,48 @@
+package com.sofly.core.global.response.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 공통
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_001", "서버 오류가 발생했습니다."),
+
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_002", "잘못된 요청입니다."),
+
+    // 인증
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 토큰입니다."),
+    
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_003", "만료된 토큰입니다."),
+
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_004", "Refresh Token을 찾을 수 없습니다."),
+
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_005", "Refresh Token이 만료되었습니다."),
+
+    // 400 Bad Request: 클라이언트의 요청이 잘못됨
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+
+    // 401 Unauthorized: 인증이 필요한 서비스에서 인증이 안 됨
+    // UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+
+    // 403 Forbidden: 인증은 됐으나 해당 리소스에 권한이 없음
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "제한된 접근입니다."),
+
+    // 404 Not Found: 요청한 리소스를 찾을 수 없음
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "해당 리소스를 찾을 수 없습니다."),
+
+    // 409 Conflict: 서버의 현재 상태와 요청이 충돌함
+    CONFLICT(HttpStatus.CONFLICT, "COMMON409", "데이터 충돌이 발생했습니다.");
+
+    // 500 Internal Server Error: 서버 내부 에러
+    // INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "예기치 않은 서버 에러가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/SuccessStatus.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/code/SuccessStatus.java
@@ -1,0 +1,24 @@
+package com.sofly.core.global.response.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessStatus implements BaseSuccessCode {
+
+    // 200 OK: 요청이 성공적으로 처리됨 (기본)
+    _OK(HttpStatus.OK, "COMMON200", "요청에 성공했습니다."),
+
+    // 201 Created: 새 리소스가 성공적으로 생성됨
+    _CREATED(HttpStatus.CREATED, "COMMON201", "리소스가 성공적으로 생성되었습니다."),
+
+    // 204 No Content
+    _NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON204", "성공적으로 처리되었으나 본문이 비어있습니다.");
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/response/exception/GeneralException.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/response/exception/GeneralException.java
@@ -1,0 +1,20 @@
+package com.sofly.core.global.response.exception;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+    private final BaseErrorCode code;
+    private final String customMessage;
+
+
+    // 기본 메시지 사용 case를 위한 생성자 정의
+    public GeneralException(BaseErrorCode code) {
+        this.code = code;
+        this.customMessage = code.getMessage();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                         "/index.html",
                         "/login/oauth2/**",
                         "/oauth2/**",
-                        "/api/auth/**",
+                        "/api/auth/refresh",
                         "/actuator/health",
                         "/swagger-ui/**",
                         "/core-docs",

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                 )
                 // JWT 필터 등록
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        new JwtAuthenticationFilter(jwtTokenProvider, filterResponseUtils),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 // 토큰 없이 authenticated() 경로 접근 시 401

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -36,33 +36,19 @@ public class SecurityConfig {
         http
             // 요청 권한 설정
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers(
-                            "/",
-                            "/index.html",
-                            "/login/oauth2/**",
-                            "/oauth2/**",
-                            "/api/auth/**",
-                            "/actuator/health",
-                            "/swagger-ui/**",
-                            "/core-docs",
-                            "/v3/api-docs/**"     
-                    ).permitAll()
-                    .anyRequest().authenticated()
-            );
-        return http.build();
-
-    }
-
-    private void configureCommonSecurity(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                // .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .requestMatchers(
+                        "/",
+                        "/index.html",
+                        "/login/oauth2/**",
+                        "/oauth2/**",
+                        "/api/auth/**",
+                        "/actuator/health",
+                        "/swagger-ui/**",
+                        "/core-docs",
+                        "/v3/api-docs/**"     
+                ).permitAll()
+                .anyRequest().authenticated()
                 )
-
                 // OAuth2 로그인 설정
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo ->
@@ -81,6 +67,21 @@ public class SecurityConfig {
                         filterResponseUtils.sendUnauthorized(response,AuthErrorCode.EMPTY_AUTHENTICATION);
                     })
                 );
+
+        return http.build();
+
+    }
+
+    private void configureCommonSecurity(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                // .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+
         
     }
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -1,11 +1,5 @@
 package com.sofly.core.global.security;
 
-import com.sofly.core.global.security.jwt.JwtAuthenticationFilter;
-import com.sofly.core.global.security.jwt.JwtTokenProvider;
-import com.sofly.core.global.security.oauth2.CustomOAuth2UserService;
-import com.sofly.core.global.security.oauth2.OAuth2AuthenticationFailureHandler;
-import com.sofly.core.global.security.oauth2.OAuth2AuthenticationSuccessHandler;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,6 +8,16 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.sofly.core.global.auth.exception.code.AuthErrorCode;
+import com.sofly.core.global.security.jwt.JwtAuthenticationFilter;
+import com.sofly.core.global.security.jwt.JwtTokenProvider;
+import com.sofly.core.global.security.oauth2.CustomOAuth2UserService;
+import com.sofly.core.global.security.oauth2.OAuth2AuthenticationFailureHandler;
+import com.sofly.core.global.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import com.sofly.core.global.security.util.FilterResponseUtils;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -24,20 +28,12 @@ public class SecurityConfig {
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
     private final JwtTokenProvider jwtTokenProvider;
+    private final FilterResponseUtils filterResponseUtils;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        configureCommonSecurity(http);
         http
-            // CSRF 비활성화 (JWT 사용)
-            .csrf(AbstractHttpConfigurer::disable)
-
-            // 폼 로그인 비활성화 (소셜 로그인만 사용)
-            .formLogin(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable)
-            // 세션 비활성화 (JWT Stateless)
-            .sessionManagement(session ->
-                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
             // 요청 권한 설정
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers(
@@ -52,23 +48,39 @@ public class SecurityConfig {
                             "/v3/api-docs/**"     
                     ).permitAll()
                     .anyRequest().authenticated()
-            )
-
-            // OAuth2 로그인 설정
-            .oauth2Login(oauth2 -> oauth2
-                    .userInfoEndpoint(userInfo ->
-                            userInfo.userService(customOAuth2UserService))
-                    .successHandler(oAuth2AuthenticationSuccessHandler)
-                    .failureHandler(oAuth2AuthenticationFailureHandler)
-            )
-
-            // JWT 필터 등록
-            .addFilterBefore(
-                    new JwtAuthenticationFilter(jwtTokenProvider),
-                    UsernamePasswordAuthenticationFilter.class
             );
-
         return http.build();
 
     }
+
+    private void configureCommonSecurity(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                // .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .failureHandler(oAuth2AuthenticationFailureHandler)
+                )
+                // JWT 필터 등록
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class
+                )
+                // 토큰 없이 authenticated() 경로 접근 시 401
+                .exceptionHandling(ex -> ex
+                    .authenticationEntryPoint((request, response, authException) -> {
+                        filterResponseUtils.sendUnauthorized(response,AuthErrorCode.EMPTY_AUTHENTICATION);
+                    })
+                );
+    }
+
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -81,6 +81,7 @@ public class SecurityConfig {
                         filterResponseUtils.sendUnauthorized(response,AuthErrorCode.EMPTY_AUTHENTICATION);
                     })
                 );
+        
     }
 
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
@@ -41,7 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (!jwtTokenProvider.validateToken(token)) {
                 // 유효하지 않은 토큰 → 즉시 401 반환, 필터 체인 중단
                 filterResponseUtils.sendUnauthorized(response, AuthErrorCode.INVALID_TOKEN);
-                return; // ← 핵심
+                return;
             }
 
             Long userId = jwtTokenProvider.getUserId(token);

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,25 +1,30 @@
 package com.sofly.core.global.security.jwt;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.util.List;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-import java.util.List;
+import com.sofly.core.global.auth.exception.code.AuthErrorCode;
+import com.sofly.core.global.security.util.FilterResponseUtils;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final FilterResponseUtils filterResponseUtils;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -30,7 +35,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         // TODO: social login jwt PR #16 성능개선 필요 (gemini-code-assist)
-        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+
+        // if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+        if (StringUtils.hasText(token)) {
+            if (!jwtTokenProvider.validateToken(token)) {
+                // 유효하지 않은 토큰 → 즉시 401 반환, 필터 체인 중단
+                filterResponseUtils.sendUnauthorized(response, AuthErrorCode.INVALID_TOKEN);
+                return; // ← 핵심
+            }
+
             Long userId = jwtTokenProvider.getUserId(token);
 
             // SecurityContext에 인증 정보 저장

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtAuthenticationFilter.java
@@ -24,7 +24,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+                                    FilterChain filterChain
+    ) throws ServletException, IOException {
 
         String token = resolveToken(request);
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtProperties.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtProperties.java
@@ -1,5 +1,7 @@
 package com.sofly.core.global.security.jwt;
 
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "jwt.token")
@@ -8,7 +10,7 @@ public record JwtProperties(
         Expiration expiration
 ) {
     public record Expiration(
-            long access,
-            long refresh
+            Duration access,
+            Duration refresh
     ) {}
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
@@ -103,7 +103,7 @@ public class JwtTokenProvider {
     private Claims parseClaims(String token) throws JwtException {
         return Jwts.parser()
                 .verifyWith(getSigningKey())
-                .clockSkewSeconds(60) // 시간 오차 허용 (네트워크 지연 등 대비)
+                .clockSkewSeconds(30) // 시간 오차 허용 (네트워크 지연 등 대비)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/jwt/JwtTokenProvider.java
@@ -1,16 +1,23 @@
 package com.sofly.core.global.security.jwt;
 
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -33,22 +40,26 @@ public class JwtTokenProvider {
 
     // ── Access Token 생성 ────────────────────────────────
     public String generateAccessToken(Long userId) {
+        Instant now = Instant.now();
+
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("type", "access")
-                .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration().access()))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(jwtProperties.expiration().access())))
                 .signWith(getSigningKey())
                 .compact();
     }
 
     // ── Refresh Token 생성 ───────────────────────────────
     public String generateRefreshToken(Long userId) {
+        Instant now = Instant.now();
+
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("type", "refresh")
-                .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration().refresh()))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(jwtProperties.expiration().refresh())))
                 .signWith(getSigningKey())
                 .compact();
     }
@@ -58,6 +69,17 @@ public class JwtTokenProvider {
         return Long.parseLong(
                 parseClaims(token).getSubject()
         );
+    }
+
+    // 단순 토큰 유효 유무 확인 함수
+    public boolean isValid(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException e) {
+            log.warn("유효하지 않은 토큰: {}", e.getMessage());
+            return false;
+        }
     }
 
     // ── 토큰 유효성 검증 ─────────────────────────────────
@@ -78,9 +100,10 @@ public class JwtTokenProvider {
     }
 
     // ── Claims 파싱 ──────────────────────────────────────
-    private Claims parseClaims(String token) {
+    private Claims parseClaims(String token) throws JwtException {
         return Jwts.parser()
                 .verifyWith(getSigningKey())
+                .clockSkewSeconds(60) // 시간 오차 허용 (네트워크 지연 등 대비)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -44,7 +44,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             RefreshToken.builder()
                 .id(String.valueOf(userId))        // key: refresh_token:{userId}
                 .refreshToken(refreshToken)
-                .expiration(jwtProperties.expiration().refresh() / 1000)
+                .expiration(jwtProperties.expiration().refresh().getSeconds())
                 .build()
         );
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshToken.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshToken.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
-import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @Builder

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshTokenRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/RefreshTokenRepository.java
@@ -2,8 +2,6 @@ package com.sofly.core.global.security.oauth2;
 
 import org.springframework.data.repository.CrudRepository;
 
-import java.util.Optional;
-
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     // findByUserId 제거 — userId를 @Id로 쓰므로 findById로 조회
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/FilterResponseUtils.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/FilterResponseUtils.java
@@ -1,0 +1,28 @@
+package com.sofly.core.global.security.util;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofly.core.global.response.ApiResponse;  // sofly 패키지에 맞게
+import com.sofly.core.global.response.code.BaseErrorCode;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FilterResponseUtils {
+
+    private final ObjectMapper objectMapper;
+
+    public void sendUnauthorized(HttpServletResponse response, BaseErrorCode errorCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        // sofly ApiResponse 구조에 맞게 수정 필요
+        ApiResponse<Object> errorResponse = ApiResponse.fail(errorCode);
+        String json = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(json);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/FilterResponseUtils.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/FilterResponseUtils.java
@@ -19,7 +19,7 @@ public class FilterResponseUtils {
 
     public void sendUnauthorized(HttpServletResponse response, BaseErrorCode errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(errorCode.getStatus().value());
         // sofly ApiResponse 구조에 맞게 수정 필요
         ApiResponse<Object> errorResponse = ApiResponse.fail(errorCode);
         String json = objectMapper.writeValueAsString(errorResponse);

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/FilterResponseUtils.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/FilterResponseUtils.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sofly.core.global.response.ApiResponse;  // sofly 패키지에 맞게
+import com.sofly.core.global.response.ApiResponse;
 import com.sofly.core.global.response.code.BaseErrorCode;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,7 +20,6 @@ public class FilterResponseUtils {
     public void sendUnauthorized(HttpServletResponse response, BaseErrorCode errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(errorCode.getStatus().value());
-        // sofly ApiResponse 구조에 맞게 수정 필요
         ApiResponse<Object> errorResponse = ApiResponse.fail(errorCode);
         String json = objectMapper.writeValueAsString(errorResponse);
         response.getWriter().write(json);

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -22,7 +22,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
     properties:
       hibernate:
@@ -85,8 +85,8 @@ jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}
     expiration:
-      access: 14400000       # 4시간
-      refresh: 1209600000    # 14일
+      access: PT4H       # 4시간
+      refresh: P14D    # 14일
 
 sofly:
   oauth2:


### PR DESCRIPTION
## 📌 PR 요약
JWT Access Token 없이 인증이 필요한 API 엔드포인트에 접근 가능한 보안 취약점을 수정합니다. `SecurityConfig` 필터 및 권한 설정을 강화하고, 공통 에러 응답 체계를 도입합니다.

## 🔧 변경 사항

### 문제
- `SecurityConfig`에서 `/api/auth/**` 전체를 `permitAll()` 처리하여 `/api/auth/logout` 등 인증이 필요한 엔드포인트가 토큰 없이 호출 가능한 상태였습니다.
- `JwtAuthenticationFilter`에서 유효하지 않은 토큰이 들어와도 필터를 그냥 통과하고, 별도 401 응답이 반환되지 않았습니다.
- `AuthenticationEntryPoint` 미설정으로 인해 인증 실패 시 일관된 에러 응답이 보장되지 않았습니다.

### 해결
- `permitAll()` 범위를 공개 엔드포인트로 최소화하였습니다.
- 유효하지 않은 토큰 요청 시 필터 레벨에서 401 응답을 반환하도록 처리하였습니다.
- `ErrorStatus` enum 기반의 공통 에러 응답 체계를 도입하였습니다.
- `@Profile` 분리로 Swagger를 운영 환경에서 차단하였습니다.

## 📋 작업 상세 내용

- [x] `SecurityConfig` — `permitAll()` 범위 축소 (`/api/auth/**` → `/api/auth/refresh`만 허용)
- [x] `SecurityConfig` — `@Profile("!prod")` / `@Profile("prod")` 분리로 Swagger 운영 차단
- [x] `SecurityConfig` — `exceptionHandling().authenticationEntryPoint()` 등록 (토큰 없이 접근 시 401)
- [x] `JwtAuthenticationFilter` — 유효하지 않은 토큰 감지 시 필터 체인 중단 및 401 반환
- [x] `FilterResponseUtils` — 필터 레벨 공통 에러 응답 유틸 추가
- [x] `ApiResponse` — `BaseErrorCode` 기반 실패 응답 메서드 추가
- [x] `BaseErrorCode` / `BaseSuccessCode` — 에러 코드 인터페이스 추가
- [x] `ErrorStatus` — 인증 관련 에러 코드 enum 추가 (`AUTH_001` ~ `AUTH_005`)

## 🔗 관련 이슈

closed #22 

## 📝 기타

- `JwtTokenProvider.validateToken()` 내부에서 만료/위변조를 구분하지 않고 `boolean`으로 반환 중입니다. 추후 만료(`AUTH_003`)와 위변조(`AUTH_002`)를 분리 응답하도록 개선이 필요합니다.
- Swagger `permitAll` 프로파일 분리 적용 시, 로컬/개발 환경에서 `spring.profiles.active=local` 또는 `dev` 설정이 필요합니다.