### PR TITLE
Infra/30 nginx config

### DIFF
--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -2,7 +2,7 @@ name: Deploy travel-core-service
 
 on:
   push:
-    branches: [ "infra/30-nginx-config" ]
+    branches: [ "develop" ]
     paths:
       - 'services/travel-core-service/**'
       - '.github/workflows/deploy-core.yml'

--- a/.github/workflows/deploy-core.yml
+++ b/.github/workflows/deploy-core.yml
@@ -2,7 +2,7 @@ name: Deploy travel-core-service
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "infra/30-nginx-config" ]
     paths:
       - 'services/travel-core-service/**'
       - '.github/workflows/deploy-core.yml'
@@ -277,6 +277,7 @@ jobs:
             sudo nginx -t
 
             # reload
+            echo "🔄 Nginx 설정 reload 중..."
             sudo nginx -s reload
 
             echo "🔍 Nginx 전환 후 헬스체크 확인..."

--- a/.github/workflows/deploy-supply.yml
+++ b/.github/workflows/deploy-supply.yml
@@ -2,7 +2,7 @@ name: Deploy travel-supply-service
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "infra/30-nginx-config" ]
     paths:
       - 'services/travel-supply-service/**'
       - '.github/workflows/deploy-supply.yml'
@@ -267,6 +267,7 @@ jobs:
             sudo nginx -t
 
             # reload
+            echo "🔄 Nginx 설정 reload 중..."
             sudo nginx -s reload
 
             echo "🔍 Nginx 전환 후 헬스체크 확인..."

--- a/.github/workflows/deploy-supply.yml
+++ b/.github/workflows/deploy-supply.yml
@@ -2,7 +2,7 @@ name: Deploy travel-supply-service
 
 on:
   push:
-    branches: [ "infra/30-nginx-config" ]
+    branches: [ "develop" ]
     paths:
       - 'services/travel-supply-service/**'
       - '.github/workflows/deploy-supply.yml'

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -2,7 +2,7 @@ name: Config nginx
 
 on:
   push:
-    branches: [ "infra/30-nginx-config" ]
+    branches: [ "develop" ]
     paths:
       - 'nginx/**'
       - '.github/workflows/nginx.yml'
@@ -30,13 +30,13 @@ jobs:
           script: |
 
             echo "👉🏻 [1] Git 최신화"
-            # cd "$DEPLOY_PATH"
-            # git remote prune origin
-            # git reset --hard HEAD
-            # git clean -fd
-            # git fetch origin develop
-            # git checkout -B develop origin/develop
-            # git reset --hard origin/develop
+            cd "$DEPLOY_PATH"
+            git remote prune origin
+            git reset --hard HEAD
+            git clean -fd
+            git fetch origin develop
+            git checkout -B develop origin/develop
+            git reset --hard origin/develop
 
             echo "📌 현재 브랜치: $(git branch --show-current)"
             echo "📌 현재 커밋:   $(git rev-parse HEAD)"

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "infra/30-nginx-config" ]
     paths:
       - 'nginx/**'
+      - '.github/workflows/nginx.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -1,0 +1,65 @@
+name: Config nginx
+
+on:
+  push:
+    branches: [ "infra/30-nginx-config" ]
+    paths:
+      - 'nginx/**'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-nginx:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        with:
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: ${{ secrets.LIGHTSAIL_USER }}
+          key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          envs: DEPLOY_PATH
+          script_stop: true
+          script: |
+
+            echo "👉🏻 [1] Git 최신화"
+            cd "$DEPLOY_PATH"
+            git remote prune origin
+            git reset --hard HEAD
+            git clean -fd
+            git fetch origin develop
+            git checkout -B develop origin/develop
+            git reset --hard origin/develop
+
+            echo "📌 현재 브랜치: $(git branch --show-current)"
+            echo "📌 현재 커밋:   $(git rev-parse HEAD)"
+            echo "📌 커밋 메시지: $(git log -1 --pretty=format:'%s')"
+            echo "📌 커밋 시간:   $(git log -1 --pretty=format:'%ci')"
+            echo "📌 커밋 작성자: $(git log -1 --pretty=format:'%an')"
+
+            echo "👉🏻 [2] 기존 nginx 설정 파일 제거"
+            sudo rm /etc/nginx/conf.d/sofly.conf
+
+            echo "👉🏻 [3] 새 nginx 설정 파일 복사"
+            sudo cp "$DEPLOY_PATH/nginx/sofly.conf" /etc/nginx/conf.d/sofly.conf
+
+            echo "👉🏻 [4] 파일 권한 설정 (root:root 644)"
+            sudo chown root:root /etc/nginx/conf.d/sofly.conf
+            sudo chmod 644 /etc/nginx/conf.d/sofly.conf
+
+            echo "👉🏻 [5] 권한 확인"
+            ls -al /etc/nginx/conf.d/sofly.conf
+
+            echo "👉🏻 [6] Nginx 문법 검사"
+            sudo nginx -t
+
+            echo "🔄 [7] Nginx reload"
+            sudo nginx -s reload
+
+            echo "✅ Nginx 배포 완료"

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -48,7 +48,7 @@ jobs:
             sudo rm /etc/nginx/conf.d/sofly.conf
 
             echo "👉🏻 [3] 새 nginx 설정 파일 복사"
