### PR TITLE
feat: Booking.com RapidAPI 호텔 검색 공급자 어댑터 구현 및 헥사고날 아키텍처 개선

### DIFF
--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/FlightSearchController.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/FlightSearchController.java
@@ -48,7 +48,7 @@ public class FlightSearchController {
     @Operation(summary = "항공편 검색", description = "공급자(supplier)를 선택하여 항공편 오퍼를 검색합니다. 기본값: amadeus")
     @GetMapping("/offers")
     public JsonNode offers(
-            @Parameter(description = "공급자 키 (amadeus | booking)", example = "amadeus")
+            @Parameter(description = "공급자 키 (amadeus | booking)", example = "booking")
             @RequestParam(required = false) String supplier,
             @ParameterObject @ModelAttribute FlightSearchRequest request
     ) {

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/FlightSearchController.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/FlightSearchController.java
@@ -1,6 +1,7 @@
 package com.sofly.supply.adapter.inbound.rest;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.application.dto.FlightDestination;
 import com.sofly.supply.application.dto.FlightSearchRequest;
 import com.sofly.supply.application.service.FlightSearchService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
 import java.beans.PropertyEditorSupport;
+import java.util.List;
 
 @Tag(name = "Flight Search", description = "항공편 검색 API")
 @RestController
@@ -45,7 +47,7 @@ public class FlightSearchController {
         });
     }
 
