### PR TITLE
Feat/23 user profile

### DIFF
--- a/services/travel-core-service/docs/user-profile.md
+++ b/services/travel-core-service/docs/user-profile.md
@@ -67,7 +67,7 @@ global/security/util/
 
 | 항목 | 내용 |
 |------|------|
-| Method | `PUT` |
+| Method | `PATCH` |
 | URL | `/api/users/me/profile` |
 | 인증 | Bearer Token 필요 |
 

--- a/services/travel-core-service/docs/user-profile.md
+++ b/services/travel-core-service/docs/user-profile.md
@@ -1,0 +1,163 @@
+# FR-002 사용자 프로필 관리 구현 문서
+
+## 개요
+
+사용자가 마이페이지에서 기본 정보 및 여행 성향을 등록·수정할 수 있는 API를 구현한다.
+등록된 프로필 정보는 AI 일정 생성 시 기본 조건으로 자동 반영된다.
+
+---
+
+## 디렉토리 구조
+
+```
+domain/user/
+  ├── code/
+  │   └── UserErrorCode.java
+  ├── controller/
+  │   └── UserController.java
+  ├── dto/
+  │   ├── UserProfileResponse.java
+  │   └── UserProfileUpdateRequest.java
+  ├── entity/
+  │   └── User.java
+  ├── exception/
+  │   └── UserException.java
+  ├── repository/
+  │   └── UserRepository.java
+  └── service/
+      └── UserService.java
+
+global/security/util/
+  └── SecurityUtils.java
+```
+
+---
+
+## API 명세
+
+### 프로필 조회
+
+| 항목 | 내용 |
+|------|------|
+| Method | `GET` |
+| URL | `/api/users/me/profile` |
+| 인증 | Bearer Token 필요 |
+
+**Response**
+```json
+{
+  "id": 1,
+  "email": "user@example.com",
+  "nickname": "여행자",
+  "profileImageUrl": "https://...",
+  "ageGroup": "TWENTIES",
+  "city": "서울",
+  "preferCompanionType": "COUPLE",
+  "budgetMin": 500000,
+  "budgetMax": 1500000,
+  "preferThemes": ["RELAXATION", "FOOD"],
+  "preferCities": ["제주", "부산"],
+  "profileCompleted": true
+}
+```
+
+---
+
+### 프로필 등록/수정
+
+| 항목 | 내용 |
+|------|------|
+| Method | `PUT` |
+| URL | `/api/users/me/profile` |
+| 인증 | Bearer Token 필요 |
+
+**Request Body**
+```json
+{
+  "nickname": "여행자",
+  "city": "서울",
+  "ageGroup": "TWENTIES",
+  "preferCompanionType": "COUPLE",
+  "budgetMin": 500000,
+  "budgetMax": 1500000,
+  "preferThemes": ["RELAXATION", "FOOD"],
+  "preferCities": ["제주", "부산"]
+}
+```
+
+**Response** - 조회 응답과 동일
+
+---
+
+## Enum 값 목록
+
+| 필드 | 값 |
+|------|----|
+| `ageGroup` | `TEENS`, `TWENTIES`, `THIRTIES`, `FORTIES_PLUS` |
+| `preferCompanionType` | `SOLO`, `COUPLE`, `FRIENDS`, `FAMILY` |
+| `preferThemes` | `RELAXATION`, `SHOPPING`, `CULTURE`, `ACTIVITY`, `FOOD` |
+
+---
+
+## 주요 파일 설명
+
+### `UserController`
+- `SecurityUtils.getCurrentUserId()`로 JWT에서 userId 추출
+- `@Valid`로 요청 DTO 검증
+
+### `UserService`
+- `getMyProfile(userId)` — 프로필 조회
+- `updateMyProfile(userId, request)` — 프로필 등록/수정
+- `getProfileForAiSchedule(userId)` — AI 일정 생성 연동용 인터페이스
+
+### `UserProfileResponse`
+- `profileCompleted` 필드 포함
+- `ageGroup`, `preferCompanionType`, `budgetMin`, `budgetMax`, `preferThemes` 모두 입력 시 `true`
+- AI 서비스에서 프로필 완성 여부 체크 시 활용
+
+### `UserException`
+- `GeneralException` 상속
+- `UserErrorCode`를 받아 도메인 전용 예외 생성
+- `AuthException`과 동일한 패턴으로 도메인별 예외 분리
+
+### `SecurityUtils`
+- `SecurityContextHolder`에서 userId(Long) 직접 추출
+- `JwtAuthenticationFilter`가 principal에 userId를 저장하는 구조 기반
+- DB 조회 없이 바로 userId 반환
+
+---
+
+## 인증 흐름
+
+```
+클라이언트 요청 (Bearer Token)
+        ↓
+JwtAuthenticationFilter
+  └── JWT 검증 → userId 추출 → SecurityContext에 저장
+        ↓
+UserController
+  └── SecurityUtils.getCurrentUserId()
+        ↓
+UserService
+  └── userRepository.findById(userId)
+```
+
+---
+
+## Validation 규칙
+
+| 필드 | 규칙 |
+|------|------|
+| `nickname` | 필수, 최대 20자 |
+| `ageGroup` | 필수 |
+| `preferCompanionType` | 필수 |
+| `budgetMin`, `budgetMax` | 0 이상 |
+| `preferThemes` | 최대 5개 |
+| `preferCities` | 최대 10개 |
+
+---
+
+## AI 일정 생성 연동
+
+`UserService.getProfileForAiSchedule(userId)`를 통해 AI 일정 서비스에서 사용자 프로필을 조회한다.
+`profileCompleted: false`인 경우 AI 서비스에서 프로필 입력을 유도하는 처리가 필요하다.

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
@@ -11,9 +11,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다."),
-    PROFILE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_002", "프로필 업데이트에 실패했습니다.");
-
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
@@ -11,11 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
-    LOGIN_ID_REQUIRED(HttpStatus.BAD_REQUEST,"LOGIN_ID_REQUIRED","로그인 ID는 필수 입력값입니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 사용자를 찾지 못했습니다."),
-    LOGIN_ID_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ID_ALREADY_EXIST","이미 존재하는 ID입니다"),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST,"INVALID_REQUEST","요청이 유효하지 않습니다")
-    ;
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다."),
+    PROFILE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_002", "프로필 업데이트에 실패했습니다.");
 
 
     private final HttpStatus status;

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/code/UserErrorCode.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다."),
+    INVALID_BUDGET_RANGE(HttpStatus.BAD_REQUEST, "INVALID_BUDGET_RANGE", "최소 예산은 최대 예산보다 클 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
@@ -1,0 +1,49 @@
+package com.sofly.core.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sofly.core.domain.user.dto.UserProfileResponse;
+import com.sofly.core.domain.user.dto.UserProfileUpdateRequest;
+import com.sofly.core.domain.user.service.UserService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/users/me")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * GET /api/users/me/profile
+     * 내 프로필 조회
+     */
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        UserProfileResponse response = userService.getMyProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * PUT /api/users/me/profile
+     * 내 프로필 등록 / 수정
+     */
+    @PutMapping("/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateMyProfile(
+            @RequestBody @Valid UserProfileUpdateRequest request
+    ) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        UserProfileResponse response = userService.updateMyProfile(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
@@ -13,9 +13,13 @@ import com.sofly.core.domain.user.service.UserService;
 import com.sofly.core.global.response.ApiResponse;
 import com.sofly.core.global.security.util.SecurityUtils;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "UserProfile", description = "프로필")
 @RestController
 @RequestMapping("/api/users/me")
 @RequiredArgsConstructor
@@ -27,6 +31,12 @@ public class UserController {
      * GET /api/users/me/profile
      * 내 프로필 조회
      */
+    @Operation(summary = "프로필 조회", description = "현재 로그인한 사용자의 프로필을 조회합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @GetMapping("/profile")
     public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile() {
         Long userId = SecurityUtils.getCurrentUserId();
@@ -38,6 +48,13 @@ public class UserController {
      * PUT /api/users/me/profile
      * 내 프로필 등록 / 수정
      */
+    @Operation(summary = "프로필 등록/수정", description = "현재 로그인한 사용자의 프로필을 등록하거나 수정합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "등록/수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @PutMapping("/profile")
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateMyProfile(
             @RequestBody @Valid UserProfileUpdateRequest request

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
@@ -45,10 +45,10 @@ public class UserController {
     }
 
     /**
-     * PUT /api/users/me/profile
+    /**
+     * PATCH /api/users/me/profile
      * 내 프로필 등록 / 수정
      */
-    @Operation(summary = "프로필 등록/수정", description = "현재 로그인한 사용자의 프로필을 등록하거나 수정합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "등록/수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/controller/UserController.java
@@ -2,7 +2,7 @@ package com.sofly.core.domain.user.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,7 +55,7 @@ public class UserController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    @PutMapping("/profile")
+    @PatchMapping("/profile")
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateMyProfile(
             @RequestBody @Valid UserProfileUpdateRequest request
     ) {

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileResponse.java
@@ -8,7 +8,7 @@ import com.sofly.core.domain.user.entity.User.TravelTheme;
 import java.util.List;
 
 /**
- * GET / PUT /api/users/me/profile 응답 DTO
+ * GET / PATCH /api/users/me/profile 응답 DTO
  */
 public record UserProfileResponse(
         Long id,

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,53 @@
+package com.sofly.core.domain.user.dto;
+
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.entity.User.AgeGroup;
+import com.sofly.core.domain.user.entity.User.CompanionType;
+import com.sofly.core.domain.user.entity.User.TravelTheme;
+
+import java.util.List;
+
+/**
+ * GET / PUT /api/users/me/profile 응답 DTO
+ */
+public record UserProfileResponse(
+        Long id,
+        String email,
+        String nickname,
+        String profileImageUrl,
+
+        // 여행 성향
+        AgeGroup ageGroup,
+        String city,
+        CompanionType preferCompanionType,
+        Integer budgetMin,
+        Integer budgetMax,
+        List<TravelTheme> preferThemes,
+        List<String> preferCities,
+
+        // 프로필 완성 여부 (AI 연동 시 활용)
+        boolean profileCompleted
+) {
+    public static UserProfileResponse from(User user) {
+        boolean completed = user.getAgeGroup() != null
+                && user.getPreferCompanionType() != null
+                && user.getBudgetMin() != null
+                && user.getBudgetMax() != null
+                && !user.getPreferThemes().isEmpty();
+
+        return new UserProfileResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getProfileImageUrl(),
+                user.getAgeGroup(),
+                user.getCity(),
+                user.getPreferCompanionType(),
+                user.getBudgetMin(),
+                user.getBudgetMax(),
+                List.copyOf(user.getPreferThemes()),
+                List.copyOf(user.getPreferCities()),
+                completed
+        );
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileUpdateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileUpdateRequest.java
@@ -1,0 +1,41 @@
+package com.sofly.core.domain.user.dto;
+
+import com.sofly.core.domain.user.entity.User.AgeGroup;
+import com.sofly.core.domain.user.entity.User.CompanionType;
+import com.sofly.core.domain.user.entity.User.TravelTheme;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * PUT /api/users/me/profile 요청 DTO
+ */
+public record UserProfileUpdateRequest(
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
+        String nickname,
+
+        String city,
+
+        @NotNull(message = "연령대는 필수입니다.")
+        AgeGroup ageGroup,
+
+        @NotNull(message = "선호 동행 타입은 필수입니다.")
+        CompanionType preferCompanionType,
+
+        @PositiveOrZero(message = "최소 예산은 0 이상이어야 합니다.")
+        Integer budgetMin,
+
+        @PositiveOrZero(message = "최대 예산은 0 이상이어야 합니다.")
+        Integer budgetMax,
+
+        @Size(max = 5, message = "선호 테마는 최대 5개까지 선택 가능합니다.")
+        List<TravelTheme> preferThemes,
+
+        @Size(max = 10, message = "선호 도시는 최대 10개까지 선택 가능합니다.")
+        List<String> preferCities
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileUpdateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileUpdateRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 /**
- * PUT /api/users/me/profile 요청 DTO
+ * PATCH /api/users/me/profile 요청 DTO
  */
 public record UserProfileUpdateRequest(
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileUpdateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/dto/UserProfileUpdateRequest.java
@@ -3,8 +3,6 @@ package com.sofly.core.domain.user.dto;
 import com.sofly.core.domain.user.entity.User.AgeGroup;
 import com.sofly.core.domain.user.entity.User.CompanionType;
 import com.sofly.core.domain.user.entity.User.TravelTheme;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
@@ -15,16 +13,13 @@ import java.util.List;
  */
 public record UserProfileUpdateRequest(
 
-        @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
         String nickname,
 
         String city,
 
-        @NotNull(message = "연령대는 필수입니다.")
         AgeGroup ageGroup,
 
-        @NotNull(message = "선호 동행 타입은 필수입니다.")
         CompanionType preferCompanionType,
 
         @PositiveOrZero(message = "최소 예산은 0 이상이어야 합니다.")

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/exception/UserException.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/exception/UserException.java
@@ -1,0 +1,21 @@
+package com.sofly.core.domain.user.exception;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class UserException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public UserException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public UserException(BaseErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/service/UserService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/service/UserService.java
@@ -36,14 +36,14 @@ public class UserService {
     public UserProfileResponse updateMyProfile(Long userId, UserProfileUpdateRequest request) {
         User user = findUserById(userId);
 
-        // 기본 정보 + 여행 성향 업데이트
+        // null이면 기존 값 유지
         user.updateProfile(
-                request.nickname(),
-                request.city(),
-                request.ageGroup(),
-                request.preferCompanionType(),
-                request.budgetMin(),
-                request.budgetMax()
+                request.nickname() != null ? request.nickname() : user.getNickname(),
+                request.city() != null ? request.city() : user.getCity(),
+                request.ageGroup() != null ? request.ageGroup() : user.getAgeGroup(),
+                request.preferCompanionType() != null ? request.preferCompanionType() : user.getPreferCompanionType(),
+                request.budgetMin() != null ? request.budgetMin() : user.getBudgetMin(),
+                request.budgetMax() != null ? request.budgetMax() : user.getBudgetMax()
         );
 
         // 선호 테마 (다중) 업데이트

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/service/UserService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/service/UserService.java
@@ -1,0 +1,78 @@
+package com.sofly.core.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofly.core.domain.user.code.UserErrorCode;
+import com.sofly.core.domain.user.dto.UserProfileResponse;
+import com.sofly.core.domain.user.dto.UserProfileUpdateRequest;
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.exception.UserException;
+import com.sofly.core.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * GET /api/users/me/profile
+     * 현재 로그인한 사용자의 프로필 조회
+     */
+    public UserProfileResponse getMyProfile(Long userId) {
+        User user = findUserById(userId);
+        return UserProfileResponse.from(user);
+    }
+
+    /**
+     * PUT /api/users/me/profile
+     * 프로필 등록 / 수정 (기본 정보 + 여행 성향)
+     */
+    @Transactional
+    public UserProfileResponse updateMyProfile(Long userId, UserProfileUpdateRequest request) {
+        User user = findUserById(userId);
+
+        // 기본 정보 + 여행 성향 업데이트
+        user.updateProfile(
+                request.nickname(),
+                request.city(),
+                request.ageGroup(),
+                request.preferCompanionType(),
+                request.budgetMin(),
+                request.budgetMax()
+        );
+
+        // 선호 테마 (다중) 업데이트
+        if (request.preferThemes() != null) {
+            user.updatePreferThemes(request.preferThemes());
+        }
+
+        // 선호 도시 태그 (다중) 업데이트
+        if (request.preferCities() != null) {
+            user.updatePreferCities(request.preferCities());
+        }
+
+        return UserProfileResponse.from(user);
+    }
+
+    // ── AI 일정 생성 연동용 ───────────────────────────────────
+
+    /**
+     * AI 일정 생성 시 사용자 프로필 정보를 기본 조건으로 제공
+     * (다른 서비스에서 호출)
+     */
+    public UserProfileResponse getProfileForAiSchedule(Long userId) {
+        return getMyProfile(userId);
+    }
+
+    // ── 내부 헬퍼 ───────────────────────────────────────────
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/service/UserService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/service/UserService.java
@@ -36,6 +36,9 @@ public class UserService {
     public UserProfileResponse updateMyProfile(Long userId, UserProfileUpdateRequest request) {
         User user = findUserById(userId);
 
+        // 예산 범위 검증
+        validateBudgetRange(request.budgetMin(), request.budgetMax());
+
         // null이면 기존 값 유지
         user.updateProfile(
                 request.nickname() != null ? request.nickname() : user.getNickname(),
@@ -74,5 +77,11 @@ public class UserService {
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private void validateBudgetRange(Integer budgetMin, Integer budgetMax) {
+        if (budgetMin != null && budgetMax != null && budgetMin > budgetMax) {
+            throw new UserException(UserErrorCode.INVALID_BUDGET_RANGE);
+        }
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 .requestMatchers(
                         "/",
                         "/index.html",
+                        "/user-profile-test.html",
                         "/login/oauth2/**",
                         "/oauth2/**",
                         "/api/auth/refresh",

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/SecurityUtils.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/util/SecurityUtils.java
@@ -1,0 +1,40 @@
+package com.sofly.core.global.security.util;
+
+import com.sofly.core.global.auth.exception.code.AuthErrorCode;
+import com.sofly.core.global.auth.exception.AuthException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+
+    private SecurityUtils() {}
+
+    /**
+     * SecurityContext에서 현재 로그인한 userId 추출
+     * JwtAuthenticationFilter에서 principal로 userId(Long)를 저장한 구조 기반
+     */
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthException(AuthErrorCode.EMPTY_AUTHENTICATION);
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Long) {
+            return (Long) principal;
+        }
+
+        // JwtAuthenticationFilter에서 userId를 String으로 넣었을 경우 대비
+        if (principal instanceof String) {
+            try {
+                return Long.parseLong((String) principal);
+            } catch (NumberFormatException e) {
+                throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+            }
+        }
+
+        throw new AuthException(AuthErrorCode.EMPTY_AUTHENTICATION);
+    }
+}

--- a/services/travel-core-service/src/main/resources/static/user-profile-test.html
+++ b/services/travel-core-service/src/main/resources/static/user-profile-test.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Profile API Tester</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&family=Pretendard:wght@300;400;600&display=swap');
+
+  :root {
+    --bg: #0d0d0d;
+    --surface: #161616;
+    --border: #2a2a2a;
+    --accent: #00e5a0;
+    --accent-dim: rgba(0, 229, 160, 0.1);
+    --text: #e8e8e8;
+    --text-dim: #666;
+    --error: #ff5f5f;
+    --warn: #ffb347;
+    --mono: 'JetBrains Mono', monospace;
+    --sans: 'Pretendard', sans-serif;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    min-height: 100vh;
+    padding: 40px 24px;
+  }
+
+  h1 {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--accent);
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin-bottom: 32px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  h1::before { content: '//'; opacity: 0.4; }
+
+  .layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 24px;
+  }
+
+  .card-title {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 20px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .method-badge {
+    font-family: var(--mono);
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+  .get { background: rgba(0, 180, 255, 0.15); color: #00b4ff; }
+  .patch { background: rgba(255, 179, 71, 0.15); color: var(--warn); }
+
+  label {
+    display: block;
+    font-size: 11px;
+    color: var(--text-dim);
+    font-family: var(--mono);
+    margin-bottom: 6px;
+    letter-spacing: 0.05em;
+  }
+
+  input, select, textarea {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 13px;
+    padding: 9px 12px;
+    outline: none;
+    transition: border-color 0.2s;
+    margin-bottom: 14px;
+  }
+  input:focus, select:focus, textarea:focus {
+    border-color: var(--accent);
+  }
+  select option { background: var(--surface); }
+
+  .token-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+    margin-bottom: 20px;
+  }
+  .token-row input { margin-bottom: 0; }
+
+  .checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 14px;
+  }
+  .chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 5px 12px;
+    font-size: 12px;
+    font-family: var(--mono);
+    cursor: pointer;
+    transition: all 0.15s;
+    user-select: none;
+  }
+  .chip input[type=checkbox] { display: none; }
+  .chip.checked {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: var(--accent-dim);
+  }
+
+  btn, .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--accent);
+    color: #000;
+    border: none;
+    border-radius: 5px;
+    padding: 10px 20px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+    letter-spacing: 0.05em;
+  }
+  .btn:hover { opacity: 0.85; }
+  .btn-ghost {
+    background: transparent;
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+  }
+  .btn-ghost:hover { color: var(--text); border-color: var(--text-dim); opacity: 1; }
+
+  .response-box {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    padding: 14px;
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.6;
+    min-height: 120px;
+    white-space: pre-wrap;
+    word-break: break-all;
+    margin-top: 14px;
+    color: var(--text-dim);
+    max-height: 320px;
+    overflow-y: auto;
+  }
+  .response-box.success { color: var(--accent); border-color: rgba(0,229,160,0.3); }
+  .response-box.error { color: var(--error); border-color: rgba(255,95,95,0.3); }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-family: var(--mono);
+    font-size: 11px;
+    padding: 3px 10px;
+    border-radius: 20px;
+    margin-bottom: 8px;
+  }
+  .status-pill.ok { background: rgba(0,229,160,0.1); color: var(--accent); }
+  .status-pill.fail { background: rgba(255,95,95,0.1); color: var(--error); }
+
+  .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .field-row > div input, .field-row > div select { margin-bottom: 0; }
+  .field-row > div { margin-bottom: 14px; }
+
+  .token-section {
+    max-width: 1100px;
+    margin: 0 auto 20px;
+  }
+
+  .hint {
+    font-size: 11px;
+    color: var(--text-dim);
+    margin-top: -10px;
+    margin-bottom: 14px;
+    font-family: var(--mono);
+  }
+
+  ::-webkit-scrollbar { width: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+</style>
+</head>
+<body>
+
+<h1>Profile API Tester &nbsp;—&nbsp; sofly</h1>
+
+<!-- Token -->
+<div class="token-section card">
+  <div class="card-title">🔑 JWT Token</div>
+  <div class="token-row">
+    <input type="text" id="token" placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." />
+    <button class="btn btn-ghost" onclick="clearToken()">Clear</button>
+  </div>
+  <div style="font-size:11px; color: var(--text-dim); font-family: var(--mono);">
+    Authorization: Bearer &lt;token&gt; 헤더로 자동 첨부됩니다.
+  </div>
+</div>
+
+<div class="layout">
+
+  <!-- GET -->
+  <div class="card">
+    <div class="card-title">
+      <span class="method-badge get">GET</span>
+      /api/users/me/profile
+    </div>
+    <p style="font-size:12px; color:var(--text-dim); margin-bottom:20px;">
+      현재 로그인한 사용자의 프로필을 조회합니다. Request Body 없이 Token만 필요합니다.
+    </p>
+    <label>Base URL</label>
+    <input type="text" id="baseUrl" value="http://localhost:8080" />
+    <button class="btn" onclick="getProfile()">▶ 조회하기</button>
+    <div id="getStatus"></div>
+    <div class="response-box" id="getResponse">// 응답이 여기 표시됩니다.</div>
+  </div>
+
+  <!-- PATCH -->
+  <div class="card">
+    <div class="card-title">
+      <span class="method-badge patch">PATCH</span>
+      /api/users/me/profile
+    </div>
+    <p style="font-size:12px; color:var(--text-dim); margin-bottom:16px;">
+      null인 필드는 기존 값이 유지됩니다. 수정할 필드만 입력하세요.
+    </p>
+
+    <label>nickname</label>
+    <input type="text" id="nickname" placeholder="비워두면 기존 값 유지" maxlength="20" />
+
+    <label>city</label>
+    <input type="text" id="city" placeholder="예: 서울" />
+
+    <div class="field-row">
+      <div>
+        <label>ageGroup</label>
+        <select id="ageGroup">
+          <option value="">— 선택 안 함 —</option>
+          <option>TEENS</option>
+          <option>TWENTIES</option>
+          <option>THIRTIES</option>
+          <option>FORTIES_PLUS</option>
+        </select>
+      </div>
+      <div>
+        <label>preferCompanionType</label>
+        <select id="companionType">
+          <option value="">— 선택 안 함 —</option>
+          <option>SOLO</option>
+          <option>COUPLE</option>
+          <option>FRIENDS</option>
+          <option>FAMILY</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="field-row">
+      <div>
+        <label>budgetMin (원)</label>
+        <input type="number" id="budgetMin" placeholder="예: 500000" min="0" />
+      </div>
+      <div>
+        <label>budgetMax (원)</label>
+        <input type="number" id="budgetMax" placeholder="예: 1500000" min="0" />
+      </div>
+    </div>
+
+    <label>preferThemes (복수 선택)</label>
+    <div class="checkbox-group" id="themes">
+      <label class="chip" onclick="toggleChip(this)"><input type="checkbox" value="RELAXATION">휴양 RELAXATION</label>
+      <label class="chip" onclick="toggleChip(this)"><input type="checkbox" value="SHOPPING">쇼핑 SHOPPING</label>
+      <label class="chip" onclick="toggleChip(this)"><input type="checkbox" value="CULTURE">문화 CULTURE</label>
+      <label class="chip" onclick="toggleChip(this)"><input type="checkbox" value="ACTIVITY">액티비티 ACTIVITY</label>
+      <label class="chip" onclick="toggleChip(this)"><input type="checkbox" value="FOOD">음식 FOOD</label>
+    </div>
+
+    <label>preferCities (쉼표로 구분)</label>
+    <input type="text" id="preferCities" placeholder="예: 제주, 부산, 강릉" />
+    <p class="hint">// 비워두면 기존 값 유지</p>
+
+    <div style="display:flex; gap:8px; align-items:center;">
+      <button class="btn" onclick="patchProfile()">▶ 수정하기</button>
+      <button class="btn btn-ghost" onclick="resetForm()">Reset</button>
+    </div>
+
+    <div id="patchStatus"></div>
+    <div class="response-box" id="patchResponse">// 응답이 여기 표시됩니다.</div>
+  </div>
+
+</div>
+
+<script>
+  function toggleChip(el) {
+    const cb = el.querySelector('input[type=checkbox]');
+    cb.checked = !cb.checked;
+    el.classList.toggle('checked', cb.checked);
+  }
+
+  function clearToken() {
+    document.getElementById('token').value = '';
+  }
+
+  function resetForm() {
+    ['nickname','city','budgetMin','budgetMax','preferCities'].forEach(id => {
+      document.getElementById(id).value = '';
+    });
+    document.getElementById('ageGroup').value = '';
+    document.getElementById('companionType').value = '';
+    document.querySelectorAll('#themes .chip').forEach(chip => {
+      chip.querySelector('input').checked = false;
+      chip.classList.remove('checked');
+    });
+    document.getElementById('patchResponse').textContent = '// 응답이 여기 표시됩니다.';
+    document.getElementById('patchResponse').className = 'response-box';
+    document.getElementById('patchStatus').innerHTML = '';
+  }
+
+  function getHeaders() {
+    const token = document.getElementById('token').value.trim();
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    return headers;
+  }
+
+  function getBaseUrl() {
+    return document.getElementById('baseUrl').value.trim().replace(/\/$/, '');
+  }
+
+  function renderStatus(elId, status) {
+    const el = document.getElementById(elId);
+    const ok = status >= 200 && status < 300;
+    el.innerHTML = `<div class="status-pill ${ok ? 'ok' : 'fail'}">${ok ? '✓' : '✗'} ${status}</div>`;
+  }
+
+  async function getProfile() {
+    const box = document.getElementById('getResponse');
+    const url = `${getBaseUrl()}/api/users/me/profile`;
+    box.textContent = '// 요청 중...';
+    box.className = 'response-box';
+    try {
+      const res = await fetch(url, { headers: getHeaders() });
+      renderStatus('getStatus', res.status);
+      const data = await res.json();
+      box.textContent = JSON.stringify(data, null, 2);
+      box.className = `response-box ${res.ok ? 'success' : 'error'}`;
+    } catch (e) {
+      box.textContent = `// 요청 실패: ${e.message}\n// CORS 또는 서버 미실행 확인`;
+      box.className = 'response-box error';
+      document.getElementById('getStatus').innerHTML = `<div class="status-pill fail">✗ Error</div>`;
+    }
+  }
+
+  async function patchProfile() {
+    const box = document.getElementById('patchResponse');
+    const url = `${getBaseUrl()}/api/users/me/profile`;
+    box.textContent = '// 요청 중...';
+    box.className = 'response-box';
+
+    const body = {};
+
+    const nickname = document.getElementById('nickname').value.trim();
+    if (nickname) body.nickname = nickname;
+
+    const city = document.getElementById('city').value.trim();
+    if (city) body.city = city;
+
+    const ageGroup = document.getElementById('ageGroup').value;
+    if (ageGroup) body.ageGroup = ageGroup;
+
+    const companionType = document.getElementById('companionType').value;
+    if (companionType) body.preferCompanionType = companionType;
+
+    const budgetMin = document.getElementById('budgetMin').value;
+    if (budgetMin !== '') body.budgetMin = Number(budgetMin);
+
+    const budgetMax = document.getElementById('budgetMax').value;
+    if (budgetMax !== '') body.budgetMax = Number(budgetMax);
+
+    const themes = [...document.querySelectorAll('#themes input:checked')].map(cb => cb.value);
+    if (themes.length > 0) body.preferThemes = themes;
+
+    const citiesRaw = document.getElementById('preferCities').value.trim();
+    if (citiesRaw) body.preferCities = citiesRaw.split(',').map(c => c.trim()).filter(Boolean);
+
+    try {
+      const res = await fetch(url, {
+        method: 'PATCH',
+        headers: getHeaders(),
+        body: JSON.stringify(body)
+      });
+      renderStatus('patchStatus', res.status);
+      const data = await res.json();
+      box.textContent = JSON.stringify(data, null, 2);
+      box.className = `response-box ${res.ok ? 'success' : 'error'}`;
+    } catch (e) {
+      box.textContent = `// 요청 실패: ${e.message}\n// CORS 또는 서버 미실행 확인`;
+      box.className = 'response-box error';
+      document.getElementById('patchStatus').innerHTML = `<div class="status-pill fail">✗ Error</div>`;
+    }
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약
FR-002 요구사항에 따라 사용자 프로필 등록/수정 API를 구현했습니다.
마이페이지에서 기본 정보 및 여행 성향을 부분 수정할 수 있으며, 등록된 프로필은 AI 일정 생성 시 기본 조건으로 자동 반영됩니다.

## 🔧 변경 사항
- `GET /api/users/me/profile` — 프로필 조회 API 추가
- `PATCH /api/users/me/profile` — 프로필 등록/수정 API 추가
  - 초기에 PUT으로 구현했으나, 일부 필드만 수정할 때 나머지 값을 전부 다시 보내야 하는 불편함이 있어 PATCH 방식으로 변경
  - null인 필드는 기존 값을 유지하는 부분 수정 방식으로 구현
- `SecurityUtils` 추가 — `JwtAuthenticationFilter`에서 principal에 저장된 userId를 SecurityContext에서 직접 추출, DB 조회 없이 처리
- 도메인별 예외 분리 — `UserException`, `UserErrorCode` 추가

## 📋 작업 상세 내용
- [x] `UserController` — GET, PATCH 엔드포인트 구현 및 Swagger `@Operation` 추가
- [x] `UserService` — `getMyProfile()`, `updateMyProfile()`, `getProfileForAiSchedule()` 구현
- [x] `UserProfileUpdateRequest` — PATCH 방식에 맞게 모든 필드 optional로 변경
- [x] `UserProfileResponse` — `profileCompleted` 필드 추가 (AI 연동 시 프로필 완성 여부 체크용)
- [x] `UserException` / `UserErrorCode` — 도메인 전용 예외 처리 분리
- [x] `SecurityUtils` — SecurityContext에서 userId 추출 유틸 추가

## 🔗 관련 이슈
- closed #23 

## 📝 기타
- `profileCompleted` 는 AI 일정 생성 서비스에서 프로필 미완성 사용자에게 프로필 입력을 유도할 때 활용할 수 있습니다.
- Body가 완전히 비어있을 때의 예외 처리는 `GlobalExceptionHandler`에 추가가 필요합니다.