### PR TITLE
Feat/34 workspace management

### DIFF
--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/code/WorkspaceErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/code/WorkspaceErrorCode.java
@@ -1,0 +1,23 @@
+package com.sofly.core.domain.workspace.code;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum WorkspaceErrorCode implements BaseErrorCode {
+
+    WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "WORKSPACE_001", "워크스페이스를 찾을 수 없습니다."),
+    WORKSPACE_FORBIDDEN(HttpStatus.FORBIDDEN, "WORKSPACE_002", "워크스페이스에 대한 권한이 없습니다."),
+    ALREADY_WORKSPACE_MEMBER(HttpStatus.CONFLICT, "WORKSPACE_003", "이미 워크스페이스 멤버입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "WORKSPACE_004", "멤버를 찾을 수 없습니다."),
+    INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "WORKSPACE_005", "유효하지 않은 초대 코드입니다."),
+    OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "WORKSPACE_006", "워크스페이스 소유자는 탈퇴할 수 없습니다."),
+    CANNOT_ASSIGN_OWNER_ROLE(HttpStatus.BAD_REQUEST, "WORKSPACE_007", "소유자 역할은 직접 변경할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceController.java
@@ -1,0 +1,214 @@
+package com.sofly.core.domain.workspace.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.sofly.core.domain.workspace.dto.request.*;
+import com.sofly.core.domain.workspace.dto.response.*;
+import com.sofly.core.domain.workspace.service.WorkspaceService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Workspace", description = "워크스페이스(여행 단위 공간)")
+@RestController
+@RequestMapping("/api/workspaces")
+@RequiredArgsConstructor
+public class WorkspaceController {
+
+    private final WorkspaceService workspaceService;
+
+    // ── 워크스페이스 CRUD ──────────────────────────────────────
+
+    @Operation(summary = "워크스페이스 생성", description = "새로운 워크스페이스(여행)를 생성합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<WorkspaceResponse>> createWorkspace(
+            @Valid @RequestBody CreateWorkspaceRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(workspaceService.createWorkspace(userId, request)));
+    }
+
+    @Operation(summary = "내 워크스페이스 목록 조회", description = "내가 소유하거나 참여 중인 워크스페이스 목록을 조회합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<WorkspaceResponse>>> getMyWorkspaces() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.getMyWorkspaces(userId)));
+    }
+
+    @Operation(summary = "워크스페이스 상세 조회", description = "워크스페이스 ID로 상세 정보를 조회합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @GetMapping("/{workspaceId}")
+    public ResponseEntity<ApiResponse<WorkspaceResponse>> getWorkspace(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.getWorkspace(userId, workspaceId)));
+    }
+
+    @Operation(summary = "워크스페이스 수정", description = "워크스페이스 정보를 수정합니다. 소유자만 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @PutMapping("/{workspaceId}")
+    public ResponseEntity<ApiResponse<WorkspaceResponse>> updateWorkspace(
+            @PathVariable Long workspaceId,
+            @Valid @RequestBody UpdateWorkspaceRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.updateWorkspace(userId, workspaceId, request)));
+    }
+
+    @Operation(summary = "워크스페이스 삭제", description = "워크스페이스를 삭제합니다. 소유자만 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @DeleteMapping("/{workspaceId}")
+    public ResponseEntity<Void> deleteWorkspace(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        workspaceService.deleteWorkspace(userId, workspaceId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 초대 / 공유 ────────────────────────────────────────────
+
+    @Operation(summary = "초대 코드 생성", description = "워크스페이스 초대 링크를 생성합니다. 소유자만 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "생성 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @PostMapping("/{workspaceId}/invite-code")
+    public ResponseEntity<ApiResponse<InviteCodeResponse>> generateInviteCode(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.generateInviteCode(userId, workspaceId)));
+    }
+
+    @Operation(summary = "초대 코드로 참여", description = "초대 코드를 통해 워크스페이스 멤버로 참여합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "참여 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 초대 코드"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 워크스페이스 멤버")
+    })
+    @PostMapping("/join/{inviteCode}")
+    public ResponseEntity<ApiResponse<WorkspaceResponse>> joinWorkspace(
+            @PathVariable String inviteCode) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.joinWorkspace(userId, inviteCode)));
+    }
+
+    // ── 멤버 관리 ──────────────────────────────────────────────
+
+    @Operation(summary = "멤버 목록 조회", description = "워크스페이스 멤버 목록을 조회합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @GetMapping("/{workspaceId}/members")
+    public ResponseEntity<ApiResponse<List<WorkspaceMemberResponse>>> getMembers(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.getMembers(userId, workspaceId)));
+    }
+
+    @Operation(summary = "멤버 역할 변경", description = "멤버의 역할을 변경합니다. 소유자만 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
+    })
+    @PatchMapping("/{workspaceId}/members/{memberId}/role")
+    public ResponseEntity<ApiResponse<WorkspaceMemberResponse>> updateMemberRole(
+            @PathVariable Long workspaceId,
+            @PathVariable Long memberId,
+            @Valid @RequestBody UpdateMemberRoleRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(
+                workspaceService.updateMemberRole(userId, workspaceId, memberId, request)));
+    }
+
+    @Operation(summary = "멤버 내보내기 / 탈퇴", description = "멤버를 내보내거나 본인이 직접 탈퇴합니다. 소유자는 탈퇴 불가합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "처리 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "소유자는 탈퇴 불가"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
+    })
+    @DeleteMapping("/{workspaceId}/members/{memberId}")
+    public ResponseEntity<Void> removeMember(
+            @PathVariable Long workspaceId,
+            @PathVariable Long memberId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        workspaceService.removeMember(userId, workspaceId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 항공편 저장 ────────────────────────────────────────────
+
+    @Operation(summary = "항공편 저장", description = "워크스페이스에 항공편을 저장합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "저장 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @PostMapping("/{workspaceId}/flights")
+    public ResponseEntity<ApiResponse<SavedFlightResponse>> saveFlight(
+            @PathVariable Long workspaceId,
+            @Valid @RequestBody SaveFlightRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(workspaceService.saveFlight(userId, workspaceId, request)));
+    }
+
+    @Operation(summary = "저장된 항공편 목록 조회", description = "워크스페이스에 저장된 항공편 목록을 조회합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @GetMapping("/{workspaceId}/flights")
+    public ResponseEntity<ApiResponse<List<SavedFlightResponse>>> getFlights(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.getFlights(userId, workspaceId)));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceController.java
@@ -6,8 +6,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.sofly.core.domain.workspace.dto.request.*;
-import com.sofly.core.domain.workspace.dto.response.*;
+import com.sofly.core.domain.workspace.dto.request.CreateWorkspaceRequest;
+import com.sofly.core.domain.workspace.dto.request.UpdateWorkspaceRequest;
+import com.sofly.core.domain.workspace.dto.response.WorkspaceResponse;
 import com.sofly.core.domain.workspace.service.WorkspaceService;
 import com.sofly.core.global.response.ApiResponse;
 import com.sofly.core.global.security.util.SecurityUtils;
@@ -18,15 +19,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "Workspace", description = "워크스페이스(여행 단위 공간)")
+@Tag(name = "Workspace", description = "워크스페이스 생성·관리")
 @RestController
 @RequestMapping("/api/workspaces")
 @RequiredArgsConstructor
 public class WorkspaceController {
 
     private final WorkspaceService workspaceService;
-
-    // ── 워크스페이스 CRUD ──────────────────────────────────────
 
     @Operation(summary = "워크스페이스 생성", description = "새로운 워크스페이스(여행)를 생성합니다.")
     @ApiResponses({
@@ -96,119 +95,5 @@ public class WorkspaceController {
         Long userId = SecurityUtils.getCurrentUserId();
         workspaceService.deleteWorkspace(userId, workspaceId);
         return ResponseEntity.noContent().build();
-    }
-
-    // ── 초대 / 공유 ────────────────────────────────────────────
-
-    @Operation(summary = "초대 코드 생성", description = "워크스페이스 초대 링크를 생성합니다. 소유자만 가능합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "생성 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
-    })
-    @PostMapping("/{workspaceId}/invite-code")
-    public ResponseEntity<ApiResponse<InviteCodeResponse>> generateInviteCode(
-            @PathVariable Long workspaceId) {
-        Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(ApiResponse.success(workspaceService.generateInviteCode(userId, workspaceId)));
-    }
-
-    @Operation(summary = "초대 코드로 참여", description = "초대 코드를 통해 워크스페이스 멤버로 참여합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "참여 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 초대 코드"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 워크스페이스 멤버")
-    })
-    @PostMapping("/join/{inviteCode}")
-    public ResponseEntity<ApiResponse<WorkspaceResponse>> joinWorkspace(
-            @PathVariable String inviteCode) {
-        Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(ApiResponse.success(workspaceService.joinWorkspace(userId, inviteCode)));
-    }
-
-    // ── 멤버 관리 ──────────────────────────────────────────────
-
-    @Operation(summary = "멤버 목록 조회", description = "워크스페이스 멤버 목록을 조회합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
-    })
-    @GetMapping("/{workspaceId}/members")
-    public ResponseEntity<ApiResponse<List<WorkspaceMemberResponse>>> getMembers(
-            @PathVariable Long workspaceId) {
-        Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(ApiResponse.success(workspaceService.getMembers(userId, workspaceId)));
-    }
-
-    @Operation(summary = "멤버 역할 변경", description = "멤버의 역할을 변경합니다. 소유자만 가능합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
-    })
-    @PatchMapping("/{workspaceId}/members/{memberId}/role")
-    public ResponseEntity<ApiResponse<WorkspaceMemberResponse>> updateMemberRole(
-            @PathVariable Long workspaceId,
-            @PathVariable Long memberId,
-            @Valid @RequestBody UpdateMemberRoleRequest request) {
-        Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(ApiResponse.success(
-                workspaceService.updateMemberRole(userId, workspaceId, memberId, request)));
-    }
-
-    @Operation(summary = "멤버 내보내기 / 탈퇴", description = "멤버를 내보내거나 본인이 직접 탈퇴합니다. 소유자는 탈퇴 불가합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "처리 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "소유자는 탈퇴 불가"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
-    })
-    @DeleteMapping("/{workspaceId}/members/{memberId}")
-    public ResponseEntity<Void> removeMember(
-            @PathVariable Long workspaceId,
-            @PathVariable Long memberId) {
-        Long userId = SecurityUtils.getCurrentUserId();
-        workspaceService.removeMember(userId, workspaceId, memberId);
-        return ResponseEntity.noContent().build();
-    }
-
-    // ── 항공편 저장 ────────────────────────────────────────────
-
-    @Operation(summary = "항공편 저장", description = "워크스페이스에 항공편을 저장합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "저장 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
-    })
-    @PostMapping("/{workspaceId}/flights")
-    public ResponseEntity<ApiResponse<SavedFlightResponse>> saveFlight(
-            @PathVariable Long workspaceId,
-            @Valid @RequestBody SaveFlightRequest request) {
-        Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(workspaceService.saveFlight(userId, workspaceId, request)));
-    }
-
-    @Operation(summary = "저장된 항공편 목록 조회", description = "워크스페이스에 저장된 항공편 목록을 조회합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
-    })
-    @GetMapping("/{workspaceId}/flights")
-    public ResponseEntity<ApiResponse<List<SavedFlightResponse>>> getFlights(
-            @PathVariable Long workspaceId) {
-        Long userId = SecurityUtils.getCurrentUserId();
-        return ResponseEntity.ok(ApiResponse.success(workspaceService.getFlights(userId, workspaceId)));
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceFlightController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceFlightController.java
@@ -1,0 +1,59 @@
+package com.sofly.core.domain.workspace.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.sofly.core.domain.workspace.dto.request.SaveFlightRequest;
+import com.sofly.core.domain.workspace.dto.response.SavedFlightResponse;
+import com.sofly.core.domain.workspace.service.WorkspaceService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Workspace Flight", description = "워크스페이스 항공편 저장·조회")
+@RestController
+@RequestMapping("/api/workspaces/{workspaceId}/flights")
+@RequiredArgsConstructor
+public class WorkspaceFlightController {
+
+    private final WorkspaceService workspaceService;
+
+    @Operation(summary = "항공편 저장", description = "워크스페이스에 항공편을 저장합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "저장 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<SavedFlightResponse>> saveFlight(
+            @PathVariable Long workspaceId,
+            @Valid @RequestBody SaveFlightRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(workspaceService.saveFlight(userId, workspaceId, request)));
+    }
+
+    @Operation(summary = "저장된 항공편 목록 조회", description = "워크스페이스에 저장된 항공편 목록을 조회합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SavedFlightResponse>>> getFlights(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.getFlights(userId, workspaceId)));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceInviteController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceInviteController.java
@@ -1,0 +1,52 @@
+package com.sofly.core.domain.workspace.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.sofly.core.domain.workspace.dto.response.InviteCodeResponse;
+import com.sofly.core.domain.workspace.dto.response.WorkspaceResponse;
+import com.sofly.core.domain.workspace.service.WorkspaceService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Workspace Invite", description = "워크스페이스 초대·공유")
+@RestController
+@RequestMapping("/api/workspaces")
+@RequiredArgsConstructor
+public class WorkspaceInviteController {
+
+    private final WorkspaceService workspaceService;
+
+    @Operation(summary = "초대 코드 생성", description = "워크스페이스 초대 링크를 생성합니다. 소유자만 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "생성 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @PostMapping("/{workspaceId}/invite-code")
+    public ResponseEntity<ApiResponse<InviteCodeResponse>> generateInviteCode(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.generateInviteCode(userId, workspaceId)));
+    }
+
+    @Operation(summary = "초대 코드로 참여", description = "초대 코드를 통해 워크스페이스 멤버로 참여합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "참여 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 초대 코드"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 워크스페이스 멤버")
+    })
+    @PostMapping("/join/{inviteCode}")
+    public ResponseEntity<ApiResponse<WorkspaceResponse>> joinWorkspace(
+            @PathVariable String inviteCode) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.joinWorkspace(userId, inviteCode)));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceMemberController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/controller/WorkspaceMemberController.java
@@ -1,0 +1,76 @@
+package com.sofly.core.domain.workspace.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.sofly.core.domain.workspace.dto.request.UpdateMemberRoleRequest;
+import com.sofly.core.domain.workspace.dto.response.WorkspaceMemberResponse;
+import com.sofly.core.domain.workspace.service.WorkspaceService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Workspace Member", description = "워크스페이스 멤버 관리")
+@RestController
+@RequestMapping("/api/workspaces/{workspaceId}/members")
+@RequiredArgsConstructor
+public class WorkspaceMemberController {
+
+    private final WorkspaceService workspaceService;
+
+    @Operation(summary = "멤버 목록 조회", description = "워크스페이스 멤버 목록을 조회합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<WorkspaceMemberResponse>>> getMembers(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(workspaceService.getMembers(userId, workspaceId)));
+    }
+
+    @Operation(summary = "멤버 역할 변경", description = "멤버의 역할을 변경합니다. 소유자만 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "소유자가 아님"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
+    })
+    @PatchMapping("/{memberId}/role")
+    public ResponseEntity<ApiResponse<WorkspaceMemberResponse>> updateMemberRole(
+            @PathVariable Long workspaceId,
+            @PathVariable Long memberId,
+            @Valid @RequestBody UpdateMemberRoleRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(
+                workspaceService.updateMemberRole(userId, workspaceId, memberId, request)));
+    }
+
+    @Operation(summary = "멤버 내보내기 / 탈퇴", description = "멤버를 내보내거나 본인이 직접 탈퇴합니다. 소유자는 탈퇴 불가합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "처리 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "소유자는 탈퇴 불가"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "멤버를 찾을 수 없음")
+    })
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> removeMember(
+            @PathVariable Long workspaceId,
+            @PathVariable Long memberId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        workspaceService.removeMember(userId, workspaceId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/CreateWorkspaceRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/CreateWorkspaceRequest.java
@@ -1,0 +1,29 @@
+package com.sofly.core.domain.workspace.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class CreateWorkspaceRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String destination;
+
+    private String countryCode;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotNull
+    private LocalDate endDate;
+
+    private Integer headcount;
+
+    private String coverImageUrl;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/SaveFlightRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/SaveFlightRequest.java
@@ -1,0 +1,37 @@
+package com.sofly.core.domain.workspace.dto.request;
+
+import com.sofly.core.domain.workspace.entity.SavedFlight.FlightType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SaveFlightRequest {
+
+    @NotBlank
+    private String flightNumber;
+
+    @NotBlank
+    private String airline;
+
+    @NotBlank
+    private String departureAirport;
+
+    @NotBlank
+    private String arrivalAirport;
+
+    @NotNull
+    private LocalDateTime departureTime;
+
+    @NotNull
+    private LocalDateTime arrivalTime;
+
+    private String duration;
+
+    private Integer price;
+
+    @NotNull
+    private FlightType flightType;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/UpdateMemberRoleRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/UpdateMemberRoleRequest.java
@@ -1,0 +1,12 @@
+package com.sofly.core.domain.workspace.dto.request;
+
+import com.sofly.core.domain.workspace.entity.WorkspaceMember.MemberRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateMemberRoleRequest {
+
+    @NotNull
+    private MemberRole role;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/UpdateWorkspaceRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/UpdateWorkspaceRequest.java
@@ -1,0 +1,27 @@
+package com.sofly.core.domain.workspace.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class UpdateWorkspaceRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String destination;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotNull
+    private LocalDate endDate;
+
+    private Integer headcount;
+
+    private String coverImageUrl;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/InviteCodeResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/InviteCodeResponse.java
@@ -1,0 +1,19 @@
+package com.sofly.core.domain.workspace.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InviteCodeResponse {
+
+    private String inviteCode;
+    private String inviteUrl;
+
+    public static InviteCodeResponse of(String inviteCode, String baseUrl) {
+        return InviteCodeResponse.builder()
+                .inviteCode(inviteCode)
+                .inviteUrl(baseUrl + "/workspaces/join/" + inviteCode)
+                .build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/SavedFlightResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/SavedFlightResponse.java
@@ -1,0 +1,39 @@
+package com.sofly.core.domain.workspace.dto.response;
+
+import com.sofly.core.domain.workspace.entity.SavedFlight;
+import com.sofly.core.domain.workspace.entity.SavedFlight.FlightType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SavedFlightResponse {
+
+    private Long id;
+    private String flightNumber;
+    private String airline;
+    private String departureAirport;
+    private String arrivalAirport;
+    private LocalDateTime departureTime;
+    private LocalDateTime arrivalTime;
+    private String duration;
+    private Integer price;
+    private FlightType flightType;
+
+    public static SavedFlightResponse from(SavedFlight flight) {
+        return SavedFlightResponse.builder()
+                .id(flight.getId())
+                .flightNumber(flight.getFlightNumber())
+                .airline(flight.getAirline())
+                .departureAirport(flight.getDepartureAirport())
+                .arrivalAirport(flight.getArrivalAirport())
+                .departureTime(flight.getDepartureTime())
+                .arrivalTime(flight.getArrivalTime())
+                .duration(flight.getDuration())
+                .price(flight.getPrice())
+                .flightType(flight.getFlightType())
+                .build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/WorkspaceMemberResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/WorkspaceMemberResponse.java
@@ -1,0 +1,27 @@
+package com.sofly.core.domain.workspace.dto.response;
+
+import com.sofly.core.domain.workspace.entity.WorkspaceMember;
+import com.sofly.core.domain.workspace.entity.WorkspaceMember.MemberRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WorkspaceMemberResponse {
+
+    private Long memberId;
+    private Long userId;
+    private String nickname;       // name → nickname
+    private String userEmail;
+    private MemberRole role;
+
+    public static WorkspaceMemberResponse from(WorkspaceMember member) {
+        return WorkspaceMemberResponse.builder()
+                .memberId(member.getId())
+                .userId(member.getUser().getId())
+                .nickname(member.getUser().getNickname()) // getNickname()으로 수정
+                .userEmail(member.getUser().getEmail())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/WorkspaceResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/WorkspaceResponse.java
@@ -1,0 +1,38 @@
+package com.sofly.core.domain.workspace.dto.response;
+
+import com.sofly.core.domain.workspace.entity.Workspace;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class WorkspaceResponse {
+
+    private Long id;
+    private String title;
+    private String destination;
+    private String countryCode;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer headcount;
+    private String coverImageUrl;
+    private Long ownerId;
+    private int memberCount;
+
+    public static WorkspaceResponse from(Workspace workspace) {
+        return WorkspaceResponse.builder()
+                .id(workspace.getId())
+                .title(workspace.getTitle())
+                .destination(workspace.getDestination())
+                .countryCode(workspace.getCountryCode())
+                .startDate(workspace.getStartDate())
+                .endDate(workspace.getEndDate())
+                .headcount(workspace.getHeadcount())
+                .coverImageUrl(workspace.getCoverImageUrl())
+                .ownerId(workspace.getOwner().getId())
+                .memberCount(workspace.getMembers().size())
+                .build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/exception/WorkspaceException.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/exception/WorkspaceException.java
@@ -1,0 +1,15 @@
+package com.sofly.core.domain.workspace.exception;
+
+import com.sofly.core.domain.workspace.code.WorkspaceErrorCode;
+import lombok.Getter;
+
+@Getter
+public class WorkspaceException extends RuntimeException {
+
+    private final WorkspaceErrorCode errorCode;
+
+    public WorkspaceException(WorkspaceErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/exception/WorkspaceException.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/exception/WorkspaceException.java
@@ -1,15 +1,21 @@
 package com.sofly.core.domain.workspace.exception;
 
-import com.sofly.core.domain.workspace.code.WorkspaceErrorCode;
+import com.sofly.core.global.response.code.BaseErrorCode;
+
 import lombok.Getter;
 
 @Getter
 public class WorkspaceException extends RuntimeException {
 
-    private final WorkspaceErrorCode errorCode;
+    private final BaseErrorCode errorCode;
 
-    public WorkspaceException(WorkspaceErrorCode errorCode) {
+    public WorkspaceException(BaseErrorCode errorCode) {
         super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+    
+    public WorkspaceException(BaseErrorCode errorCode, String customMessage){
+        super(customMessage);
         this.errorCode = errorCode;
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/SavedFlightRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/SavedFlightRepository.java
@@ -1,0 +1,13 @@
+package com.sofly.core.domain.workspace.repository;
+
+import com.sofly.core.domain.workspace.entity.SavedFlight;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SavedFlightRepository extends JpaRepository<SavedFlight, Long> {
+
+    List<SavedFlight> findAllByWorkspaceId(Long workspaceId);
+
+    List<SavedFlight> findAllByWorkspaceIdAndFlightType(Long workspaceId, SavedFlight.FlightType flightType);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
@@ -6,19 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
 
     boolean existsByWorkspaceIdAndUserId(Long workspaceId, Long userId);
 
-    Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
-
-    List<WorkspaceMember> findAllByUserId(Long userId);
-
-    List<WorkspaceMember> findAllByWorkspaceId(Long workspaceId); // 추가
-
-    // wm.userId → wm.user.id 로 수정 (연관관계 필드)
-    @Query("SELECT wm FROM WorkspaceMember wm JOIN FETCH wm.workspace WHERE wm.user.id = :userId")
-    List<WorkspaceMember> findAllWithWorkspaceByUserId(@Param("userId") Long userId);
+    // 기존 findAllByWorkspaceId 삭제하고 아래로 교체
+    @Query("SELECT wm FROM WorkspaceMember wm JOIN FETCH wm.user WHERE wm.workspace.id = :workspaceId")
+    List<WorkspaceMember> findAllWithUserByWorkspaceId(@Param("workspaceId") Long workspaceId);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
@@ -1,0 +1,24 @@
+package com.sofly.core.domain.workspace.repository;
+
+import com.sofly.core.domain.workspace.entity.WorkspaceMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
+
+    boolean existsByWorkspaceIdAndUserId(Long workspaceId, Long userId);
+
+    Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
+
+    List<WorkspaceMember> findAllByUserId(Long userId);
+
+    List<WorkspaceMember> findAllByWorkspaceId(Long workspaceId); // 추가
+
+    // wm.userId → wm.user.id 로 수정 (연관관계 필드)
+    @Query("SELECT wm FROM WorkspaceMember wm JOIN FETCH wm.workspace WHERE wm.user.id = :userId")
+    List<WorkspaceMember> findAllWithWorkspaceByUserId(@Param("userId") Long userId);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
@@ -1,11 +1,24 @@
 package com.sofly.core.domain.workspace.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.sofly.core.domain.workspace.entity.Workspace;
 
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
-    Optional<Workspace> findByInviteCode(String inviteCode); // 초대 코드 조회용
+
+    @Query("SELECT w FROM Workspace w JOIN FETCH w.owner WHERE w.inviteCode = :inviteCode")
+    Optional<Workspace> findWithOwnerByInviteCode(@Param("inviteCode") String inviteCode);
+
+    @Query("SELECT w FROM Workspace w JOIN FETCH w.owner WHERE w.id = :workspaceId")
+    Optional<Workspace> findWithOwnerById(@Param("workspaceId") Long workspaceId);
+
+    @Query("SELECT DISTINCT wm.workspace FROM WorkspaceMember wm " +
+           "JOIN FETCH wm.workspace.owner " +
+           "WHERE wm.user.id = :userId")
+    List<Workspace> findAllWithOwnerByUserId(@Param("userId") Long userId);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
@@ -1,8 +1,11 @@
 package com.sofly.core.domain.workspace.repository;
 
-import com.sofly.core.domain.workspace.entity.Workspace;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
+import com.sofly.core.domain.workspace.entity.Workspace;
 
+public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
+    Optional<Workspace> findByInviteCode(String inviteCode); // 초대 코드 조회용
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
@@ -1,0 +1,250 @@
+package com.sofly.core.domain.workspace.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.repository.UserRepository;
+import com.sofly.core.domain.workspace.code.WorkspaceErrorCode;
+import com.sofly.core.domain.workspace.dto.request.CreateWorkspaceRequest;
+import com.sofly.core.domain.workspace.dto.request.SaveFlightRequest;
+import com.sofly.core.domain.workspace.dto.request.UpdateMemberRoleRequest;
+import com.sofly.core.domain.workspace.dto.request.UpdateWorkspaceRequest;
+import com.sofly.core.domain.workspace.dto.response.InviteCodeResponse;
+import com.sofly.core.domain.workspace.dto.response.SavedFlightResponse;
+import com.sofly.core.domain.workspace.dto.response.WorkspaceMemberResponse;
+import com.sofly.core.domain.workspace.dto.response.WorkspaceResponse;
+import com.sofly.core.domain.workspace.entity.SavedFlight;
+import com.sofly.core.domain.workspace.entity.Workspace;
+import com.sofly.core.domain.workspace.entity.WorkspaceMember;
+import com.sofly.core.domain.workspace.entity.WorkspaceMember.MemberRole;
+import com.sofly.core.domain.workspace.exception.WorkspaceException;
+import com.sofly.core.domain.workspace.repository.SavedFlightRepository;
+import com.sofly.core.domain.workspace.repository.WorkspaceMemberRepository;
+import com.sofly.core.domain.workspace.repository.WorkspaceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WorkspaceService {
+
+    private final WorkspaceRepository workspaceRepository;
+    private final WorkspaceMemberRepository workspaceMemberRepository;
+    private final SavedFlightRepository savedFlightRepository;
+    private final UserRepository userRepository;
+
+    @Value("${sofly.oauth2.redirect-uri}")
+    private String baseUrl;
+
+    // ── 워크스페이스 생성 ──────────────────────────────────────
+
+    @Transactional
+    public WorkspaceResponse createWorkspace(Long userId, CreateWorkspaceRequest request) {
+        User owner = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        Workspace workspace = Workspace.builder()
+                .title(request.getTitle())
+                .destination(request.getDestination())
+                .countryCode(request.getCountryCode())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .headcount(request.getHeadcount())
+                .coverImageUrl(request.getCoverImageUrl())
+                .owner(owner)
+                .build();
+
+        // 소유자를 멤버 목록에도 OWNER로 등록
+        WorkspaceMember ownerMember = WorkspaceMember.ofOwner(workspace, owner);
+        workspace.addMember(ownerMember);
+
+        workspaceRepository.save(workspace);
+        return WorkspaceResponse.from(workspace);
+    }
+
+    // ── 내 워크스페이스 목록 조회 ──────────────────────────────
+
+    public List<WorkspaceResponse> getMyWorkspaces(Long userId) {
+        return workspaceMemberRepository.findAllByUserId(userId).stream()
+                .map(WorkspaceMember::getWorkspace)
+                .map(WorkspaceResponse::from)
+                .toList();
+    }
+
+    // ── 워크스페이스 단건 조회 ─────────────────────────────────
+
+    public WorkspaceResponse getWorkspace(Long userId, Long workspaceId) {
+        Workspace workspace = findWorkspaceById(workspaceId);
+        validateMember(workspaceId, userId);
+        return WorkspaceResponse.from(workspace);
+    }
+
+    // ── 워크스페이스 수정 ──────────────────────────────────────
+
+    @Transactional
+    public WorkspaceResponse updateWorkspace(Long userId, Long workspaceId, UpdateWorkspaceRequest request) {
+        Workspace workspace = findWorkspaceById(workspaceId);
+        validateOwner(workspace, userId);
+
+        workspace.update(
+                request.getTitle(),
+                request.getDestination(),
+                request.getStartDate(),
+                request.getEndDate(),
+                request.getHeadcount(),
+                request.getCoverImageUrl()
+        );
+
+        return WorkspaceResponse.from(workspace);
+    }
+
+    // ── 워크스페이스 삭제 ──────────────────────────────────────
+
+    @Transactional
+    public void deleteWorkspace(Long userId, Long workspaceId) {
+        Workspace workspace = findWorkspaceById(workspaceId);
+        validateOwner(workspace, userId);
+        workspaceRepository.delete(workspace);
+    }
+
+    // ── 초대 코드 생성 ─────────────────────────────────────────
+
+    @Transactional
+    public InviteCodeResponse generateInviteCode(Long userId, Long workspaceId) {
+        Workspace workspace = findWorkspaceById(workspaceId);
+        validateOwner(workspace, userId);
+
+        String code = UUID.randomUUID().toString();
+        workspace.generateInviteCode(code);
+
+        return InviteCodeResponse.of(code, baseUrl);
+    }
+
+    // ── 초대 코드로 멤버 가입 ──────────────────────────────────
+
+    @Transactional
+    public WorkspaceResponse joinWorkspace(Long userId, String inviteCode) {
+        Workspace workspace = workspaceRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.INVALID_INVITE_CODE));
+
+        if (workspaceMemberRepository.existsByWorkspaceIdAndUserId(workspace.getId(), userId)) {
+            throw new WorkspaceException(WorkspaceErrorCode.ALREADY_WORKSPACE_MEMBER);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.MEMBER_NOT_FOUND));
+
+        WorkspaceMember newMember = WorkspaceMember.ofViewer(workspace, user);
+        workspace.addMember(newMember);
+
+        return WorkspaceResponse.from(workspace);
+    }
+
+    // ── 멤버 목록 조회 ─────────────────────────────────────────
+
+    public List<WorkspaceMemberResponse> getMembers(Long userId, Long workspaceId) {
+        validateMember(workspaceId, userId);
+        return workspaceMemberRepository.findAllByWorkspaceId(workspaceId).stream()
+                .map(WorkspaceMemberResponse::from)
+                .toList();
+    }
+
+    // ── 멤버 역할 변경 ─────────────────────────────────────────
+
+    @Transactional
+    public WorkspaceMemberResponse updateMemberRole(Long userId, Long workspaceId,
+                                                    Long memberId, UpdateMemberRoleRequest request) {
+        Workspace workspace = findWorkspaceById(workspaceId);
+        validateOwner(workspace, userId);
+
+        if (request.getRole() == MemberRole.OWNER) {
+            throw new WorkspaceException(WorkspaceErrorCode.CANNOT_ASSIGN_OWNER_ROLE);
+        }
+
+        WorkspaceMember member = workspaceMemberRepository.findById(memberId)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.MEMBER_NOT_FOUND));
+
+        member.updateRole(request.getRole());
+        return WorkspaceMemberResponse.from(member);
+    }
+
+    // ── 멤버 내보내기 / 탈퇴 ──────────────────────────────────
+
+    @Transactional
+    public void removeMember(Long userId, Long workspaceId, Long memberId) {
+        Workspace workspace = findWorkspaceById(workspaceId);
+
+        WorkspaceMember target = workspaceMemberRepository.findById(memberId)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.MEMBER_NOT_FOUND));
+
+        boolean isSelf = target.getUser().getId().equals(userId);
+        boolean isOwner = workspace.isOwner(userId);
+
+        if (isSelf && isOwner) {
+            throw new WorkspaceException(WorkspaceErrorCode.OWNER_CANNOT_LEAVE);
+        }
+        if (!isSelf && !isOwner) {
+            throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_FORBIDDEN);
+        }
+
+        workspaceMemberRepository.delete(target);
+    }
+
+    // ── 항공편 저장 ────────────────────────────────────────────
+
+    @Transactional
+    public SavedFlightResponse saveFlight(Long userId, Long workspaceId, SaveFlightRequest request) {
+        Workspace workspace = findWorkspaceById(workspaceId);
+        validateMember(workspaceId, userId);
+
+        SavedFlight flight = SavedFlight.builder()
+                .workspace(workspace)
+                .flightNumber(request.getFlightNumber())
+                .airline(request.getAirline())
+                .departureAirport(request.getDepartureAirport())
+                .arrivalAirport(request.getArrivalAirport())
+                .departureTime(request.getDepartureTime())
+                .arrivalTime(request.getArrivalTime())
+                .duration(request.getDuration())
+                .price(request.getPrice())
+                .flightType(request.getFlightType())
+                .build();
+
+        savedFlightRepository.save(flight);
+        return SavedFlightResponse.from(flight);
+    }
+
+    // ── 항공편 목록 조회 ───────────────────────────────────────
+
+    public List<SavedFlightResponse> getFlights(Long userId, Long workspaceId) {
+        validateMember(workspaceId, userId);
+        return savedFlightRepository.findAllByWorkspaceId(workspaceId).stream()
+                .map(SavedFlightResponse::from)
+                .toList();
+    }
+
+    // ── 내부 헬퍼 ─────────────────────────────────────────────
+
+    private Workspace findWorkspaceById(Long workspaceId) {
+        return workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
+    }
+
+    private void validateOwner(Workspace workspace, Long userId) {
+        if (!workspace.isOwner(userId)) {
+            throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_FORBIDDEN);
+        }
+    }
+
+    private void validateMember(Long workspaceId, Long userId) {
+        if (!workspaceMemberRepository.existsByWorkspaceIdAndUserId(workspaceId, userId)) {
+            throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_FORBIDDEN);
+        }
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
@@ -73,13 +73,12 @@ public class WorkspaceService {
     // ── 내 워크스페이스 목록 조회 ──────────────────────────────
 
     public List<WorkspaceResponse> getMyWorkspaces(Long userId) {
-        return workspaceMemberRepository.findAllByUserId(userId).stream()
-                .map(WorkspaceMember::getWorkspace)
+        return workspaceRepository.findAllWithOwnerByUserId(userId).stream()
                 .map(WorkspaceResponse::from)
                 .toList();
     }
 
-    // ── 워크스페이스 단건 조회 ─────────────────────────────────
+    // ── 워크스페이스 상세 조회 ─────────────────────────────────
 
     public WorkspaceResponse getWorkspace(Long userId, Long workspaceId) {
         Workspace workspace = findWorkspaceById(workspaceId);
@@ -132,7 +131,7 @@ public class WorkspaceService {
 
     @Transactional
     public WorkspaceResponse joinWorkspace(Long userId, String inviteCode) {
-        Workspace workspace = workspaceRepository.findByInviteCode(inviteCode)
+        Workspace workspace = workspaceRepository.findWithOwnerByInviteCode(inviteCode)
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.INVALID_INVITE_CODE));
 
         if (workspaceMemberRepository.existsByWorkspaceIdAndUserId(workspace.getId(), userId)) {
@@ -153,7 +152,7 @@ public class WorkspaceService {
     public List<WorkspaceMemberResponse> getMembers(Long userId, Long workspaceId) {
         findWorkspaceById(workspaceId);
         validateMember(workspaceId, userId);
-        return workspaceMemberRepository.findAllByWorkspaceId(workspaceId).stream()
+        return workspaceMemberRepository.findAllWithUserByWorkspaceId(workspaceId).stream()
                 .map(WorkspaceMemberResponse::from)
                 .toList();
     }
@@ -236,7 +235,7 @@ public class WorkspaceService {
     // ── 내부 헬퍼 ─────────────────────────────────────────────
 
     private Workspace findWorkspaceById(Long workspaceId) {
-        return workspaceRepository.findById(workspaceId)
+        return workspaceRepository.findWithOwnerById(workspaceId)
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
     }
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
@@ -7,7 +7,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sofly.core.domain.user.code.UserErrorCode;
 import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.exception.UserException;
 import com.sofly.core.domain.user.repository.UserRepository;
 import com.sofly.core.domain.workspace.code.WorkspaceErrorCode;
 import com.sofly.core.domain.workspace.dto.request.CreateWorkspaceRequest;
@@ -47,7 +49,7 @@ public class WorkspaceService {
     @Transactional
     public WorkspaceResponse createWorkspace(Long userId, CreateWorkspaceRequest request) {
         User owner = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         Workspace workspace = Workspace.builder()
                 .title(request.getTitle())
@@ -149,6 +151,7 @@ public class WorkspaceService {
     // ── 멤버 목록 조회 ─────────────────────────────────────────
 
     public List<WorkspaceMemberResponse> getMembers(Long userId, Long workspaceId) {
+        findWorkspaceById(workspaceId);
         validateMember(workspaceId, userId);
         return workspaceMemberRepository.findAllByWorkspaceId(workspaceId).stream()
                 .map(WorkspaceMemberResponse::from)
@@ -223,6 +226,7 @@ public class WorkspaceService {
     // ── 항공편 목록 조회 ───────────────────────────────────────
 
     public List<SavedFlightResponse> getFlights(Long userId, Long workspaceId) {
+        findWorkspaceById(workspaceId);
         validateMember(workspaceId, userId);
         return savedFlightRepository.findAllByWorkspaceId(workspaceId).stream()
                 .map(SavedFlightResponse::from)

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
@@ -8,7 +8,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.sofly.core.domain.user.exception.UserException;
+import com.sofly.core.domain.workspace.exception.WorkspaceException;
 import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.response.code.BaseErrorCode;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,6 +24,25 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleSoflyException(SoflyException e) {
         log.warn("SoflyException: {}", e.getMessage());
         ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getMessage()));
+    }
+
+    // GlobalExceptionHandler에 추가
+    @ExceptionHandler(WorkspaceException.class)
+    public ResponseEntity<ApiResponse<Void>> handleWorkspaceException(WorkspaceException e) {
+        log.warn("WorkspaceException: {}", e.getMessage());
+        BaseErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserProfileException(UserException e) {
+        log.warn("UserException: {}", e.getMessage());
+        BaseErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode.getMessage()));

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SwaggerConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SwaggerConfig.java
@@ -1,5 +1,8 @@
 package com.sofly.core.global.security;
 
+import java.util.List;
+
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,6 +12,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.tags.Tag;
 
 @Configuration
 public class SwaggerConfig {
@@ -30,5 +34,17 @@ public class SwaggerConfig {
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")));
+    }
+
+    @Bean
+    public OpenApiCustomizer tagsOrderCustomizer() {
+        return openApi -> openApi.setTags(List.of(
+                new Tag().name("Auth").description("인증 관련 API"),
+                new Tag().name("UserProfile").description("프로필"),
+                new Tag().name("Workspace").description("워크스페이스 생성·관리"),
+                new Tag().name("Workspace Invite").description("워크스페이스 초대·공유"),
+                new Tag().name("Workspace Member").description("워크스페이스 멤버 관리"),
+                new Tag().name("Workspace Flight").description("워크스페이스 항공편 저장·조회")
+        ));
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SwaggerConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SwaggerConfig.java
@@ -44,7 +44,9 @@ public class SwaggerConfig {
                 new Tag().name("Workspace").description("워크스페이스 생성·관리"),
                 new Tag().name("Workspace Invite").description("워크스페이스 초대·공유"),
                 new Tag().name("Workspace Member").description("워크스페이스 멤버 관리"),
-                new Tag().name("Workspace Flight").description("워크스페이스 항공편 저장·조회")
+                new Tag().name("Workspace Flight").description("워크스페이스 항공편 저장·조회"),
+                new Tag().name("Chat").description("AI 여행 플래너 채팅"),
+                new Tag().name("Schedule").description("일정 관리 API")
         ));
     }
 }

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -96,6 +96,8 @@ sofly:
 springdoc:
   swagger-ui:
     path: /core/swagger-ui
+    tags-sorter: list
+    operations-sorter: list 
   api-docs:
     path: /core/v3/api-docs
 


### PR DESCRIPTION
## 📌 PR 요약
FR-030, FR-031 기반 워크스페이스 도메인 전체 구현 및 Swagger 문서 정렬 설정

## 🔧 변경 사항
- 워크스페이스 생성·관리, 초대/공유, 멤버 관리, 항공편 저장 기능 신규 구현
- 도메인별 예외 코드 패턴 적용 (`WorkspaceErrorCode`, `WorkspaceException`)
- Controller를 역할별로 4개 파일로 분리하여 응집도 향상 및 Swagger 문서 가독성 개선
- `OpenApiCustomizer`를 통해 Swagger 태그 노출 순서 고정

## 📋 작업 상세 내용
- [x] Repository 구현 (`WorkspaceRepository`, `WorkspaceMemberRepository`, `SavedFlightRepository`)
- [x] Request / Response DTO 구현
- [x] `WorkspaceErrorCode`, `WorkspaceSuccessCode`, `WorkspaceException` 구현
- [x] `WorkspaceService` 비즈니스 로직 구현
  - [x] 워크스페이스 CRUD
  - [x] 초대 코드 생성 및 멤버 가입 플로우
  - [x] 멤버 역할 변경 / 내보내기 / 탈퇴
  - [x] 항공편 저장 및 조회
- [x] Controller 4개로 분리 (`WorkspaceController`, `WorkspaceInviteController`, `WorkspaceMemberController`, `WorkspaceFlightController`)
- [x] 각 Controller Swagger 문서 작성
- [x] `SwaggerConfig`에 `OpenApiCustomizer` 추가로 태그 순서 고정
- [x] `application.yml` springdoc 정렬 옵션 추가 (`tags-sorter: list`)
- [x] `application.yml` 초대 링크용 `sofly.base-url` 추가

## 🔗 관련 이슈
- closed #34 
- closed #35 
## 📝 기타
- `WorkspaceMember` 생성 시 `ofOwner()`, `ofViewer()` 팩토리 메서드 활용
- OWNER 역할로의 직접 변경 및 OWNER 본인 탈퇴는 방어 로직으로 막아둠
- 초대 링크 형식: `{sofly.base-url}/workspaces/join/{inviteCode}` (UUID 기반)
- `User.getName()` → `User.getNickname()` 필드명 불일치 수정 포함