-    @Operation(summary = "항공편 검색", description = "공급자(supplier)를 선택하여 항공편 오퍼를 검색합니다. 기본값: amadeus")
+    @Operation(summary = "항공편 검색", description = "공급자(supplier)를 선택하여 항공편 오퍼를 검색합니다. 기본값: booking")
     @GetMapping("/offers")
     public JsonNode offers(
             @Parameter(description = "공급자 키 (amadeus | booking)", example = "booking")
@@ -53,5 +55,16 @@ public class FlightSearchController {
             @ParameterObject @ModelAttribute FlightSearchRequest request
     ) {
         return flightSearchService.search(supplier, request);
+    }
+
+    @Operation(summary = "공항 검색", description = "항공 검색을 하기 위해 필요한 공항 id를 받을 수 있음")
+    @GetMapping("/destinations")
+    public List<FlightDestination> searchDestination(
+            @Parameter(description = "검색어 (Names of airport, locations, cities, districts, places, countries, counties etc)", example = "korea")
+            @RequestParam String query,
+            @Parameter(description = "언어 선택", example = "en-us")
+            @RequestParam String languageCode
+    ){
+        return flightSearchService.searchDestination(query, languageCode);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/GooglePlacesController.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/GooglePlacesController.java
@@ -1,7 +1,7 @@
 package com.sofly.supply.adapter.inbound.rest;
 
 import com.sofly.supply.adapter.outbound.google.GooglePlacesClient;
-import com.sofly.supply.adapter.outbound.google.PlaceInfo;
+import com.sofly.supply.application.dto.PlaceInfo;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
@@ -1,8 +1,8 @@
 package com.sofly.supply.adapter.inbound.rest;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.sofly.supply.adapter.outbound.google.PlaceInfo;
 import com.sofly.supply.application.dto.HotelDestination;
+import com.sofly.supply.application.dto.PlaceInfo;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.dto.HotelSortOption;
@@ -76,6 +76,7 @@ public class HotelSearchController {
         return hotelSearchService.getFilter(request);
     }
 
+    @Operation(summary = "호텔 장소 정보 조회", description = "Google Places API로 호텔의 평점과 리뷰 수를 조회합니다.")
     @GetMapping("/place-info")
     public PlaceInfo placeInfo(
             @RequestParam String hotelName,

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
@@ -1,12 +1,24 @@
 package com.sofly.supply.adapter.inbound.rest;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.adapter.outbound.google.PlaceInfo;
-import com.sofly.supply.application.dto.HotelSearchResult;
+import com.sofly.supply.application.dto.HotelDestination;
+import com.sofly.supply.application.dto.HotelOptionsRequest;
+import com.sofly.supply.application.dto.HotelSearchRequest;
+import com.sofly.supply.application.dto.HotelSortOption;
 import com.sofly.supply.application.service.HotelSearchService;
-import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.*;
 
+import java.beans.PropertyEditorSupport;
+
+@Tag(name = "Hotel Search", description = "호텔 검색 API")
 @RestController
 @RequestMapping("/supply/hotels")
 public class HotelSearchController {
@@ -17,16 +29,51 @@ public class HotelSearchController {
         this.hotelSearchService = hotelSearchService;
     }
 
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.registerCustomEditor(HotelSearchRequest.Units.class, new PropertyEditorSupport() {
+            @Override
+            public void setAsText(String text) {
+                setValue(text == null || text.isBlank() ? null : HotelSearchRequest.Units.valueOf(text.toUpperCase()));
+            }
+        });
+        binder.registerCustomEditor(HotelSearchRequest.TemperatureUnit.class, new PropertyEditorSupport() {
+            @Override
+            public void setAsText(String text) {
+                setValue(text == null || text.isBlank() ? null : HotelSearchRequest.TemperatureUnit.valueOf(text.toUpperCase()));
+            }
+        });
+    }
+
+    @Operation(summary = "호텔 검색", description = "공급자(supplier)를 선택하여 호텔 오퍼를 검색합니다. 기본값: booking")
     @GetMapping("/offers")
-    public List<HotelSearchResult> offers(
-            @RequestParam String cityCode,
-            @RequestParam java.time.LocalDate checkIn,
-            @RequestParam java.time.LocalDate checkOut,
-            @RequestParam(defaultValue = "1") int adults,
-            @RequestParam(defaultValue = "1") int roomQuantity,
-            @RequestParam(required = false) String supplier
+    public JsonNode offers(
+            @Parameter(description = "공급자 키 (booking | amadeus)", example = "booking")
+            @RequestParam(required = false) String supplier,
+            @ParameterObject @ModelAttribute HotelSearchRequest request
     ) {
-        return hotelSearchService.search(supplier, cityCode, checkIn, checkOut, adults, roomQuantity);
+        return hotelSearchService.search(supplier, request);
+    }
+
+    @Operation(summary = "호텔 목적지 검색", description = "도시/지역명으로 dest_id와 search_type을 조회합니다. 호텔 검색 전에 먼저 호출하세요. 반환값에서 dest_id와 dest_type을 사용하면 됩니다.")
+    @GetMapping("/destinations")
+    public List<HotelDestination> searchDestination(
+            @Parameter(description = "검색어 (도시명, 지역명 등)", example = "seoul")
+            @RequestParam String query
+    ) {
+        return hotelSearchService.searchDestination(query);
+    }
+
+    @Operation(summary = "정렬 옵션 조회", description = "호텔 검색에 사용 가능한 sort_by 값 목록을 조회합니다.")
+    @GetMapping("/sort-options")
+    public List<HotelSortOption> getSortBy(@ParameterObject @ModelAttribute HotelOptionsRequest request) {
+        return hotelSearchService.getSortBy(request);
+    }
+
+    @Operation(summary = "필터 옵션 조회", description = "호텔 검색에 사용 가능한 categories_filter 값 목록을 조회합니다. 초기 요청 시 categoriesFilter는 비워두세요.")
+    @GetMapping("/filter-options")
+    public JsonNode getFilter(@ParameterObject @ModelAttribute HotelOptionsRequest request) {
+        return hotelSearchService.getFilter(request);
     }
 
     @GetMapping("/place-info")

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/amadeus/hotels/AmadeusHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/amadeus/hotels/AmadeusHotelAdapter.java
@@ -2,6 +2,7 @@ package com.sofly.supply.adapter.outbound.amadeus.hotels;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.adapter.outbound.amadeus.auth.AmadeusAuthClient;
+import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.port.outbound.HotelSupplierPort;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -9,6 +10,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.StreamSupport;
+
+// HotelSearchRequest에 amadeus 전용 변수들 만들어줘야 됨
+// amadeus 사용은 보류 상태이니 나중에 수정하도록 함
 
 @Component
 public class AmadeusHotelAdapter implements HotelSupplierPort {
@@ -29,14 +33,14 @@ public class AmadeusHotelAdapter implements HotelSupplierPort {
     }
 
     @Override
-    public JsonNode searchHotelsByCity(String cityCode, LocalDate checkIn, LocalDate checkOut, int adults, int roomQuantity) {
+    public JsonNode searchHotelsByCity(HotelSearchRequest request) {
         String token = authClient.getAccessToken();
 
         // Step 1: 도시 코드로 호텔 ID 목록 조회
         JsonNode hotelListResponse = amadeusWebClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/v1/reference-data/locations/hotels/by-city")
-                        .queryParam("cityCode", cityCode)
+                        //.queryParam("cityCode", cityCode)
                         .queryParam("radius", 5)
                         .queryParam("radiusUnit", "KM")
                         .queryParam("hotelSource", "ALL")
@@ -46,9 +50,9 @@ public class AmadeusHotelAdapter implements HotelSupplierPort {
                 .bodyToMono(JsonNode.class)
                 .block();
 
-        if (hotelListResponse == null || !hotelListResponse.has("data")) {
-            throw new IllegalStateException("No hotels found for city: " + cityCode);
-        }
+//        if (hotelListResponse == null || !hotelListResponse.has("data")) {
+//            throw new IllegalStateException("No hotels found for city: " + cityCode);
+//        }
 
         List<String> hotelIds = StreamSupport
                 .stream(hotelListResponse.get("data").spliterator(), false)
@@ -56,19 +60,19 @@ public class AmadeusHotelAdapter implements HotelSupplierPort {
                 .map(hotel -> hotel.get("hotelId").asText())
                 .toList();
 
-        if (hotelIds.isEmpty()) {
-            throw new IllegalStateException("No hotel IDs found for city: " + cityCode);
-        }
+//        if (hotelIds.isEmpty()) {
+//            throw new IllegalStateException("No hotel IDs found for city: " + cityCode);
+//        }
 
         // Step 2: 호텔 오퍼(가격/객실) 조회
         return amadeusWebClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/v3/shopping/hotel-offers")
                         .queryParam("hotelIds", String.join(",", hotelIds))
-                        .queryParam("checkInDate", checkIn)
-                        .queryParam("checkOutDate", checkOut)
-                        .queryParam("adults", adults)
-                        .queryParam("roomQuantity", roomQuantity)
+                        //.queryParam("checkInDate", checkIn)
+                        //.queryParam("checkOutDate", checkOut)
+                        //.queryParam("adults", adults)
+                        //.queryParam("roomQuantity", roomQuantity)
                         .queryParam("bestRateOnly", true)
                         .build())
                 .header("Authorization", "Bearer " + token)

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/google/GooglePlacesClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/google/GooglePlacesClient.java
@@ -1,6 +1,8 @@
 package com.sofly.supply.adapter.outbound.google;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.application.dto.PlaceInfo;
+import com.sofly.supply.application.port.outbound.PlaceInfoPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -14,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 @Component
-public class GooglePlacesClient {
+public class GooglePlacesClient implements PlaceInfoPort {
 
     private static final Logger log = LoggerFactory.getLogger(GooglePlacesClient.class);
     private static final int MAX_PHOTOS = 3;

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/RapidApiJsonUtils.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/RapidApiJsonUtils.java
@@ -1,0 +1,36 @@
+package com.sofly.supply.adapter.outbound.rapidapi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class RapidApiJsonUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private RapidApiJsonUtils() {}
+
+    public static JsonNode parseJson(String response) {
+        try {
+            return OBJECT_MAPPER.readTree(response);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("RapidAPI 응답 파싱 실패", e);
+        }
+    }
+
+    public static JsonNode nullNode() {
+        return OBJECT_MAPPER.nullNode();
+    }
+
+    public static String textOrNull(JsonNode node, String field) {
+        return node.hasNonNull(field) ? node.get(field).asText() : null;
+    }
+
+    public static Double doubleOrNull(JsonNode node, String field) {
+        return node.hasNonNull(field) ? node.get(field).asDouble() : null;
+    }
+
+    public static Integer intOrNull(JsonNode node, String field) {
+        return node.hasNonNull(field) ? node.get(field).asInt() : null;
+    }
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
@@ -1,6 +1,7 @@
 package com.sofly.supply.adapter.outbound.rapidapi.flights;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.adapter.outbound.rapidapi.RapidApiJsonUtils;
 import com.sofly.supply.application.dto.FlightDestination;
 import com.sofly.supply.application.port.outbound.FlightMetaPort;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +42,7 @@ public class BookingComFlightMetaClient implements FlightMetaPort {
 
             for (JsonNode item : response.get("data")) {
                 FlightDestination.DistanceToCity distanceToCity = null;
-                if (item.has("distanceToCity") && !item.get("distanceToCity").isNull()) {
+                if (item.hasNonNull("distanceToCity")) {
                     JsonNode d = item.get("distanceToCity");
                     distanceToCity = new FlightDestination.DistanceToCity(
                             d.get("value").asDouble(),
@@ -50,19 +51,19 @@ public class BookingComFlightMetaClient implements FlightMetaPort {
                 }
 
                 results.add(new FlightDestination(
-                        textOrNull(item, "id"),
-                        textOrNull(item, "type"),
-                        textOrNull(item, "name"),
-                        textOrNull(item, "code"),
-                        textOrNull(item, "city"),
-                        textOrNull(item, "cityName"),
-                        textOrNull(item, "regionName"),
-                        textOrNull(item, "country"),
-                        textOrNull(item, "countryName"),
-                        textOrNull(item, "countryNameShort"),
-                        textOrNull(item, "photoUri"),
+                        RapidApiJsonUtils.textOrNull(item, "id"),
+                        RapidApiJsonUtils.textOrNull(item, "type"),
+                        RapidApiJsonUtils.textOrNull(item, "name"),
+                        RapidApiJsonUtils.textOrNull(item, "code"),
+                        RapidApiJsonUtils.textOrNull(item, "city"),
+                        RapidApiJsonUtils.textOrNull(item, "cityName"),
+                        RapidApiJsonUtils.textOrNull(item, "regionName"),
+                        RapidApiJsonUtils.textOrNull(item, "country"),
+                        RapidApiJsonUtils.textOrNull(item, "countryName"),
+                        RapidApiJsonUtils.textOrNull(item, "countryNameShort"),
+                        RapidApiJsonUtils.textOrNull(item, "photoUri"),
                         distanceToCity,
-                        textOrNull(item, "parent")
+                        RapidApiJsonUtils.textOrNull(item, "parent")
                 ));
             }
 
@@ -73,7 +74,4 @@ public class BookingComFlightMetaClient implements FlightMetaPort {
         }
     }
 
-    private String textOrNull(JsonNode node, String field) {
-        return node.has(field) && !node.get(field).isNull() ? node.get(field).asText() : null;
-    }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
@@ -1,0 +1,78 @@
+package com.sofly.supply.adapter.outbound.rapidapi.flights;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.application.dto.FlightDestination;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BookingComFlightMetaClient {
+    private static final Logger log = LoggerFactory.getLogger(BookingComFlightMetaClient.class);
+
+    private final WebClient rapidApiWebClient;
+
+    public List<FlightDestination> searchDestinations(String query, String languageCode){
+        try{
+            JsonNode response = rapidApiWebClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/api/v1/flights/searchDestination")
+                            .queryParam("query", query)
+                            .queryParam("languagecode", languageCode)
+                            .build()
+                    )
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            List<FlightDestination> results = new ArrayList<>();
+
+            if (response == null || !response.has("data")) {
+                return results;
+            }
+
+            for (JsonNode item : response.get("data")) {
+                FlightDestination.DistanceToCity distanceToCity = null;
+                if (item.has("distanceToCity") && !item.get("distanceToCity").isNull()) {
+                    JsonNode d = item.get("distanceToCity");
+                    distanceToCity = new FlightDestination.DistanceToCity(
+                            d.get("value").asDouble(),
+                            d.get("unit").asText()
+                    );
+                }
+
+                results.add(new FlightDestination(
+                        textOrNull(item, "id"),
+                        textOrNull(item, "type"),
+                        textOrNull(item, "name"),
+                        textOrNull(item, "code"),
+                        textOrNull(item, "city"),
+                        textOrNull(item, "cityName"),
+                        textOrNull(item, "regionName"),
+                        textOrNull(item, "country"),
+                        textOrNull(item, "countryName"),
+                        textOrNull(item, "countryNameShort"),
+                        textOrNull(item, "photoUri"),
+                        distanceToCity,
+                        textOrNull(item, "parent")
+                ));
+            }
+
+            return results;
+        } catch (WebClientResponseException e){
+            log.warn("Booking.com searchDestination API error: {} {}", e.getStatusCode(), e.getMessage());
+            return List.of();
+        }
+    }
+
+    private String textOrNull(JsonNode node, String field) {
+        return node.has(field) && !node.get(field).isNull() ? node.get(field).asText() : null;
+    }
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
@@ -2,6 +2,7 @@ package com.sofly.supply.adapter.outbound.rapidapi.flights;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.application.dto.FlightDestination;
+import com.sofly.supply.application.port.outbound.FlightMetaPort;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +15,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class BookingComFlightMetaClient {
+public class BookingComFlightMetaClient implements FlightMetaPort {
     private static final Logger log = LoggerFactory.getLogger(BookingComFlightMetaClient.class);
 
     private final WebClient rapidApiWebClient;

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
@@ -26,8 +26,6 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
 
     @Override
     public JsonNode searchFlightOffers(FlightSearchRequest request) {
-        //log.debug("BookingCom flight search - fromId={}, toId={}, departDate={}", request.getFromId(), request.getToId(), request.getDepartDate());
-
         String response = rapidApiWebClient.get()
                 .uri(uriBuilder -> {
                     var builder = uriBuilder
@@ -52,14 +50,13 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
                     if (request.getPageNo() != null)
                         builder.queryParam("pageNo", request.getPageNo());
 
-                    var uri = builder.build();
-                    //log.debug("BookingCom request URI: {}", uri);
-                    return uri;
+                    return builder.build();
                 })
                 .retrieve()
                 .bodyToMono(String.class)
                 .block();
 
+        if (response == null) return OBJECT_MAPPER.nullNode();
         return parseJson(response);
     }
 

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
@@ -26,7 +26,7 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
 
     @Override
     public JsonNode searchFlightOffers(FlightSearchRequest request) {
-        log.debug("BookingCom flight search - fromId={}, toId={}, departDate={}", request.getFromId(), request.getToId(), request.getDepartDate());
+        //log.debug("BookingCom flight search - fromId={}, toId={}, departDate={}", request.getFromId(), request.getToId(), request.getDepartDate());
 
         String response = rapidApiWebClient.get()
                 .uri(uriBuilder -> {
@@ -53,7 +53,7 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
                         builder.queryParam("pageNo", request.getPageNo());
 
                     var uri = builder.build();
-                    log.debug("BookingCom request URI: {}", uri);
+                    //log.debug("BookingCom request URI: {}", uri);
                     return uri;
                 })
                 .retrieve()

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
@@ -1,8 +1,7 @@
 package com.sofly.supply.adapter.outbound.rapidapi.flights;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofly.supply.adapter.outbound.rapidapi.RapidApiJsonUtils;
 import com.sofly.supply.application.dto.FlightSearchRequest;
 import com.sofly.supply.application.port.outbound.FlightSupplierPort;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +13,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Component
 @RequiredArgsConstructor
 public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final WebClient rapidApiWebClient;
 
@@ -56,15 +53,7 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
                 .bodyToMono(String.class)
                 .block();
 
-        if (response == null) return OBJECT_MAPPER.nullNode();
-        return parseJson(response);
-    }
-
-    private JsonNode parseJson(String response) {
-        try {
-            return OBJECT_MAPPER.readTree(response);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Booking.com 응답 파싱 실패", e);
-        }
+        if (response == null) return RapidApiJsonUtils.nullNode();
+        return RapidApiJsonUtils.parseJson(response);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComDestinationClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComDestinationClient.java
@@ -1,0 +1,154 @@
+package com.sofly.supply.adapter.outbound.rapidapi.hotels;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.application.dto.HotelDestination;
+import com.sofly.supply.application.dto.HotelOptionsRequest;
+import com.sofly.supply.application.dto.HotelSortOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriBuilder;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+@Component
+public class BookingComDestinationClient {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingComDestinationClient.class);
+
+    private final WebClient rapidApiWebClient;
+
+    public BookingComDestinationClient(WebClient rapidApiWebClient) {
+        this.rapidApiWebClient = rapidApiWebClient;
+    }
+
+    public List<HotelDestination> searchDestination(String query) {
+        try {
+            JsonNode response = rapidApiWebClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/api/v1/hotels/searchDestination")
+                            .queryParam("query", query)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            List<HotelDestination> results = new ArrayList<>();
+
+            if (response == null || !response.has("data")) {
+                return results;
+            }
+
+            for (JsonNode item : response.get("data")) {
+                results.add(new HotelDestination(
+                        textOrNull(item, "dest_id"),
+                        textOrNull(item, "dest_type"),
+                        textOrNull(item, "name"),
+                        textOrNull(item, "label"),
+                        textOrNull(item, "city_name"),
+                        textOrNull(item, "country"),
+                        textOrNull(item, "region"),
+                        doubleOrNull(item, "latitude"),
+                        doubleOrNull(item, "longitude"),
+                        textOrNull(item, "image_url"),
+                        intOrNull(item, "hotels")
+                ));
+            }
+
+            return results;
+
+        } catch (WebClientResponseException e) {
+            log.warn("Booking.com searchDestination API error: {} {}", e.getStatusCode(), e.getMessage());
+            return List.of();
+        }
+    }
+
+    public List<HotelSortOption> getSortBy(HotelOptionsRequest request) {
+        try {
+            JsonNode response = rapidApiWebClient.get()
+                    .uri(optionsUriBuilder("/api/v1/hotels/getSortBy", request, false))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            List<HotelSortOption> results = new ArrayList<>();
+
+            if (response == null || !response.has("data")) {
+                return results;
+            }
+
+            for (JsonNode item : response.get("data")) {
+                results.add(new HotelSortOption(
+                        textOrNull(item, "id"),
+                        textOrNull(item, "title")
+                ));
+            }
+
+            return results;
+
+        } catch (WebClientResponseException e) {
+            log.warn("Booking.com getSortBy API error: {} {}", e.getStatusCode(), e.getMessage());
+            return List.of();
+        }
+    }
+
+    public JsonNode getFilter(HotelOptionsRequest request) {
+        try {
+            JsonNode response = rapidApiWebClient.get()
+                    .uri(optionsUriBuilder("/api/v1/hotels/getFilter", request, true))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (response == null || !response.has("data")) {
+                return null;
+            }
+
+            JsonNode data = response.get("data");
+            return data.has("filters") ? data.get("filters") : data;
+
+        } catch (WebClientResponseException e) {
+            log.warn("Booking.com getFilter API error: {} {}", e.getStatusCode(), e.getMessage());
+            return null;
+        }
+    }
+
+    private Function<UriBuilder, URI> optionsUriBuilder(String path, HotelOptionsRequest req, boolean includeCategories) {
+        return uriBuilder -> {
+            var builder = uriBuilder
+                    .path(path)
+                    .queryParam("dest_id", req.getDestId())
+                    .queryParam("search_type", req.getSearchType())
+                    .queryParam("arrival_date", req.getArrivalDate())
+                    .queryParam("departure_date", req.getDepartureDate());
+
+            if (req.getAdults() != null)
+                builder.queryParam("adults", req.getAdults());
+            if (req.getChildrenAge() != null)
+                builder.queryParam("children_age", req.getChildrenAge());
+            if (req.getRoomQty() != null)
+                builder.queryParam("room_qty", req.getRoomQty());
+            if (includeCategories && req.getCategoriesFilter() != null)
+                builder.queryParam("categories_filter", req.getCategoriesFilter());
+
+            return builder.build();
+        };
+    }
+
+    private String textOrNull(JsonNode node, String field) {
+        return node.has(field) && !node.get(field).isNull() ? node.get(field).asText() : null;
+    }
+
+    private Double doubleOrNull(JsonNode node, String field) {
+        return node.has(field) && !node.get(field).isNull() ? node.get(field).asDouble() : null;
+    }
+
+    private Integer intOrNull(JsonNode node, String field) {
+        return node.has(field) && !node.get(field).isNull() ? node.get(field).asInt() : null;
+    }
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
@@ -26,43 +26,42 @@ public class BookingComHotelAdapter implements  HotelSupplierPort {
     public JsonNode searchHotelsByCity(HotelSearchRequest request){
 
         String response = rapidApiWebClient.get()
-                .uri(urlBuilder ->{
+                .uri(urlBuilder -> {
                         var builder = urlBuilder
                                 .path("/api/v1/hotels/searchHotels")
-                                .queryParam("destId", request.getDestId())
-                                .queryParam("searchType", request.getSearchType())
-                                .queryParam("arrivalDate", request.getArrivalDate())
-                                .queryParam("departureDate", request.getDepartureDate());
+                                .queryParam("dest_id", request.getDestId())
+                                .queryParam("search_type", request.getSearchType())
+                                .queryParam("arrival_date", request.getArrivalDate())
+                                .queryParam("departure_date", request.getDepartureDate());
 
                                 if (request.getAdults() != null)
                                     builder.queryParam("adults", request.getAdults());
-                                if (request.getChildrenAge()!= null)
-                                    builder.queryParam("childrenAge", request.getChildrenAge());
+                                if (request.getChildrenAge() != null)
+                                    builder.queryParam("children_age", request.getChildrenAge());
                                 if (request.getRoomQty() != null)
-                                    builder.queryParam("roomQty", request.getRoomQty());
+                                    builder.queryParam("room_qty", request.getRoomQty());
                                 if (request.getPriceMin() != null)
-                                    builder.queryParam("priceMin", request.getPriceMin());
+                                    builder.queryParam("price_min", request.getPriceMin());
                                 if (request.getPriceMax() != null)
-                                    builder.queryParam("priceMax", request.getPriceMax());
+                                    builder.queryParam("price_max", request.getPriceMax());
                                 if (request.getSortBy() != null)
-                                    builder.queryParam("sortBy", request.getSortBy());
+                                    builder.queryParam("sort_by", request.getSortBy());
                                 if (request.getCategoriesFilter() != null)
-                                    builder.queryParam("categoriesFilter", request.getCategoriesFilter());
+                                    builder.queryParam("categories_filter", request.getCategoriesFilter());
                                 if (request.getPageNumber() != null)
-                                    builder.queryParam("pageNumber", request.getPageNumber());
+                                    builder.queryParam("page_number", request.getPageNumber());
                                 if (request.getUnits() != null)
-                                    builder.queryParam("units", request.getUnits());
+                                    builder.queryParam("units", request.getUnits().name().toLowerCase());
                                 if (request.getTemperatureUnit() != null)
-                                    builder.queryParam("temperatureUnit", request.getTemperatureUnit());
+                                    builder.queryParam("temperature_unit", request.getTemperatureUnit().getValue());
                                 if (request.getLanguageCode() != null)
-                                    builder.queryParam("languageCode", request.getLanguageCode());
+                                    builder.queryParam("languagecode", request.getLanguageCode());
                                 if (request.getCurrencyCode() != null)
-                                    builder.queryParam("currencyCode", request.getCurrencyCode());
+                                    builder.queryParam("currency_code", request.getCurrencyCode());
                                 if (request.getLocation() != null)
                                     builder.queryParam("location", request.getLocation());
 
-                                var uri = builder.build();
-                                return uri;
+                                return builder.build();
                 })
                 .retrieve()
                 .bodyToMono(String.class)

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
@@ -67,6 +67,7 @@ public class BookingComHotelAdapter implements  HotelSupplierPort {
                 .bodyToMono(String.class)
                 .block();
 
+        if (response == null) return OBJECT_MAPPER.nullNode();
         return parseJson(response);
     }
 

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
@@ -1,8 +1,7 @@
 package com.sofly.supply.adapter.outbound.rapidapi.hotels;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofly.supply.adapter.outbound.rapidapi.RapidApiJsonUtils;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.port.outbound.HotelSupplierPort;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +10,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
 @RequiredArgsConstructor
-public class BookingComHotelAdapter implements  HotelSupplierPort {
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+public class BookingComHotelAdapter implements HotelSupplierPort {
 
     private final WebClient rapidApiWebClient;
 
@@ -67,15 +64,7 @@ public class BookingComHotelAdapter implements  HotelSupplierPort {
                 .bodyToMono(String.class)
                 .block();
 
-        if (response == null) return OBJECT_MAPPER.nullNode();
-        return parseJson(response);
-    }
-
-    private JsonNode parseJson(String response) {
-        try {
-            return OBJECT_MAPPER.readTree(response);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Booking.com 응답 파싱 실패", e);
-        }
+        if (response == null) return RapidApiJsonUtils.nullNode();
+        return RapidApiJsonUtils.parseJson(response);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
@@ -1,20 +1,81 @@
 package com.sofly.supply.adapter.outbound.rapidapi.hotels;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.port.outbound.HotelSupplierPort;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
-public class BookingComHotelAdapter {
-//    @Override
-//    public String supplierKey(){
-//        return "booking";
-//    }
-//
-//    @Override
-//    public JsonNode searchHotelsByCity(String cityCode, LocalDate checkIn, LocalDate checkOut, int adults, int roomQuantity){
-//        // WebClient로 Booking.com RapidAPI 호출
-//    }
+@RequiredArgsConstructor
+public class BookingComHotelAdapter implements  HotelSupplierPort {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final WebClient rapidApiWebClient;
+
+    @Override
+    public String supplierKey(){
+        return "booking";
+    }
+
+    @Override
+    public JsonNode searchHotelsByCity(HotelSearchRequest request){
+
+        String response = rapidApiWebClient.get()
+                .uri(urlBuilder ->{
+                        var builder = urlBuilder
+                                .path("/api/v1/hotels/searchHotels")
+                                .queryParam("destId", request.getDestId())
+                                .queryParam("searchType", request.getSearchType())
+                                .queryParam("arrivalDate", request.getArrivalDate())
+                                .queryParam("departureDate", request.getDepartureDate());
+
+                                if (request.getAdults() != null)
+                                    builder.queryParam("adults", request.getAdults());
+                                if (request.getChildrenAge()!= null)
+                                    builder.queryParam("childrenAge", request.getChildrenAge());
+                                if (request.getRoomQty() != null)
+                                    builder.queryParam("roomQty", request.getRoomQty());
+                                if (request.getPriceMin() != null)
+                                    builder.queryParam("priceMin", request.getPriceMin());
+                                if (request.getPriceMax() != null)
+                                    builder.queryParam("priceMax", request.getPriceMax());
+                                if (request.getSortBy() != null)
+                                    builder.queryParam("sortBy", request.getSortBy());
+                                if (request.getCategoriesFilter() != null)
+                                    builder.queryParam("categoriesFilter", request.getCategoriesFilter());
+                                if (request.getPageNumber() != null)
+                                    builder.queryParam("pageNumber", request.getPageNumber());
+                                if (request.getUnits() != null)
+                                    builder.queryParam("units", request.getUnits());
+                                if (request.getTemperatureUnit() != null)
+                                    builder.queryParam("temperatureUnit", request.getTemperatureUnit());
+                                if (request.getLanguageCode() != null)
+                                    builder.queryParam("languageCode", request.getLanguageCode());
+                                if (request.getCurrencyCode() != null)
+                                    builder.queryParam("currencyCode", request.getCurrencyCode());
+                                if (request.getLocation() != null)
+                                    builder.queryParam("location", request.getLocation());
+
+                                var uri = builder.build();
+                                return uri;
+                })
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        return parseJson(response);
+    }
+
+    private JsonNode parseJson(String response) {
+        try {
+            return OBJECT_MAPPER.readTree(response);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Booking.com 응답 파싱 실패", e);
+        }
+    }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.application.dto.HotelDestination;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSortOption;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -17,15 +18,12 @@ import java.util.List;
 import java.util.function.Function;
 
 @Component
-public class BookingComDestinationClient {
+@RequiredArgsConstructor
+public class BookingComHotelMetaClient {
 
-    private static final Logger log = LoggerFactory.getLogger(BookingComDestinationClient.class);
+    private static final Logger log = LoggerFactory.getLogger(BookingComHotelMetaClient.class);
 
     private final WebClient rapidApiWebClient;
-
-    public BookingComDestinationClient(WebClient rapidApiWebClient) {
-        this.rapidApiWebClient = rapidApiWebClient;
-    }
 
     public List<HotelDestination> searchDestination(String query) {
         try {

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.application.dto.HotelDestination;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSortOption;
+import com.sofly.supply.application.port.outbound.HotelMetaPort;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +20,7 @@ import java.util.function.Function;
 
 @Component
 @RequiredArgsConstructor
-public class BookingComHotelMetaClient {
+public class BookingComHotelMetaClient implements HotelMetaPort {
 
     private static final Logger log = LoggerFactory.getLogger(BookingComHotelMetaClient.class);
 

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
@@ -1,6 +1,7 @@
 package com.sofly.supply.adapter.outbound.rapidapi.hotels;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.adapter.outbound.rapidapi.RapidApiJsonUtils;
 import com.sofly.supply.application.dto.HotelDestination;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSortOption;
@@ -45,17 +46,17 @@ public class BookingComHotelMetaClient implements HotelMetaPort {
 
             for (JsonNode item : response.get("data")) {
                 results.add(new HotelDestination(
-                        textOrNull(item, "dest_id"),
-                        textOrNull(item, "dest_type"),
-                        textOrNull(item, "name"),
-                        textOrNull(item, "label"),
-                        textOrNull(item, "city_name"),
-                        textOrNull(item, "country"),
-                        textOrNull(item, "region"),
-                        doubleOrNull(item, "latitude"),
-                        doubleOrNull(item, "longitude"),
-                        textOrNull(item, "image_url"),
-                        intOrNull(item, "hotels")
+                        RapidApiJsonUtils.textOrNull(item, "dest_id"),
+                        RapidApiJsonUtils.textOrNull(item, "dest_type"),
+                        RapidApiJsonUtils.textOrNull(item, "name"),
+                        RapidApiJsonUtils.textOrNull(item, "label"),
+                        RapidApiJsonUtils.textOrNull(item, "city_name"),
+                        RapidApiJsonUtils.textOrNull(item, "country"),
+                        RapidApiJsonUtils.textOrNull(item, "region"),
+                        RapidApiJsonUtils.doubleOrNull(item, "latitude"),
+                        RapidApiJsonUtils.doubleOrNull(item, "longitude"),
+                        RapidApiJsonUtils.textOrNull(item, "image_url"),
+                        RapidApiJsonUtils.intOrNull(item, "hotels")
                 ));
             }
 
@@ -83,8 +84,8 @@ public class BookingComHotelMetaClient implements HotelMetaPort {
 
             for (JsonNode item : response.get("data")) {
                 results.add(new HotelSortOption(
-                        textOrNull(item, "id"),
-                        textOrNull(item, "title")
+                        RapidApiJsonUtils.textOrNull(item, "id"),
+                        RapidApiJsonUtils.textOrNull(item, "title")
                 ));
             }
 
@@ -139,15 +140,4 @@ public class BookingComHotelMetaClient implements HotelMetaPort {
         };
     }
 
-    private String textOrNull(JsonNode node, String field) {
-        return node.has(field) && !node.get(field).isNull() ? node.get(field).asText() : null;
-    }
-
-    private Double doubleOrNull(JsonNode node, String field) {
-        return node.has(field) && !node.get(field).isNull() ? node.get(field).asDouble() : null;
-    }
-
-    private Integer intOrNull(JsonNode node, String field) {
-        return node.has(field) && !node.get(field).isNull() ? node.get(field).asInt() : null;
-    }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/FlightDestination.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/FlightDestination.java
@@ -11,7 +11,7 @@ public record FlightDestination(
         String country,
         String countryName,
         String countryNameShort,
-        String photoUrl,
+        String photoUri,
         DistanceToCity distanceToCity,
         String parent
 ){

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/FlightDestination.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/FlightDestination.java
@@ -1,0 +1,22 @@
+package com.sofly.supply.application.dto;
+
+public record FlightDestination(
+        String id,
+        String type,
+        String name,
+        String code,
+        String city,
+        String cityName,
+        String regionName,
+        String country,
+        String countryName,
+        String countryNameShort,
+        String photoUrl,
+        DistanceToCity distanceToCity,
+        String parent
+){
+    public record DistanceToCity(
+      double value,
+      String unit
+    ){}
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelDestination.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelDestination.java
@@ -1,0 +1,15 @@
+package com.sofly.supply.application.dto;
+
+public record HotelDestination(
+        String destId,
+        String destType,
+        String name,
+        String label,
+        String cityName,
+        String country,
+        String region,
+        Double latitude,
+        Double longitude,
+        String imageUrl,
+        Integer hotels
+) {}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelOptionsRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelOptionsRequest.java
@@ -1,0 +1,40 @@
+package com.sofly.supply.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HotelOptionsRequest {
+
+    @Schema(defaultValue = "-2092174", required = true)
+    private String destId;
+
+    @Schema(defaultValue = "CITY", required = true)
+    private String searchType;
+
+    @Schema(defaultValue = "2026-04-06", required = true)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate arrivalDate;
+
+    @Schema(defaultValue = "2026-04-08", required = true)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate departureDate;
+
+    @Schema(defaultValue = "1")
+    private Integer adults;
+
+    private String childrenAge;
+
+    @Schema(defaultValue = "1")
+    private Integer roomQty;
+
+    // getFilter 전용 (초기 요청 시 비워두면 됨)
+    private String categoriesFilter;
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
@@ -13,10 +13,10 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class HotelSearchRequest {
 
-    @Schema(defaultValue = "-2092174", required = true)
+    @Schema(defaultValue = "267199", required = true)
     private Float destId;
 
-    @Schema(defaultValue = "CITY", required = true)
+    @Schema(defaultValue = "LANDMARK", required = true)
     private String searchType;
 
     @Schema(defaultValue = "2026-04-06", required = true)
@@ -45,8 +45,10 @@ public class HotelSearchRequest {
     @Schema(defaultValue = "0")
     private Float priceMax;
 
+    @Schema(defaultValue = "price")
     private String sortBy;
 
+    @Schema(defaultValue = "popular")
     private String categoriesFilter;
 
     @Schema(defaultValue = "METRIC")
@@ -55,7 +57,7 @@ public class HotelSearchRequest {
     @Schema(defaultValue = "Celsius")
     private TemperatureUnit temperatureUnit;
 
-    @Schema(defaultValue = "ko-kr")
+    @Schema(defaultValue = "ko")
     private String languageCode;
 
     @Schema(defaultValue = "KRW")

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 public class HotelSearchRequest {
 
     @Schema(defaultValue = "267199", required = true)
-    private Float destId;
+    private String destId;
 
     @Schema(defaultValue = "LANDMARK", required = true)
     private String searchType;
@@ -77,7 +77,6 @@ public class HotelSearchRequest {
         private final String value;
 
         TemperatureUnit(String value) { this.value = value; }
-        TemperatureUnit() { this.value = this.name(); }
 
         public String getValue() { return value; }
     }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
@@ -1,0 +1,82 @@
+package com.sofly.supply.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HotelSearchRequest {
+
+    @Schema(defaultValue = "-2092174", required = true)
+    private Float destId;
+
+    @Schema(defaultValue = "CITY", required = true)
+    private String searchType;
+
+    @Schema(defaultValue = "2026-04-06", required = true)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate arrivalDate; //checkIn
+
+    @Schema(defaultValue = "2026-04-08", required = true)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate departureDate; //checkOut
+
+    @Schema(defaultValue = "1")
+    private Integer adults;
+
+    @Schema(defaultValue = "0")
+    private String childrenAge;
+
+    @Schema(defaultValue = "1")
+    private Integer roomQty;
+
+    @Schema(defaultValue = "1")
+    private Integer pageNumber;
+
+    @Schema(defaultValue = "0")
+    private Float priceMin;
+
+    @Schema(defaultValue = "0")
+    private Float priceMax;
+
+    private String sortBy;
+
+    private String categoriesFilter;
+
+    @Schema(defaultValue = "METRIC")
+    private Units units;
+
+    @Schema(defaultValue = "Celsius")
+    private TemperatureUnit temperatureUnit;
+
+    @Schema(defaultValue = "ko-kr")
+    private String languageCode;
+
+    @Schema(defaultValue = "KRW")
+    private String currencyCode;
+
+    private String location;
+
+    public enum Units{
+        METRIC,
+        IMPERIAL;
+    }
+
+    public enum TemperatureUnit{
+        CELSIUS("c"),
+        FAHRENHEIT("f");
+
+        private final String value;
+
+        TemperatureUnit(String value) { this.value = value; }
+        TemperatureUnit() { this.value = this.name(); }
+
+        public String getValue() { return value; }
+    }
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSortOption.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSortOption.java
@@ -1,0 +1,3 @@
+package com.sofly.supply.application.dto;
+
+public record HotelSortOption(String id, String title) {}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/PlaceInfo.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/PlaceInfo.java
@@ -1,10 +1,7 @@
-package com.sofly.supply.adapter.outbound.google;
-
-import java.util.List;
+package com.sofly.supply.application.dto;
 
 public record PlaceInfo(
         String placeId,
         Double rating,
         Integer userRatingsTotal
-        //List<String> photoUrls
 ) {}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/FlightMetaPort.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/FlightMetaPort.java
@@ -1,0 +1,9 @@
+package com.sofly.supply.application.port.outbound;
+
+import com.sofly.supply.application.dto.FlightDestination;
+
+import java.util.List;
+
+public interface FlightMetaPort {
+    List<FlightDestination> searchDestinations(String query, String languageCode);
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/HotelMetaPort.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/HotelMetaPort.java
@@ -1,0 +1,14 @@
+package com.sofly.supply.application.port.outbound;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.application.dto.HotelDestination;
+import com.sofly.supply.application.dto.HotelOptionsRequest;
+import com.sofly.supply.application.dto.HotelSortOption;
+
+import java.util.List;
+
+public interface HotelMetaPort {
+    List<HotelDestination> searchDestination(String query);
+    List<HotelSortOption> getSortBy(HotelOptionsRequest request);
+    JsonNode getFilter(HotelOptionsRequest request);
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/HotelSupplierPort.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/HotelSupplierPort.java
@@ -1,11 +1,12 @@
 package com.sofly.supply.application.port.outbound;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.application.dto.HotelSearchRequest;
 
 public interface HotelSupplierPort {
 
     /* "amadeus" or 다른 외부 api */
     String supplierKey();
 
-    JsonNode searchHotelsByCity(String cityCode, java.time.LocalDate checkIn, java.time.LocalDate checkOut, int adults, int roomQuantity);
+    JsonNode searchHotelsByCity(HotelSearchRequest request);
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/PlaceInfoPort.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/PlaceInfoPort.java
@@ -1,0 +1,7 @@
+package com.sofly.supply.application.port.outbound;
+
+import com.sofly.supply.application.dto.PlaceInfo;
+
+public interface PlaceInfoPort {
+    PlaceInfo fetchPlaceInfo(String hotelName, String cityCode);
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/FlightSearchService.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/FlightSearchService.java
@@ -1,9 +1,9 @@
 package com.sofly.supply.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.sofly.supply.adapter.outbound.rapidapi.flights.BookingComFlightMetaClient;
 import com.sofly.supply.application.dto.FlightDestination;
 import com.sofly.supply.application.dto.FlightSearchRequest;
+import com.sofly.supply.application.port.outbound.FlightMetaPort;
 import com.sofly.supply.application.port.outbound.FlightSupplierPort;
 import org.springframework.stereotype.Service;
 
@@ -13,11 +13,11 @@ import java.util.List;
 public class FlightSearchService {
 
     private final SupplierRouter router;
-    private final BookingComFlightMetaClient bookingComFlightMetaClient;
+    private final FlightMetaPort flightMetaPort;
 
-    public FlightSearchService(SupplierRouter router, BookingComFlightMetaClient bookingComFlightMetaClient) {
+    public FlightSearchService(SupplierRouter router, FlightMetaPort flightMetaPort) {
         this.router = router;
-        this.bookingComFlightMetaClient = bookingComFlightMetaClient;
+        this.flightMetaPort = flightMetaPort;
     }
 
     public JsonNode search(String supplier, FlightSearchRequest request) {
@@ -26,6 +26,6 @@ public class FlightSearchService {
     }
 
     public List<FlightDestination> searchDestination(String query, String languageCode) {
-        return bookingComFlightMetaClient.searchDestinations(query, languageCode);
+        return flightMetaPort.searchDestinations(query, languageCode);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/FlightSearchService.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/FlightSearchService.java
@@ -1,21 +1,31 @@
 package com.sofly.supply.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.adapter.outbound.rapidapi.flights.BookingComFlightMetaClient;
+import com.sofly.supply.application.dto.FlightDestination;
 import com.sofly.supply.application.dto.FlightSearchRequest;
 import com.sofly.supply.application.port.outbound.FlightSupplierPort;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class FlightSearchService {
 
     private final SupplierRouter router;
+    private final BookingComFlightMetaClient bookingComFlightMetaClient;
 
-    public FlightSearchService(SupplierRouter router) {
+    public FlightSearchService(SupplierRouter router, BookingComFlightMetaClient bookingComFlightMetaClient) {
         this.router = router;
+        this.bookingComFlightMetaClient = bookingComFlightMetaClient;
     }
 
     public JsonNode search(String supplier, FlightSearchRequest request) {
         FlightSupplierPort selected = router.selectFlightSupplier(supplier);
         return selected.searchFlightOffers(request);
+    }
+
+    public List<FlightDestination> searchDestination(String query, String languageCode) {
+        return bookingComFlightMetaClient.searchDestinations(query, languageCode);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
@@ -3,10 +3,13 @@ package com.sofly.supply.application.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.adapter.outbound.google.GooglePlacesClient;
 import com.sofly.supply.adapter.outbound.google.PlaceInfo;
-import com.sofly.supply.application.dto.HotelSearchResult;
+import com.sofly.supply.adapter.outbound.rapidapi.hotels.BookingComDestinationClient;
+import com.sofly.supply.application.dto.HotelDestination;
+import com.sofly.supply.application.dto.HotelOptionsRequest;
+import com.sofly.supply.application.dto.HotelSearchRequest;
+import com.sofly.supply.application.dto.HotelSortOption;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -14,35 +17,29 @@ public class HotelSearchService {
 
     private final SupplierRouter router;
     private final GooglePlacesClient googlePlacesClient;
+    private final BookingComDestinationClient destinationClient;
 
-    public HotelSearchService(SupplierRouter router, GooglePlacesClient googlePlacesClient) {
+    public HotelSearchService(SupplierRouter router, GooglePlacesClient googlePlacesClient,
+                               BookingComDestinationClient destinationClient) {
         this.router = router;
         this.googlePlacesClient = googlePlacesClient;
+        this.destinationClient = destinationClient;
     }
 
-    public List<HotelSearchResult> search(String supplier, String cityCode, java.time.LocalDate checkIn, java.time.LocalDate checkOut, int adults, int roomQuantity) {
-        JsonNode amadeusResponse = router.selectHotelSupplier(supplier).searchHotelsByCity(cityCode, checkIn, checkOut, adults, roomQuantity);
+    public JsonNode search(String supplier, HotelSearchRequest request) {
+        return router.selectHotelSupplier(supplier).searchHotelsByCity(request);
+    }
 
-        List<HotelSearchResult> results = new ArrayList<>();
+    public List<HotelDestination> searchDestination(String query) {
+        return destinationClient.searchDestination(query);
+    }
 
-        if (amadeusResponse == null || !amadeusResponse.has("data")) {
-            return results;
-        }
+    public List<HotelSortOption> getSortBy(HotelOptionsRequest request) {
+        return destinationClient.getSortBy(request);
+    }
 
-        for (JsonNode item : amadeusResponse.get("data")) {
-            JsonNode hotel = item.get("hotel");
-
-            String hotelId   = hotel.has("hotelId")   ? hotel.get("hotelId").asText()   : null;
-            String hotelName = hotel.has("name")       ? hotel.get("name").asText()       : null;
-            String city      = hotel.has("cityCode")   ? hotel.get("cityCode").asText()   : cityCode;
-            Double lat       = hotel.has("latitude")   ? hotel.get("latitude").asDouble() : null;
-            Double lng       = hotel.has("longitude")  ? hotel.get("longitude").asDouble(): null;
-            JsonNode offers  = item.get("offers");
-
-            results.add(new HotelSearchResult(hotelId, hotelName, city, lat, lng, offers));
-        }
-
-        return results;
+    public JsonNode getFilter(HotelOptionsRequest request) {
+        return destinationClient.getFilter(request);
     }
 
     public PlaceInfo getPlaceInfo(String hotelName, String cityCode) {

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
@@ -1,13 +1,13 @@
 package com.sofly.supply.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.sofly.supply.adapter.outbound.google.GooglePlacesClient;
-import com.sofly.supply.adapter.outbound.google.PlaceInfo;
-import com.sofly.supply.adapter.outbound.rapidapi.hotels.BookingComHotelMetaClient;
 import com.sofly.supply.application.dto.HotelDestination;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.dto.HotelSortOption;
+import com.sofly.supply.application.dto.PlaceInfo;
+import com.sofly.supply.application.port.outbound.HotelMetaPort;
+import com.sofly.supply.application.port.outbound.PlaceInfoPort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,14 +16,13 @@ import java.util.List;
 public class HotelSearchService {
 
     private final SupplierRouter router;
-    private final GooglePlacesClient googlePlacesClient;
-    private final BookingComHotelMetaClient destinationClient;
+    private final PlaceInfoPort placeInfoPort;
+    private final HotelMetaPort hotelMetaPort;
 
-    public HotelSearchService(SupplierRouter router, GooglePlacesClient googlePlacesClient,
-                               BookingComHotelMetaClient destinationClient) {
+    public HotelSearchService(SupplierRouter router, PlaceInfoPort placeInfoPort, HotelMetaPort hotelMetaPort) {
         this.router = router;
-        this.googlePlacesClient = googlePlacesClient;
-        this.destinationClient = destinationClient;
+        this.placeInfoPort = placeInfoPort;
+        this.hotelMetaPort = hotelMetaPort;
     }
 
     public JsonNode search(String supplier, HotelSearchRequest request) {
@@ -31,18 +30,18 @@ public class HotelSearchService {
     }
 
     public List<HotelDestination> searchDestination(String query) {
-        return destinationClient.searchDestination(query);
+        return hotelMetaPort.searchDestination(query);
     }
 
     public List<HotelSortOption> getSortBy(HotelOptionsRequest request) {
-        return destinationClient.getSortBy(request);
+        return hotelMetaPort.getSortBy(request);
     }
 
     public JsonNode getFilter(HotelOptionsRequest request) {
-        return destinationClient.getFilter(request);
+        return hotelMetaPort.getFilter(request);
     }
 
     public PlaceInfo getPlaceInfo(String hotelName, String cityCode) {
-        return googlePlacesClient.fetchPlaceInfo(hotelName, cityCode);
+        return placeInfoPort.fetchPlaceInfo(hotelName, cityCode);
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
@@ -3,7 +3,7 @@ package com.sofly.supply.application.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.adapter.outbound.google.GooglePlacesClient;
 import com.sofly.supply.adapter.outbound.google.PlaceInfo;
-import com.sofly.supply.adapter.outbound.rapidapi.hotels.BookingComDestinationClient;
+import com.sofly.supply.adapter.outbound.rapidapi.hotels.BookingComHotelMetaClient;
 import com.sofly.supply.application.dto.HotelDestination;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSearchRequest;
@@ -17,10 +17,10 @@ public class HotelSearchService {
 
     private final SupplierRouter router;
     private final GooglePlacesClient googlePlacesClient;
-    private final BookingComDestinationClient destinationClient;
+    private final BookingComHotelMetaClient destinationClient;
 
     public HotelSearchService(SupplierRouter router, GooglePlacesClient googlePlacesClient,
-                               BookingComDestinationClient destinationClient) {
+                               BookingComHotelMetaClient destinationClient) {
         this.router = router;
         this.googlePlacesClient = googlePlacesClient;
         this.destinationClient = destinationClient;

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/config/WebClientConfig.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/config/WebClientConfig.java
@@ -29,10 +29,15 @@ public class WebClientConfig {
 
     @Bean("rapidApiWebClient")
     public WebClient rapidApiWebClient(RapidApiProperties props){
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(BUFFER_SIZE))
+                .build();
+
         return WebClient.builder()
                 .baseUrl(props.baseUrl())
                 .defaultHeader("X-RapidAPI-Key", props.apiKey())
                 .defaultHeader("X-RapidAPI-Host", props.host())
+                .exchangeStrategies(strategies)
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 PR 요약
- Booking.com RapidAPI를 통한 호텔 검색 공급자 어댑터를 구현하고, 헥사고날 아키텍처에 맞게 Port 인터페이스를 도입하여 공급자 확장성을 개선했습니다.

## 🔧 변경 사항
- `HotelSearchRequest` DTO 추가 및 `HotelSupplierPort` 시그니처를 통합하여 모든 호텔 공급사가 동일한 인터페이스를 사용하도록 통일
- `BookingComHotelAdapter` 및 `BookingComHotelMetaClient` 구현 (RapidAPI 호텔 검색)
- `FlightMetaPort`, `HotelMetaPort`, `PlaceInfoPort` 등 Port 인터페이스 도입으로 헥사고날 아키텍처 준수
- 항공 목적지 검색 API(`/supply/flights/destinations`) 추가
- `BookingComDestinationClient` → `BookingComHotelMetaClient` 네이밍 정리
- `rapidApiWebClient` 버퍼 사이즈 설정 누락으로 인한 버그 수정
- `PlaceInfo`를 `application/dto`로 이동하여 레이어 분리 준수

## 📋 작업 상세 내용
- [x] HotelSearchRequest DTO 추가 및 HotelSupplierPort 시그니처 통합
- [x] BookingComHotelAdapter 구현 (RapidAPI 호텔 검색 연동)
- [x] Port 인터페이스 도입 (FlightMetaPort, HotelMetaPort, PlaceInfoPort)
- [x] 항공 목적지 검색 API 추가
- [x] 네이밍/구조 리팩토링 및 버그 수정

## 🔗 관련 이슈
- closed #29

## 📝 기타
- `supplier=booking` 쿼리 파라미터로 Booking.com 호텔 검색 공급자 선택 가능