-            sudo cp "$DEPLOY_PATH/nginx/sofly.conf" /etc/nginx/conf.d/sofly.conf
+            sudo cp $DEPLOY_PATH/nginx/sofly.conf /etc/nginx/conf.d/sofly.conf
 
             echo "👉🏻 [4] 파일 권한 설정 (root:root 644)"
             sudo chown root:root /etc/nginx/conf.d/sofly.conf

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -59,6 +59,8 @@ jobs:
 
             echo "👉🏻 [6] Nginx 문법 검사"
             sudo nginx -t
+            
+            cat $DEPLOY_PATH/nginx/sofly.conf
 
             echo "🔄 [7] Nginx reload"
             sudo nginx -s reload

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -30,13 +30,13 @@ jobs:
           script: |
 
             echo "👉🏻 [1] Git 최신화"
-            cd "$DEPLOY_PATH"
-            git remote prune origin
-            git reset --hard HEAD
-            git clean -fd
-            git fetch origin develop
-            git checkout -B develop origin/develop
-            git reset --hard origin/develop
+            # cd "$DEPLOY_PATH"
+            # git remote prune origin
+            # git reset --hard HEAD
+            # git clean -fd
+            # git fetch origin develop
+            # git checkout -B develop origin/develop
+            # git reset --hard origin/develop
 
             echo "📌 현재 브랜치: $(git branch --show-current)"
             echo "📌 현재 커밋:   $(git rev-parse HEAD)"
@@ -48,7 +48,7 @@ jobs:
             sudo rm /etc/nginx/conf.d/sofly.conf
 
             echo "👉🏻 [3] 새 nginx 설정 파일 복사"
-            sudo cp $DEPLOY_PATH/nginx/sofly.conf /etc/nginx/conf.d/sofly.conf
+            sudo cp "$DEPLOY_PATH/nginx/sofly.conf" /etc/nginx/conf.d/sofly.conf
 
             echo "👉🏻 [4] 파일 권한 설정 (root:root 644)"
             sudo chown root:root /etc/nginx/conf.d/sofly.conf
@@ -59,8 +59,8 @@ jobs:
 
             echo "👉🏻 [6] Nginx 문법 검사"
             sudo nginx -t
-            
-            cat $DEPLOY_PATH/nginx/sofly.conf
+
+            cat "$DEPLOY_PATH/nginx/sofly.conf"
 
             echo "🔄 [7] Nginx reload"
             sudo nginx -s reload

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -49,6 +49,7 @@ jobs:
 
             echo "👉🏻 [3] 새 nginx 설정 파일 복사"
             sudo cp "$DEPLOY_PATH/nginx/sofly.conf" /etc/nginx/conf.d/sofly.conf
+            ls -al /etc/nginx/conf.d/sofly.conf
 
             echo "👉🏻 [4] 파일 권한 설정 (root:root 644)"
             sudo chown root:root /etc/nginx/conf.d/sofly.conf

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -61,9 +61,10 @@ jobs:
             echo "👉🏻 [6] Nginx 문법 검사"
             sudo nginx -t
 
+            echo "👉🏻 [6] sofly.conf"
             cat "$DEPLOY_PATH/nginx/sofly.conf"
 
-            echo "🔄 [7] Nginx reload"
+            echo "🔄 [8] Nginx reload"
             sudo nginx -s reload
 
             echo "✅ Nginx 배포 완료"

--- a/nginx/sofly.conf
+++ b/nginx/sofly.conf
@@ -41,33 +41,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-
-    location /swagger-ui/ {
+    location /core/ {
         proxy_pass $core_url;
-        proxy_set_header Host $host;
+    	proxy_set_header Host $host;
+     	proxy_set_header X-Real-IP $remote_addr;
+    	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    	proxy_set_header X-Forwarded-Proto $scheme;
     }
-    location /v3/api-docs/ {
-        proxy_pass $core_url;
-        proxy_set_header Host $host;
-    }
-
-    location /core-docs/ {
-        proxy_pass $core_url;
-        proxy_set_header Host $host;
-    }
-    location /v3/api-docs/core {
-        proxy_pass $core_url;
-        proxy_set_header Host $host;
-    }
-    location /supply-docs/ {
-        proxy_pass $supply_url;
-        proxy_set_header Host $host;
-    }
-    location /v3/api-docs/supply {
-        proxy_pass $supply_url;
-        proxy_set_header Host $host;
-    }
-
     location /supply/ {
         proxy_pass $supply_url;
         proxy_set_header Host $host;

--- a/nginx/sofly.conf
+++ b/nginx/sofly.conf
@@ -59,5 +59,7 @@ server {
         proxy_pass $core_url;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/nginx/sofly.conf
+++ b/nginx/sofly.conf
@@ -1,0 +1,64 @@
+# HTTP → HTTPS 리다이렉트
+server {
+    listen 80;
+    server_name api.sofly.co.kr;
+    if ($host = api.sofly.co.kr) {
+        return 301 https://$host$request_uri;
+    }
+}
+# HTTPS + Blue/Green 라우팅
+server {
+    listen 443 ssl;
+    server_name api.sofly.co.kr;
+
+    # ← include를 server 블록 안으로 이동
+    include /etc/nginx/bluegreen/service-url-core.inc;
+    include /etc/nginx/bluegreen/service-url-supply.inc;
+
+    ssl_certificate /etc/letsencrypt/live/api.sofly.co.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.sofly.co.kr/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location /api/ {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /login/ {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /oauth2/ {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /swagger-ui/ {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+    }
+    location /v3/api-docs/ {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+    }
+    location /supply/ {
+        proxy_pass $supply_url;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location / {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/nginx/sofly.conf
+++ b/nginx/sofly.conf
@@ -41,6 +41,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
     location /swagger-ui/ {
         proxy_pass $core_url;
         proxy_set_header Host $host;
@@ -49,6 +50,24 @@ server {
         proxy_pass $core_url;
         proxy_set_header Host $host;
     }
+
+    location /core-docs/ {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+    }
+    location /v3/api-docs/core {
+        proxy_pass $core_url;
+        proxy_set_header Host $host;
+    }
+    location /supply-docs/ {
+        proxy_pass $supply_url;
+        proxy_set_header Host $host;
+    }
+    location /v3/api-docs/supply {
+        proxy_pass $supply_url;
+        proxy_set_header Host $host;
+    }
+
     location /supply/ {
         proxy_pass $supply_url;
         proxy_set_header Host $host;

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.sofly.core.global.response.ApiResponse;
 
@@ -48,9 +47,4 @@ public class GlobalExceptionHandler {
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
-
-    // @ExceptionHandler(NoResourceFoundException.class)
-    // protected ResponseEntity<?> handleNoResourceFoundException(NoResourceFoundException e) {
-    //     return ResponseEntity.notFound().build();
-    // }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
@@ -1,14 +1,17 @@
 package com.sofly.core.global.exception;
 
-import com.sofly.core.global.response.ApiResponse;
-import lombok.extern.slf4j.Slf4j;
+import java.util.stream.Collectors;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
-import java.util.stream.Collectors;
+import com.sofly.core.global.response.ApiResponse;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -44,5 +47,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<?> handleNoResourceFoundException(NoResourceFoundException e) {
+        return ResponseEntity.notFound().build();
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
@@ -49,8 +49,8 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
 
-    @ExceptionHandler(NoResourceFoundException.class)
-    protected ResponseEntity<?> handleNoResourceFoundException(NoResourceFoundException e) {
-        return ResponseEntity.notFound().build();
-    }
+    // @ExceptionHandler(NoResourceFoundException.class)
+    // protected ResponseEntity<?> handleNoResourceFoundException(NoResourceFoundException e) {
+    //     return ResponseEntity.notFound().build();
+    // }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -44,12 +44,9 @@ public class SecurityConfig {
                         "/oauth2/**",
                         "/api/auth/refresh",
                         "/actuator/health",
-
                         "/swagger-ui/**",
                         "/core-docs",
-                        // "/core-docs/**",
-                        // "/v3/ai-docs/core/**",
-                        "/v3/api-docs/**"
+                        "/v3/api-docs/**"     
                 ).permitAll()
                 .anyRequest().authenticated()
                 )

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -44,14 +44,7 @@ public class SecurityConfig {
                         "/oauth2/**",
                         "/api/auth/refresh",
                         "/actuator/health",
-                        "/swagger-ui/**",
-                        "/swagger-ui/index.html",
-                        "/webjars/**",
-                        "/core-docs/**",
-                        "/core-docs",
-                        "/core-docs/",
-                        "/v3/api-docs/**",
-                        "/v3/api-docs/core"
+                        "/core/**"
                 ).permitAll()
                 .anyRequest().authenticated()
                 )

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                         "/oauth2/**",
                         "/api/auth/refresh",
                         "/actuator/health",
-                        "/core/**"
+                        "/core/swagger-ui/**",
+                        "/core/v3/api-docs/**"
                 ).permitAll()
                 .anyRequest().authenticated()
                 )

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/core-docs",
                         // "/core-docs/**",
-                        "/v3/api-docs/core/**",
+                        // "/v3/ai-docs/core/**",
                         "/v3/api-docs/**"
                 ).permitAll()
                 .anyRequest().authenticated()

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -46,10 +46,10 @@ public class SecurityConfig {
                         "/actuator/health",
 
                         "/swagger-ui/**",
-                        // "/core-docs",
-                        "/core-docs/**",
-                        "/v3/api-docs/core/**"
-                        // "/v3/api-docs/**"     
+                        "/core-docs",
+                        // "/core-docs/**",
+                        "/v3/api-docs/core/**",
+                        "/v3/api-docs/**"
                 ).permitAll()
                 .anyRequest().authenticated()
                 )

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         "/actuator/health",
                         "/swagger-ui/**",
                         "/core-docs",
+                        "/core-docs/",
                         "/v3/api-docs/**"     
                 ).permitAll()
                 .anyRequest().authenticated()

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -46,10 +46,10 @@ public class SecurityConfig {
                         "/actuator/health",
 
                         "/swagger-ui/**",
-                        "/core-docs",
+                        // "/core-docs",
                         "/core-docs/**",
-                        "/v3/api-docs/core/**",
-                        "/v3/api-docs/**"     
+                        "/v3/api-docs/core/**"
+                        // "/v3/api-docs/**"     
                 ).permitAll()
                 .anyRequest().authenticated()
                 )

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -45,9 +45,13 @@ public class SecurityConfig {
                         "/api/auth/refresh",
                         "/actuator/health",
                         "/swagger-ui/**",
+                        "/swagger-ui/index.html",
+                        "/webjars/**",
+                        "/core-docs/**",
                         "/core-docs",
                         "/core-docs/",
-                        "/v3/api-docs/**"     
+                        "/v3/api-docs/**",
+                        "/v3/api-docs/core"
                 ).permitAll()
                 .anyRequest().authenticated()
                 )

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -44,8 +44,11 @@ public class SecurityConfig {
                         "/oauth2/**",
                         "/api/auth/refresh",
                         "/actuator/health",
+
                         "/swagger-ui/**",
                         "/core-docs",
+                        "/core-docs/**",
+                        "/v3/api-docs/core/**",
                         "/v3/api-docs/**"     
                 ).permitAll()
                 .anyRequest().authenticated()

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -1,6 +1,6 @@
 server:
   port: 8080
-  forward-headers-strategy: framework
+  # forward-headers-strategy: framework
 
 spring:
   application:

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -96,7 +96,6 @@ sofly:
 springdoc:
   swagger-ui:
     path: /core-docs
-    disable-swagger-default-url: true
   api-docs:
     path: /v3/api-docs/core
 

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -96,6 +96,7 @@ sofly:
 springdoc:
   swagger-ui:
     path: /core-docs
+    disable-swagger-default-url: true
   api-docs:
     path: /v3/api-docs/core
 

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -95,9 +95,9 @@ sofly:
 
 springdoc:
   swagger-ui:
-    path: /core-docs
+    path: /core/swagger-ui
   api-docs:
-    path: /v3/api-docs/core
+    path: /core/v3/api-docs
 
 logging:
   exception-conversion-word: "%wEx{0}"

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -1,6 +1,6 @@
 server:
   port: 8080
-  # forward-headers-strategy: framework
+  forward-headers-strategy: framework
 
 spring:
   application:

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -6,6 +6,10 @@ spring:
   application:
     name: travel-core-service
 
+  web:
+    resource:
+      add-mappings: false
+      
   ai:
     google:
       genai:

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -6,10 +6,6 @@ spring:
   application:
     name: travel-core-service
 
-  web:
-    resource:
-      add-mappings: false
-      
   ai:
     google:
       genai:

--- a/services/travel-supply-service/src/main/resources/application.yaml
+++ b/services/travel-supply-service/src/main/resources/application.yaml
@@ -23,9 +23,9 @@ amadeus:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui
+    path: /supply/swagger-ui
   api-docs:
-    path: /v3/api-docs/supply
+    path: /supply/v3/api-docs
 
 google:
   places:

--- a/services/travel-supply-service/src/main/resources/application.yaml
+++ b/services/travel-supply-service/src/main/resources/application.yaml
@@ -25,7 +25,7 @@ springdoc:
   swagger-ui:
     path: /swagger-ui
   api-docs:
-    path: /v3/api-docs
+    path: /v3/api-docs/supply
 
 google:
   places:

--- a/services/travel-supply-service/src/main/resources/application.yaml
+++ b/services/travel-supply-service/src/main/resources/application.yaml
@@ -23,9 +23,10 @@ amadeus:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui
+    path: /supply-docs
+    disable-swagger-default-url: true
   api-docs:
-    path: /v3/api-docs
+    path: /v3/api-docs/supply
 
 google:
   places:

--- a/services/travel-supply-service/src/main/resources/application.yaml
+++ b/services/travel-supply-service/src/main/resources/application.yaml
@@ -23,9 +23,9 @@ amadeus:
 
 springdoc:
   swagger-ui:
-    path: /supply-docs
+    path: /swagger-ui
   api-docs:
-    path: /v3/api-docs/supply
+    path: /v3/api-docs
 
 google:
   places:

--- a/services/travel-supply-service/src/main/resources/application.yaml
+++ b/services/travel-supply-service/src/main/resources/application.yaml
@@ -24,7 +24,6 @@ amadeus:
 springdoc:
   swagger-ui:
     path: /supply-docs
-    disable-swagger-default-url: true
   api-docs:
     path: /v3/api-docs/supply
 


### PR DESCRIPTION
## 📌 PR 요약
Nginx location 블록 재구성 및 Swagger UI 라우팅 문제를 해결합니다.
Core, Supply 서비스의 Swagger를 각각 `/core/swagger-ui`, `/supply/swagger-ui` 경로로 분리하였으며, Github Actions를 통해 nginx 설정 파일을 자동 배포하는 workflow를 추가합니다.

## 🔧 변경 사항
- **Swagger 라우팅 구조 변경**
  - 기존 `/swagger-ui/`, `/v3/api-docs/` location 블록 제거
  - `/core/` 경로로 core 서비스 swagger 접근
  - `/supply/` 경로로 supply 서비스 swagger 접근
  - springdoc 리다이렉트 시 `/supply/`, `/core/` 경로를 유지하면서 nginx가 정확한 서비스로 라우팅하도록 구조 변경
- **springdoc 경로 변경**
  - core: `/core-docs` → `/core/swagger-ui`, `/v3/api-docs/core` → `/core/v3/api-docs`
  - supply: `/supply-docs` → `/supply/swagger-ui`, `/v3/api-docs/supply` → `/supply/v3/api-docs`
- **SecurityConfig 정리**
  - 기존 `/swagger-ui/**`, `/core-docs/**` 등 불필요한 permitAll 경로 제거
  - `/core/**` 단일 경로로 통일
- **Github Actions nginx 배포 workflow 추가**
  - `nginx/sofly.conf` 파일 변경 시 자동으로 서버에 배포
  - 파일 권한 자동 설정 (root:root 644)
  - nginx -t 문법 검사 후 reload

## 📋 작업 상세 내용
- [x] `nginx/sofly.conf` — location 블록 재구성 (`/core/`, `/supply/` 추가, `/swagger-ui/` 제거)
- [x] `core application-core.yaml` — springdoc 경로 `/core/swagger-ui`, `/core/v3/api-docs`로 변경
- [x] `supply application.yaml` — springdoc 경로 `/supply/swagger-ui`, `/supply/v3/api-docs`로 변경
- [x] `SecurityConfig` — `/core/**` 단일 경로로 permitAll 정리
- [x] `.github/nginx.yml` — nginx 설정 자동 배포 workflow 추가

## 🔗 관련 이슈
- closed #30 

## 📝 기타
- Swagger 접속 경로
  - Core: `https://api.sofly.co.kr/core/swagger-ui/index.html`
  - Supply: `https://api.sofly.co.kr/supply/swagger-ui/index.html`