### PR TITLE
Feat/45 conquest map

### DIFF
--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,26 +1,19 @@
 version: '3.8'
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.4.0
-    container_name: zookeeper
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-      KAFKA_HEAP_OPTS: "-Xmx128m -Xms64m"  # 메모리 최소화
-    ports:
-      - "2181:2181"
-
   kafka:
-    image: confluentinc/cp-kafka:7.4.0
+    image: confluentinc/cp-kafka:7.6.0
     container_name: kafka
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_LOG_RETENTION_HOURS: 24
-      KAFKA_HEAP_OPTS: "-Xmx384m -Xms256m"  # 메모리 최소화
+      KAFKA_HEAP_OPTS: "-Xmx384m -Xms256m"
+      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,0 +1,25 @@
+# docker-compose.yml
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_HEAP_OPTS: "-Xmx512m -Xms256m"  # 메모리 제한 (Lightsail용)

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml
 version: '3.8'
 services:
   zookeeper:
@@ -7,6 +6,7 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+      KAFKA_HEAP_OPTS: "-Xmx128m -Xms64m"  # 메모리 최소화
     ports:
       - "2181:2181"
 
@@ -22,4 +22,5 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_HEAP_OPTS: "-Xmx512m -Xms256m"  # 메모리 제한 (Lightsail용)
+      KAFKA_LOG_RETENTION_HOURS: 24
+      KAFKA_HEAP_OPTS: "-Xmx384m -Xms256m"  # 메모리 최소화

--- a/services/travel-core-service/.gitignore
+++ b/services/travel-core-service/.gitignore
@@ -40,3 +40,6 @@ out/
 .env
 .env.core
 .env.supply
+
+### Claude ###
+.claude/**

--- a/services/travel-core-service/docs/conquest-map.md
+++ b/services/travel-core-service/docs/conquest-map.md
@@ -1,0 +1,732 @@
+# Conquest Map — 기술 문서
+
+> **대상 독자** 프론트엔드 개발자 (React 구현 시 참고)
+> **테스트 페이지** `http://localhost:8080/conquest-test.html`
+> **Base URL** `http://localhost:8080`
+> **인증 방식** JWT Bearer Token
+
+---
+
+## 목차
+
+1. [기능 개요](#1-기능-개요)
+2. [테스트 페이지 사용법](#2-테스트-페이지-사용법)
+3. [기술 스택 & 라이브러리](#3-기술-스택--라이브러리)
+4. [API 명세](#4-api-명세)
+5. [데이터 모델](#5-데이터-모델)
+6. [지도 구현 상세](#6-지도-구현-상세)
+7. [UI 컴포넌트 구조](#7-ui-컴포넌트-구조)
+8. [자동 상태 전환 로직](#8-자동-상태-전환-로직)
+9. [React 구현 가이드](#9-react-구현-가이드)
+
+---
+
+## 1. 기능 개요
+
+Conquest Map은 사용자의 여행 발자국을 세계 지도 위에 시각화하는 기능입니다.
+
+| 기능 | 설명 |
+|------|------|
+| **국가 색칠** | 방문 상태에 따라 세계 지도 국가를 3가지 색으로 표시 |
+| **도시 핀** | 방문한 도시를 지도 위 핀으로 표시, 줌 레벨에 따라 클러스터링 |
+| **항공 경로 Arc** | 워크스페이스에 저장된 항공편을 곡선 경로로 시각화 |
+| **상태 수동 변경** | 국가/도시 클릭 → 미방문 / 예정 / 완료 수동 변경 |
+| **워크스페이스 연동** | 국가 클릭 시 해당 국가와 연관된 워크스페이스 목록 표시 |
+| **여행 통계** | 방문 국가 수, 도시 수, 여행일, 이동거리, 대륙별 분포 |
+| **일괄 등록** | 과거 방문 이력을 JSON으로 한번에 등록 |
+
+### 방문 상태 (VisitStatus)
+
+| 상태 | 값 | 색상 | 의미 |
+|------|----|------|------|
+| 미방문 | `UNVISITED` | `#374151` (어두운 회색) | 아직 방문하지 않은 국가/도시 |
+| 방문 예정 | `PLANNED` | `#f59e0b` (amber) | 항공권이 있거나 계획 중인 여행 |
+| 방문 완료 | `VISITED` | `#8b5cf6` (purple) | 이미 방문한 국가/도시 |
+
+---
+
+## 2. 테스트 페이지 사용법
+
+### 초기 설정
+
+```
+1. http://localhost:8080/conquest-test.html 접속
+2. 헤더 우측 "Mapbox Token" 입력 (pk.eyJ1... 형식의 퍼블릭 토큰)
+3. "지도 로드" 버튼 클릭 → 세계 지도 렌더링
+4. "Base URL" 확인 (기본값: http://localhost:8080)
+5. "JWT Token" 입력 (로그인 후 발급된 accessToken)
+6. "데이터 로드" 버튼 클릭 → 지도에 방문 데이터 반영
+```
+
+> 입력한 토큰과 Base URL은 `localStorage`에 자동 저장됩니다 (새로고침 후에도 유지).
+
+### 주요 인터랙션
+
+| 동작 | 결과 |
+|------|------|
+| 국가 클릭 | 오른쪽 사이드바에 워크스페이스 목록 슬라이드인 |
+| 사이드바 "상태 변경" 클릭 | 해당 국가의 방문 상태 변경 모달 |
+| 워크스페이스 카드 클릭 | 해당 여행의 항공 경로만 지도에 하이라이트 |
+| "전체 경로" 버튼 클릭 | 모든 항공 경로 표시로 복원 |
+| 도시 핀 클릭 | 팝업 표시 (도시명, 상태, 방문 횟수) + 상태 변경 버튼 |
+| 클러스터 클릭 | 해당 지역으로 줌인 |
+| 통계 패널 "일괄 등록" | JSON 편집기로 과거 방문 이력 등록 |
+| 통계 패널 닫기(✕) | 패널이 왼쪽으로 슬라이드아웃 (지도 가리지 않음) |
+
+---
+
+## 3. 기술 스택 & 라이브러리
+
+### 테스트 페이지 (`conquest-test.html`)
+
+| 라이브러리 | 버전 | 역할 | CDN |
+|-----------|------|------|-----|
+| **Mapbox GL JS** | v3.4.0 | 세계 지도 렌더링, 레이어 관리, 이벤트 처리 | `api.mapbox.com/mapbox-gl-js/v3.4.0/` |
+| Vanilla JS | ES2020+ | 상태 관리, API 호출, DOM 조작 | — |
+
+> 클러스터링은 Mapbox GL JS의 **내장 클러스터 기능** (`cluster: true`)을 사용합니다.
+> 별도의 Supercluster 라이브러리는 사용하지 않습니다.
+
+### React 구현 시 권장 스택
+
+| 라이브러리 | 역할 |
+|-----------|------|
+| `react-map-gl` 또는 `mapbox-gl` 직접 사용 | 지도 렌더링 |
+| `deck.gl` (`ArcLayer`) | 항공 경로 Arc 시각화 (고품질) |
+| `supercluster` + `use-supercluster` | 도시 핀 클러스터링 |
+| `@turf/turf` | 거리 계산, 좌표 보정 등 GeoJSON 유틸리티 |
+
+---
+
+## 4. API 명세
+
+모든 엔드포인트는 `/api/conquest` 아래에 위치하며 JWT 인증이 필요합니다.
+
+### 공통 응답 형식
+
+```json
+{
+  "success": true,
+  "message": null,
+  "data": { ... }
+}
+```
+
+---
+
+### 4-1. 정복 지도 조회
+
+```
+GET /api/conquest
+Authorization: Bearer {accessToken}
+```
+
+방문한 모든 국가와 도시 목록을 반환합니다.
+
+**Response Body**
+
+```json
+{
+  "success": true,
+  "data": {
+    "countries": [
+      {
+        "id": 1,
+        "countryCode": "KR",
+        "countryName": "대한민국",
+        "status": "VISITED",
+        "continent": "ASIA",
+        "continentName": "아시아",
+        "visitCount": 10
+      }
+    ],
+    "cities": [
+      {
+        "id": 1,
+        "cityName": "Seoul",
+        "countryCode": "KR",
+        "latitude": 37.5665,
+        "longitude": 126.978,
+        "status": "VISITED",
+        "visitCount": 5
+      }
+    ]
+  }
+}
+```
+
+---
+
+### 4-2. 여행 통계 조회
+
+```
+GET /api/conquest/stats
+Authorization: Bearer {accessToken}
+```
+
+**Response Body**
+
+```json
+{
+  "success": true,
+  "data": {
+    "visitedCountryCount": 12,
+    "totalCountryCount": 195,
+    "visitedCountryPercentage": 6.2,
+    "visitedCityCount": 25,
+    "totalTravelDays": 84,
+    "totalDistanceKm": 48320.5,
+    "continentStats": [
+      {
+        "continent": "ASIA",
+        "continentName": "아시아",
+        "visitedCountryCount": 5
+      },
+      {
+        "continent": "EUROPE",
+        "continentName": "유럽",
+        "visitedCountryCount": 4
+      }
+    ]
+  }
+}
+```
+
+---
+
+### 4-3. 전체 항공 경로 조회
+
+```
+GET /api/conquest/routes
+Authorization: Bearer {accessToken}
+```
+
+저장된 모든 항공편의 출발지/도착지 좌표와 경로 정보를 반환합니다.
+
+**Response Body**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "flightId": 1,
+      "workspaceId": 10,
+      "workspaceTitle": "도쿄 여행",
+      "departureAirport": "ICN",
+      "departureCity": "Seoul",
+      "departureCountryCode": "KR",
+      "departureLat": 37.4602,
+      "departureLng": 126.4407,
+      "arrivalAirport": "NRT",
+      "arrivalCity": "Tokyo",
+      "arrivalCountryCode": "JP",
+      "arrivalLat": 35.7647,
+      "arrivalLng": 140.3864,
+      "departureTime": "2025-03-15T09:30:00",
+      "arrivalTime": "2025-03-15T11:45:00",
+      "airline": "대한항공",
+      "flightNumber": "KE701",
+      "distanceKm": 1214.3,
+      "routeType": "INTERNATIONAL"
+    }
+  ]
+}
+```
+
+---
+
+### 4-4. 워크스페이스별 항공 경로 조회
+
+```
+GET /api/conquest/routes/workspaces/{workspaceId}
+Authorization: Bearer {accessToken}
+```
+
+특정 워크스페이스에 속한 항공편 경로만 반환합니다. 응답 구조는 4-3과 동일.
+
+---
+
+### 4-5. 국가별 워크스페이스 목록 조회
+
+```
+GET /api/conquest/countries/{countryCode}/workspaces
+Authorization: Bearer {accessToken}
+```
+
+국가를 클릭했을 때 해당 국가와 연관된 워크스페이스 목록을 반환합니다.
+
+**Path Variable**
+
+| 파라미터 | 타입 | 예시 |
+|---------|------|------|
+| `countryCode` | String (ISO alpha-2) | `JP`, `FR`, `US` |
+
+**Response Body**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 10,
+      "title": "도쿄 여행 2025",
+      "destination": "도쿄",
+      "countryCode": "JP",
+      "startDate": "2025-03-15",
+      "endDate": "2025-03-20",
+      "coverImageUrl": "https://...",
+      "memberCount": 2
+    }
+  ]
+}
+```
+
+---
+
+### 4-6. 국가 방문 상태 변경
+
+```
+PUT /api/conquest/countries/{countryCode}/status
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+```
+
+**Request Body**
+
+```json
+{
+  "status": "VISITED"
+}
+```
+
+`status` 허용값: `UNVISITED` | `PLANNED` | `VISITED`
+
+**Response Body** — 변경된 국가 정보 (4-1의 country 객체와 동일 구조)
+
+---
+
+### 4-7. 도시 추가 / 업데이트
+
+```
+POST /api/conquest/cities
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+```
+
+도시가 이미 존재하면 업데이트, 없으면 생성합니다. (도시명 + 국가코드 기준)
+
+**Request Body**
+
+```json
+{
+  "cityName": "Tokyo",
+  "countryCode": "JP",
+  "latitude": 35.6762,
+  "longitude": 139.6503,
+  "status": "VISITED"
+}
+```
+
+**Response** `201 Created` + 생성/업데이트된 도시 정보
+
+---
+
+### 4-8. 도시 방문 상태 변경
+
+```
+PUT /api/conquest/cities/{cityId}/status
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+```
+
+**Request Body**
+
+```json
+{
+  "status": "VISITED"
+}
+```
+
+**Response Body** — 변경된 도시 정보 (4-1의 city 객체와 동일 구조)
+
+---
+
+### 4-9. 과거 방문 일괄 등록
+
+```
+POST /api/conquest/bulk-import
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+```
+
+국가와 도시를 한번에 등록합니다. `countries`와 `cities` 둘 다 선택적입니다.
+
+**Request Body**
+
+```json
+{
+  "countries": [
+    { "countryCode": "JP", "status": "VISITED" },
+    { "countryCode": "FR", "status": "VISITED" }
+  ],
+  "cities": [
+    {
+      "cityName": "Tokyo",
+      "countryCode": "JP",
+      "latitude": 35.6762,
+      "longitude": 139.6503,
+      "status": "VISITED"
+    }
+  ]
+}
+```
+
+**Response** `204 No Content` (응답 바디 없음)
+
+---
+
+## 5. 데이터 모델
+
+### VisitStatus Enum
+
+```
+UNVISITED  → 미방문 (기본값)
+PLANNED    → 방문 예정 (항공편 등록 시 자동 전환)
+VISITED    → 방문 완료 (항공편 출발일 경과 시 자동 전환)
+```
+
+### Continent Enum
+
+| 값 | 한국어 표시명 |
+|----|-------------|
+| `ASIA` | 아시아 |
+| `EUROPE` | 유럽 |
+| `NORTH_AMERICA` | 북아메리카 |
+| `SOUTH_AMERICA` | 남아메리카 |
+| `AFRICA` | 아프리카 |
+| `OCEANIA` | 오세아니아 |
+
+### RouteType Enum
+
+```
+DOMESTIC       → 국내선 (출발/도착 국가코드 동일)
+INTERNATIONAL  → 국제선
+```
+
+---
+
+## 6. 지도 구현 상세
+
+### 6-1. Mapbox 소스 구성
+
+```
+country-boundaries  (vector)
+  └─ mapbox://mapbox.country-boundaries-v1
+      └─ source-layer: "country_boundaries"
+          ├─ property: iso_3166_1      (국가 코드, ISO alpha-2)
+          └─ property: worldview       (지도 세계관 필터용)
+
+cities  (geojson, cluster: true)
+  └─ 방문 도시 포인트 데이터
+      ├─ cluster: true
+      ├─ clusterMaxZoom: 8
+      └─ clusterRadius: 38
+
+routes  (geojson)
+  └─ 항공 경로 곡선 LineString 데이터
+```
+
+### 6-2. Mapbox 레이어 구성
+
+| 레이어 ID | 타입 | 소스 | 용도 |
+|-----------|------|------|------|
+| `c-fill` | fill | country-boundaries | 국가 방문 상태별 색칠 |
+| `c-line` | line | country-boundaries | 국가 경계선 (연한 회색) |
+| `c-hover` | fill | country-boundaries | 마우스 호버 시 밝기 증가 |
+| `c-sel` | line | country-boundaries | 선택된 국가 보라색 테두리 |
+| `rt-line` | line | routes | 항공 경로 본선 |
+| `rt-glow` | line | routes | 항공 경로 glow 효과 (불투명도 낮은 두꺼운 선) |
+| `cl-circle` | circle | cities | 클러스터 원형 |
+| `cl-count` | symbol | cities | 클러스터 개수 텍스트 |
+| `city-pt` | circle | cities | 개별 도시 핀 |
+
+### 6-3. 국가 색상 표현식
+
+Mapbox `match` 표현식을 동적으로 생성해 국가별 색상을 지정합니다.
+
+```javascript
+// API 응답으로 받은 countries 배열 기반으로 생성
+const expr = ['match', ['get', 'iso_3166_1']];
+
+for (const country of countries) {
+  if (country.status === 'VISITED') {
+    expr.push(country.countryCode, '#8b5cf6'); // purple
+  } else if (country.status === 'PLANNED') {
+    expr.push(country.countryCode, '#f59e0b'); // amber
+  }
+  // UNVISITED는 기본값으로 처리
+}
+
+expr.push('#1e293b'); // 기본값 (미방문)
+
+map.setPaintProperty('c-fill', 'fill-color', expr);
+```
+
+### 6-4. 항공 경로 Arc 생성
+
+직선 경로 대신 Quadratic Bezier 곡선으로 호 모양을 만듭니다.
+
+```javascript
+function arc(from, to, numPoints = 80) {
+  let [x1, y1] = from;
+  let [x2, y2] = to;
+
+  // 날짜변경선(antimeridian) 처리
+  if (Math.abs(x2 - x1) > 180) {
+    x2 += x2 > x1 ? -360 : 360;
+  }
+
+  // 이차 베지어 제어점: 두 지점 중간에서 위도 방향으로 올림
+  const mx = (x1 + x2) / 2;
+  const my = (y1 + y2) / 2;
+  const dist = Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+  const ctrlY = my + dist * 0.28; // 거리에 비례해 호의 높이 결정
+
+  const points = [];
+  for (let i = 0; i <= numPoints; i++) {
+    const t = i / numPoints, mt = 1 - t;
+    points.push([
+      mt * mt * x1 + 2 * mt * t * mx + t * t * x2,
+      mt * mt * y1 + 2 * mt * t * ctrlY + t * t * y2
+    ]);
+  }
+  return points; // GeoJSON LineString의 coordinates로 사용
+}
+```
+
+> **주의**: 경로 데이터의 `departureLng`, `departureLat`, `arrivalLng`, `arrivalLat` 값이 `0`이거나 누락된 경우 해당 경로는 렌더링에서 제외됩니다.
+
+### 6-5. 도시 클러스터링
+
+Mapbox의 내장 GeoJSON 클러스터링을 사용합니다.
+
+```javascript
+map.addSource('cities', {
+  type: 'geojson',
+  data: citiesGeoJSON,
+  cluster: true,
+  clusterMaxZoom: 8,   // 줌 8 이상에서 클러스터 해제
+  clusterRadius: 38    // 38px 반경 내 핀을 하나로 묶음
+});
+```
+
+클러스터 클릭 시 `getClusterExpansionZoom`으로 자동 줌인:
+
+```javascript
+map.on('click', 'cl-circle', e => {
+  const clusterId = e.features[0].properties.cluster_id;
+  map.getSource('cities').getClusterExpansionZoom(clusterId, (err, zoom) => {
+    if (!err) map.easeTo({ center: e.features[0].geometry.coordinates, zoom });
+  });
+});
+```
+
+### 6-6. 세계관(Worldview) 필터
+
+국가 경계선이 중복 렌더링되지 않도록 worldview 필터를 적용합니다.
+
+```javascript
+const WV_FILTER = [
+  'any',
+  ['==', ['get', 'worldview'], 'all'],  // 모든 세계관에서 공통인 국경
+  ['==', ['get', 'worldview'], 'US']    // 미국 세계관 기준 추가 보완
+];
+```
+
+---
+
+## 7. UI 컴포넌트 구조
+
+```
+Header
+├─ Mapbox Token 입력 + 지도 로드 버튼
+├─ Base URL 입력
+└─ JWT Token 입력 + 데이터 로드 버튼
+
+MapWrapper (position: relative)
+├─ #map (Mapbox GL 렌더링 대상)
+├─ #initOverlay   (지도 로드 전 안내 오버레이)
+├─ #statsPanel    (좌측 통계 패널, 고정 오버레이)
+├─ #legend        (좌측 하단, 색상 범례)
+├─ #routeBar      (하단 중앙, 경로 필터 버튼)
+├─ #wsSidebar     (우측 슬라이드 사이드바, 워크스페이스 목록)
+└─ #statusModal   (상태 변경 모달, 국가/도시 공통)
+```
+
+### 레이아웃 사이즈 참고
+
+| 요소 | 크기 |
+|------|------|
+| 헤더 | 고정 높이, `flex-wrap: wrap` |
+| 통계 패널 | 너비 252px, 좌측 14px 오프셋 |
+| 워크스페이스 사이드바 | 너비 310px, 우측 슬라이드인 (`translateX` 트랜지션) |
+| 경로 컨트롤 바 | 하단 중앙 고정 (`left: 50%; transform: translateX(-50%)`) |
+
+---
+
+## 8. 자동 상태 전환 로직
+
+프론트엔드에서 직접 구현하지 않아도 백엔드가 자동으로 처리하는 로직입니다.
+
+### 항공편 등록 → PLANNED 자동 전환
+
+```
+SavedFlight 저장 (FlightSavedEvent 발행)
+  └─ ConquestMapService.onFlightSaved() 호출
+      ├─ 해당 워크스페이스의 모든 멤버에 대해
+      ├─ 도착 국가 → PLANNED 상태로 전환
+      └─ 도착 도시 → PLANNED 상태로 전환 (AirportInfoService로 공항→도시 매핑)
+```
+
+### 스케줄러 → VISITED 자동 전환
+
+```
+Spring Scheduler (매일 실행)
+  └─ ConquestMapService.promotePlannedToVisited()
+      ├─ PLANNED 상태인 모든 국가/도시 조회
+      └─ 해당 항공편 출발 시각이 현재보다 이전이면 VISITED로 전환
+```
+
+> **프론트엔드 영향**: 데이터 로드(`GET /api/conquest`) 시 항상 최신 상태가 반영됩니다. 폴링이나 웹소켓은 필요 없습니다.
+
+---
+
+## 9. React 구현 가이드
+
+### 9-1. 권장 상태 구조
+
+```typescript
+interface ConquestState {
+  // 서버 데이터
+  countries: VisitedCountryResponse[];
+  cities: VisitedCityResponse[];
+  stats: ConquestStatsResponse | null;
+  routes: TripRouteResponse[];
+
+  // UI 상태
+  selectedCountryCode: string | null;  // 클릭된 국가
+  routeFilter: 'all' | 'none' | number; // number = workspaceId
+  isWsSidebarOpen: boolean;
+  workspaces: WorkspaceConquestResponse[]; // 선택 국가의 워크스페이스
+}
+```
+
+### 9-2. API 호출 흐름
+
+```
+컴포넌트 마운트
+  ├─ GET /api/conquest    → countries, cities 상태 업데이트 → 지도 레이어 업데이트
+  ├─ GET /api/conquest/stats  → 통계 패널 업데이트
+  └─ GET /api/conquest/routes → 경로 레이어 업데이트
+
+국가 클릭
+  └─ GET /api/conquest/countries/{code}/workspaces → 사이드바 표시
+
+상태 변경 확인
+  ├─ PUT /api/conquest/countries/{code}/status
+  └─ (완료 후) GET /api/conquest 재호출 → 지도 갱신
+
+워크스페이스 카드 클릭
+  └─ GET /api/conquest/routes/workspaces/{id} → 경로 레이어 갱신
+```
+
+### 9-3. Mapbox 레이어 색상 동적 업데이트
+
+```typescript
+// countries 배열 변경 시 호출
+function updateCountryColors(map: mapboxgl.Map, countries: VisitedCountryResponse[]) {
+  const colorExpr: mapboxgl.Expression = ['match', ['get', 'iso_3166_1']];
+
+  for (const c of countries) {
+    if (c.status === 'VISITED') colorExpr.push(c.countryCode, '#8b5cf6');
+    else if (c.status === 'PLANNED') colorExpr.push(c.countryCode, '#f59e0b');
+  }
+  colorExpr.push('#1e293b'); // fallback
+
+  map.setPaintProperty('country-fill', 'fill-color', colorExpr);
+}
+```
+
+### 9-4. 도시 GeoJSON 변환
+
+```typescript
+function citiesToGeoJSON(cities: VisitedCityResponse[]): GeoJSON.FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: cities.map(city => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [city.longitude, city.latitude] },
+      properties: {
+        id: city.id,
+        cityName: city.cityName,
+        countryCode: city.countryCode,
+        status: city.status,
+        visitCount: city.visitCount,
+        color: city.status === 'VISITED' ? '#8b5cf6'
+             : city.status === 'PLANNED' ? '#f59e0b' : '#374151',
+      }
+    }))
+  };
+}
+```
+
+### 9-5. deck.gl ArcLayer 사용 시 (권장)
+
+테스트 페이지는 Mapbox LineString으로 구현했지만, React에서는 deck.gl `ArcLayer`가 더 고품질입니다.
+
+```typescript
+import { ArcLayer } from '@deck.gl/layers';
+
+const arcLayer = new ArcLayer({
+  id: 'flight-arcs',
+  data: routes,
+  getSourcePosition: (r) => [r.departureLng, r.departureLat],
+  getTargetPosition: (r) => [r.arrivalLng, r.arrivalLat],
+  getSourceColor: [167, 139, 250, 180],   // #a78bfa
+  getTargetColor: [139, 92, 246, 180],    // #8b5cf6
+  getWidth: 2,
+  greatCircle: true, // 대원 경로 자동 계산 (antimeridian 처리 포함)
+});
+```
+
+> `greatCircle: true` 옵션 사용 시 antimeridian 처리가 자동으로 됩니다.
+
+### 9-6. 상태별 색상 상수
+
+```typescript
+export const STATUS_COLORS = {
+  VISITED:   { fill: '#8b5cf6', stroke: 'rgba(167,139,250,0.5)', label: '방문 완료' },
+  PLANNED:   { fill: '#f59e0b', stroke: 'rgba(251,191,36,0.5)',  label: '방문 예정' },
+  UNVISITED: { fill: '#374151', stroke: 'rgba(107,114,128,0.3)', label: '미방문'    },
+} as const;
+```
+
+### 9-7. 주요 엣지 케이스
+
+| 케이스 | 처리 방법 |
+|--------|----------|
+| 국가 데이터가 없는 경우 (API 미등록 국가) | `PUT /countries/{code}/status` 호출하면 백엔드가 자동 생성 |
+| 도시 좌표가 null인 경우 | 해당 도시는 GeoJSON에 포함하지 않음 |
+| 경로 출발지/도착지 좌표가 0인 경우 | 해당 경로는 필터링해 렌더링 제외 |
+| 날짜변경선을 넘는 경로 | deck.gl `greatCircle: true` 또는 수동 경도 보정 (`±360`) |
+| 동일 위치 다수 도시 | 클러스터링으로 자동 처리됨 |
+
+---
+
+## 참고 링크
+
+- [Mapbox GL JS 공식 문서](https://docs.mapbox.com/mapbox-gl-js/api/)
+- [Mapbox Country Boundaries 타일셋](https://docs.mapbox.com/data/tilesets/reference/mapbox-country-boundaries-v1/)
+- [deck.gl ArcLayer](https://deck.gl/docs/api-reference/layers/arc-layer)
+- [react-map-gl](https://visgl.github.io/react-map-gl/)

--- a/services/travel-core-service/src/main/java/com/sofly/core/TravelCoreServiceApplication.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/TravelCoreServiceApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableJpaAuditing 
+@EnableJpaAuditing
 @EnableFeignClients
+@EnableScheduling
 @ConfigurationPropertiesScan 
 public class TravelCoreServiceApplication {
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/code/ConquestErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/code/ConquestErrorCode.java
@@ -1,0 +1,19 @@
+package com.sofly.core.domain.conquest.code;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ConquestErrorCode implements BaseErrorCode {
+
+    COUNTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "CONQUEST_001", "방문 국가 정보를 찾을 수 없습니다."),
+    CITY_NOT_FOUND(HttpStatus.NOT_FOUND, "CONQUEST_002", "방문 도시 정보를 찾을 수 없습니다."),
+    CONQUEST_FORBIDDEN(HttpStatus.FORBIDDEN, "CONQUEST_003", "해당 정복 정보에 접근 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/controller/ConquestMapController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/controller/ConquestMapController.java
@@ -1,0 +1,164 @@
+package com.sofly.core.domain.conquest.controller;
+
+import com.sofly.core.domain.conquest.dto.request.BulkImportRequest;
+import com.sofly.core.domain.conquest.dto.request.CityCreateRequest;
+import com.sofly.core.domain.conquest.dto.request.StatusUpdateRequest;
+import com.sofly.core.domain.conquest.dto.response.*;
+import com.sofly.core.domain.conquest.service.ConquestMapService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Conquest Map", description = "정복 지도 - 방문 국가·도시 관리 및 여행 통계")
+@RestController
+@RequestMapping("/api/conquest")
+@RequiredArgsConstructor
+public class ConquestMapController {
+
+    private final ConquestMapService conquestMapService;
+
+    // ── 지도 전체 데이터 조회 ──────────────────────────────────────────
+
+    @Operation(summary = "정복 지도 전체 조회", description = "내 방문 국가·도시 목록을 반환합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<ConquestMapResponse>> getConquestMap() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(conquestMapService.getConquestMap(userId)));
+    }
+
+    // ── 통계 패널 ──────────────────────────────────────────────────────
+
+    @Operation(summary = "여행 통계 조회", description = "방문 국가 수, 도시 수, 총 여행 일수, 이동 거리, 대륙별 분포를 반환합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @GetMapping("/stats")
+    public ResponseEntity<ApiResponse<ConquestStatsResponse>> getStats() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(conquestMapService.getStats(userId)));
+    }
+
+    // ── 국가 상태 수동 변경 ────────────────────────────────────────────
+
+    @Operation(summary = "국가 방문 상태 변경", description = "국가 코드(ISO alpha-2)로 방문 상태를 직접 변경합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 오류"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @PutMapping("/countries/{countryCode}/status")
+    public ResponseEntity<ApiResponse<VisitedCountryResponse>> updateCountryStatus(
+            @PathVariable String countryCode,
+            @Valid @RequestBody StatusUpdateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(
+                conquestMapService.updateCountryStatus(userId, countryCode, request)));
+    }
+
+    // ── 도시 추가 / 상태 설정 ──────────────────────────────────────────
+
+    @Operation(summary = "도시 추가 또는 상태 설정", description = "도시를 수동으로 추가하거나 기존 도시의 상태를 변경합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성/변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 오류"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @PostMapping("/cities")
+    public ResponseEntity<ApiResponse<VisitedCityResponse>> addOrUpdateCity(
+            @Valid @RequestBody CityCreateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(conquestMapService.addOrUpdateCity(userId, request)));
+    }
+
+    // ── 도시 상태 변경 ─────────────────────────────────────────────────
+
+    @Operation(summary = "도시 방문 상태 변경", description = "도시 ID로 방문 상태를 변경합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "도시를 찾을 수 없음")
+    })
+    @PutMapping("/cities/{cityId}/status")
+    public ResponseEntity<ApiResponse<VisitedCityResponse>> updateCityStatus(
+            @PathVariable Long cityId,
+            @Valid @RequestBody StatusUpdateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(
+                conquestMapService.updateCityStatus(userId, cityId, request)));
+    }
+
+    // ── 과거 방문 일괄 등록 ────────────────────────────────────────────
+
+    @Operation(summary = "방문 이력 일괄 등록", description = "과거 방문한 국가·도시를 한 번에 등록합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "등록 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 오류"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @PostMapping("/bulk-import")
+    public ResponseEntity<Void> bulkImport(@Valid @RequestBody BulkImportRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        conquestMapService.bulkImport(userId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── 국가별 워크스페이스 목록 ───────────────────────────────────────
+
+    @Operation(summary = "국가별 워크스페이스 조회", description = "특정 국가를 목적지로 하는 내 워크스페이스 목록을 반환합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @GetMapping("/countries/{countryCode}/workspaces")
+    public ResponseEntity<ApiResponse<List<WorkspaceConquestResponse>>> getWorkspacesByCountry(
+            @PathVariable String countryCode) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(
+                conquestMapService.getWorkspacesByCountry(userId, countryCode)));
+    }
+
+    // ── 여행 경로 전체 조회 ────────────────────────────────────────────
+
+    @Operation(summary = "전체 여행 경로 조회", description = "내 모든 워크스페이스의 항공 경로를 반환합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음")
+    })
+    @GetMapping("/routes")
+    public ResponseEntity<ApiResponse<List<TripRouteResponse>>> getTripRoutes() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(conquestMapService.getTripRoutes(userId)));
+    }
+
+    // ── 워크스페이스별 여행 경로 조회 ──────────────────────────────────
+
+    @Operation(summary = "워크스페이스 여행 경로 조회", description = "특정 워크스페이스의 항공 경로를 반환합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 정보 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "워크스페이스를 찾을 수 없음")
+    })
+    @GetMapping("/routes/workspaces/{workspaceId}")
+    public ResponseEntity<ApiResponse<List<TripRouteResponse>>> getTripRoutesByWorkspace(
+            @PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(
+                conquestMapService.getTripRoutesByWorkspace(userId, workspaceId)));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/request/BulkImportRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/request/BulkImportRequest.java
@@ -1,0 +1,42 @@
+package com.sofly.core.domain.conquest.dto.request;
+
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class BulkImportRequest {
+
+    private List<CountryImport> countries;
+    private List<CityImport> cities;
+
+    @Getter
+    public static class CountryImport {
+        @NotBlank
+        private String countryCode;
+
+        @NotNull
+        private VisitStatus status;
+    }
+
+    @Getter
+    public static class CityImport {
+        @NotBlank
+        private String cityName;
+
+        @NotBlank
+        private String countryCode;
+
+        @NotNull
+        private Double latitude;
+
+        @NotNull
+        private Double longitude;
+
+        @NotNull
+        private VisitStatus status;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/request/CityCreateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/request/CityCreateRequest.java
@@ -1,0 +1,25 @@
+package com.sofly.core.domain.conquest.dto.request;
+
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CityCreateRequest {
+
+    @NotBlank(message = "도시명은 필수입니다.")
+    private String cityName;
+
+    @NotBlank(message = "국가 코드는 필수입니다.")
+    private String countryCode;
+
+    @NotNull(message = "위도는 필수입니다.")
+    private Double latitude;
+
+    @NotNull(message = "경도는 필수입니다.")
+    private Double longitude;
+
+    @NotNull(message = "상태값은 필수입니다.")
+    private VisitStatus status;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/request/StatusUpdateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/request/StatusUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.sofly.core.domain.conquest.dto.request;
+
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class StatusUpdateRequest {
+
+    @NotNull(message = "상태값은 필수입니다.")
+    private VisitStatus status;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/ConquestMapResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/ConquestMapResponse.java
@@ -1,0 +1,14 @@
+package com.sofly.core.domain.conquest.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ConquestMapResponse {
+
+    private List<VisitedCountryResponse> countries;
+    private List<VisitedCityResponse> cities;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/ConquestStatsResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/ConquestStatsResponse.java
@@ -1,0 +1,49 @@
+package com.sofly.core.domain.conquest.dto.response;
+
+import com.sofly.core.domain.conquest.enums.Continent;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ConquestStatsResponse {
+
+    private static final int TOTAL_COUNTRY_COUNT = 195;
+
+    private int visitedCountryCount;
+    private int totalCountryCount;
+    private double visitedCountryPercentage;
+    private int visitedCityCount;
+    private int totalTravelDays;
+    private double totalDistanceKm;
+    private List<ContinentStats> continentStats;
+
+    public static ConquestStatsResponse of(
+            int visitedCountryCount,
+            int visitedCityCount,
+            int totalTravelDays,
+            double totalDistanceKm,
+            List<ContinentStats> continentStats
+    ) {
+        double percentage = Math.round((double) visitedCountryCount / TOTAL_COUNTRY_COUNT * 1000.0) / 10.0;
+        return ConquestStatsResponse.builder()
+                .visitedCountryCount(visitedCountryCount)
+                .totalCountryCount(TOTAL_COUNTRY_COUNT)
+                .visitedCountryPercentage(percentage)
+                .visitedCityCount(visitedCityCount)
+                .totalTravelDays(totalTravelDays)
+                .totalDistanceKm(totalDistanceKm)
+                .continentStats(continentStats)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class ContinentStats {
+        private Continent continent;
+        private String continentName;
+        private int visitedCountryCount;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/TripRouteResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/TripRouteResponse.java
@@ -1,0 +1,39 @@
+package com.sofly.core.domain.conquest.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class TripRouteResponse {
+
+    private Long flightId;
+    private Long workspaceId;
+    private String workspaceTitle;
+
+    private String departureAirport;
+    private String departureCity;
+    private String departureCountryCode;
+    private double departureLat;
+    private double departureLng;
+
+    private String arrivalAirport;
+    private String arrivalCity;
+    private String arrivalCountryCode;
+    private double arrivalLat;
+    private double arrivalLng;
+
+    private LocalDateTime departureTime;
+    private LocalDateTime arrivalTime;
+
+    private String airline;
+    private String flightNumber;
+    private double distanceKm;
+
+    // 국가 간 이동: INTERNATIONAL, 동일 국가 내: DOMESTIC
+    private RouteType routeType;
+
+    public enum RouteType { INTERNATIONAL, DOMESTIC }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/VisitedCityResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/VisitedCityResponse.java
@@ -1,0 +1,31 @@
+package com.sofly.core.domain.conquest.dto.response;
+
+import com.sofly.core.domain.conquest.entity.VisitedCity;
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class VisitedCityResponse {
+
+    private Long id;
+    private String cityName;
+    private String countryCode;
+    private double latitude;
+    private double longitude;
+    private VisitStatus status;
+    private int visitCount;
+
+    public static VisitedCityResponse from(VisitedCity visitedCity) {
+        return VisitedCityResponse.builder()
+                .id(visitedCity.getId())
+                .cityName(visitedCity.getCityName())
+                .countryCode(visitedCity.getCountryCode())
+                .latitude(visitedCity.getLatitude())
+                .longitude(visitedCity.getLongitude())
+                .status(visitedCity.getStatus())
+                .visitCount(visitedCity.getVisitCount())
+                .build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/VisitedCountryResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/VisitedCountryResponse.java
@@ -1,0 +1,32 @@
+package com.sofly.core.domain.conquest.dto.response;
+
+import com.sofly.core.domain.conquest.entity.VisitedCountry;
+import com.sofly.core.domain.conquest.enums.Continent;
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class VisitedCountryResponse {
+
+    private Long id;
+    private String countryCode;
+    private String countryName;
+    private VisitStatus status;
+    private Continent continent;
+    private String continentName;
+    private int visitCount;
+
+    public static VisitedCountryResponse from(VisitedCountry visitedCountry) {
+        return VisitedCountryResponse.builder()
+                .id(visitedCountry.getId())
+                .countryCode(visitedCountry.getCountryCode())
+                .countryName(visitedCountry.getCountryName())
+                .status(visitedCountry.getStatus())
+                .continent(visitedCountry.getContinent())
+                .continentName(visitedCountry.getContinent().getDisplayName())
+                .visitCount(visitedCountry.getVisitCount())
+                .build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/WorkspaceConquestResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/dto/response/WorkspaceConquestResponse.java
@@ -1,0 +1,34 @@
+package com.sofly.core.domain.conquest.dto.response;
+
+import com.sofly.core.domain.workspace.entity.Workspace;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class WorkspaceConquestResponse {
+
+    private Long id;
+    private String title;
+    private String destination;
+    private String countryCode;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String coverImageUrl;
+    private int memberCount;
+
+    public static WorkspaceConquestResponse from(Workspace workspace) {
+        return WorkspaceConquestResponse.builder()
+                .id(workspace.getId())
+                .title(workspace.getTitle())
+                .destination(workspace.getDestination())
+                .countryCode(workspace.getCountryCode())
+                .startDate(workspace.getStartDate())
+                .endDate(workspace.getEndDate())
+                .coverImageUrl(workspace.getCoverImageUrl())
+                .memberCount(workspace.getMembers().size())
+                .build();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/entity/VisitedCity.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/entity/VisitedCity.java
@@ -1,0 +1,55 @@
+package com.sofly.core.domain.conquest.entity;
+
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+    name = "visited_cities",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "city_name", "country_code"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class VisitedCity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String cityName;
+
+    @Column(nullable = false, length = 2)
+    private String countryCode;
+
+    @Column(nullable = false)
+    private double latitude;
+
+    @Column(nullable = false)
+    private double longitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private VisitStatus status = VisitStatus.PLANNED;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private int visitCount = 0;
+
+    public void updateStatus(VisitStatus status) {
+        this.status = status;
+        if (status == VisitStatus.VISITED) {
+            this.visitCount++;
+        }
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/entity/VisitedCountry.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/entity/VisitedCountry.java
@@ -1,0 +1,58 @@
+package com.sofly.core.domain.conquest.entity;
+
+import com.sofly.core.domain.conquest.enums.Continent;
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+    name = "visited_countries",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "country_code"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class VisitedCountry extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 2)
+    private String countryCode;     // ISO 3166-1 alpha-2
+
+    @Column(nullable = false)
+    private String countryName;     // 한국어 국가명
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private VisitStatus status = VisitStatus.UNVISITED;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Continent continent;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private int visitCount = 0;
+
+    public void updateStatus(VisitStatus status) {
+        this.status = status;
+        if (status == VisitStatus.VISITED) {
+            this.visitCount++;
+        }
+    }
+
+    public void incrementVisitCount() {
+        this.visitCount++;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/enums/Continent.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/enums/Continent.java
@@ -1,0 +1,17 @@
+package com.sofly.core.domain.conquest.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Continent {
+    ASIA("아시아"),
+    EUROPE("유럽"),
+    NORTH_AMERICA("북아메리카"),
+    SOUTH_AMERICA("남아메리카"),
+    AFRICA("아프리카"),
+    OCEANIA("오세아니아");
+
+    private final String displayName;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/enums/VisitStatus.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/enums/VisitStatus.java
@@ -1,0 +1,7 @@
+package com.sofly.core.domain.conquest.enums;
+
+public enum VisitStatus {
+    UNVISITED,
+    PLANNED,
+    VISITED
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/event/FlightSavedEvent.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/event/FlightSavedEvent.java
@@ -1,0 +1,22 @@
+package com.sofly.core.domain.conquest.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 항공편 저장 시 발행되는 이벤트.
+ * 워크스페이스 멤버 전원의 정복 지도에 도착 국가/도시를 PLANNED 상태로 반영한다.
+ */
+@Getter
+@RequiredArgsConstructor
+public class FlightSavedEvent {
+
+    private final List<Long> memberUserIds;   // 워크스페이스 멤버 userId 목록
+    private final Long workspaceId;
+    private final String departureAirport;    // IATA
+    private final String arrivalAirport;      // IATA
+    private final LocalDateTime departureTime;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/exception/ConquestException.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/exception/ConquestException.java
@@ -1,0 +1,15 @@
+package com.sofly.core.domain.conquest.exception;
+
+import com.sofly.core.global.response.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ConquestException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public ConquestException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/repository/VisitedCityRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/repository/VisitedCityRepository.java
@@ -1,0 +1,19 @@
+package com.sofly.core.domain.conquest.repository;
+
+import com.sofly.core.domain.conquest.entity.VisitedCity;
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface VisitedCityRepository extends JpaRepository<VisitedCity, Long> {
+
+    List<VisitedCity> findByUserId(Long userId);
+
+    Optional<VisitedCity> findByUserIdAndCityNameAndCountryCode(Long userId, String cityName, String countryCode);
+
+    List<VisitedCity> findByUserIdAndCountryCode(Long userId, String countryCode);
+
+    List<VisitedCity> findByStatus(VisitStatus status);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/repository/VisitedCountryRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/repository/VisitedCountryRepository.java
@@ -1,0 +1,19 @@
+package com.sofly.core.domain.conquest.repository;
+
+import com.sofly.core.domain.conquest.entity.VisitedCountry;
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface VisitedCountryRepository extends JpaRepository<VisitedCountry, Long> {
+
+    List<VisitedCountry> findByUserId(Long userId);
+
+    Optional<VisitedCountry> findByUserIdAndCountryCode(Long userId, String countryCode);
+
+    List<VisitedCountry> findByUserIdAndStatus(Long userId, VisitStatus status);
+
+    List<VisitedCountry> findByStatus(VisitStatus status);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
@@ -1,0 +1,26 @@
+package com.sofly.core.domain.conquest.scheduler;
+
+import com.sofly.core.domain.conquest.service.ConquestMapService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매일 자정에 PLANNED 상태의 국가/도시 중
+ * 항공편 출발일이 지난 항목을 VISITED 로 자동 전환한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VisitStatusScheduler {
+
+    private final ConquestMapService conquestMapService;
+
+    @Scheduled(cron = "0 0 0 * * *")   // 매일 00:00
+    public void promoteToVisited() {
+        log.info("[ConquestScheduler] PLANNED → VISITED 자동 전환 시작");
+        conquestMapService.promotePlannedToVisited();
+        log.info("[ConquestScheduler] 완료");
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
@@ -1,10 +1,13 @@
 package com.sofly.core.domain.conquest.scheduler;
 
-import com.sofly.core.domain.conquest.service.ConquestMapService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import com.sofly.core.domain.conquest.service.ConquestMapService;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 매일 자정에 PLANNED 상태의 국가/도시 중
@@ -18,10 +21,21 @@ public class VisitStatusScheduler {
     private final ConquestMapService conquestMapService;
 
     // TODO: PLANNED status change to VISITED time setting 
+    // 10초마다 실행으로 임시 변경
+    // @Scheduled(fixedDelay = 10000)
     @Scheduled(fixedDelay = 1800000)  // 1800000ms = 30분
     public void promoteToVisited() {
         log.info("[ConquestScheduler] PLANNED → VISITED 자동 전환 시작");
         conquestMapService.promotePlannedToVisited();
         log.info("[ConquestScheduler] 완료");
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            promoteToVisited();
+        } catch (Exception e) {
+            log.warn("[ConquestScheduler] 초기 실행 실패 - 다음 스케줄에서 재시도: {}", e.getMessage());
+        }
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
@@ -17,7 +17,7 @@ public class VisitStatusScheduler {
 
     private final ConquestMapService conquestMapService;
 
-    @Scheduled(cron = "0 0 0 * * *")   // 매일 00:00
+    @Scheduled(fixedDelay = 1800000)  // 1800000ms = 30분
     public void promoteToVisited() {
         log.info("[ConquestScheduler] PLANNED → VISITED 자동 전환 시작");
         conquestMapService.promotePlannedToVisited();

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/scheduler/VisitStatusScheduler.java
@@ -17,6 +17,7 @@ public class VisitStatusScheduler {
 
     private final ConquestMapService conquestMapService;
 
+    // TODO: PLANNED status change to VISITED time setting 
     @Scheduled(fixedDelay = 1800000)  // 1800000ms = 30분
     public void promoteToVisited() {
         log.info("[ConquestScheduler] PLANNED → VISITED 자동 전환 시작");

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/service/AirportInfoService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/service/AirportInfoService.java
@@ -1,0 +1,221 @@
+package com.sofly.core.domain.conquest.service;
+
+import com.sofly.core.domain.conquest.enums.Continent;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class AirportInfoService {
+
+    public record AirportInfo(
+            String iataCode,
+            String countryCode,
+            String countryNameKo,
+            String cityName,
+            double latitude,
+            double longitude,
+            Continent continent
+    ) {}
+
+    private static final Map<String, AirportInfo> AIRPORT_MAP = Map.ofEntries(
+            // ── 한국 ──────────────────────────────────────────────────────────
+            entry("ICN", "KR", "대한민국", "인천", 37.4602, 126.4407, Continent.ASIA),
+            entry("GMP", "KR", "대한민국", "서울", 37.5583, 126.7906, Continent.ASIA),
+            entry("PUS", "KR", "대한민국", "부산", 35.1795, 128.9384, Continent.ASIA),
+            entry("CJU", "KR", "대한민국", "제주", 33.5113, 126.4930, Continent.ASIA),
+            // ── 일본 ──────────────────────────────────────────────────────────
+            entry("NRT", "JP", "일본", "도쿄", 35.7647, 140.3864, Continent.ASIA),
+            entry("HND", "JP", "일본", "도쿄", 35.5494, 139.7798, Continent.ASIA),
+            entry("KIX", "JP", "일본", "오사카", 34.4272, 135.2440, Continent.ASIA),
+            entry("ITM", "JP", "일본", "오사카", 34.7855, 135.4380, Continent.ASIA),
+            entry("NGO", "JP", "일본", "나고야", 34.8583, 136.8048, Continent.ASIA),
+            entry("FUK", "JP", "일본", "후쿠오카", 33.5858, 130.4508, Continent.ASIA),
+            entry("CTS", "JP", "일본", "삿포로", 42.7752, 141.6922, Continent.ASIA),
+            entry("OKA", "JP", "일본", "오키나와", 26.1958, 127.6464, Continent.ASIA),
+            // ── 중국 ──────────────────────────────────────────────────────────
+            entry("PEK", "CN", "중국", "베이징", 40.0799, 116.6031, Continent.ASIA),
+            entry("PKX", "CN", "중국", "베이징", 39.5098, 116.4105, Continent.ASIA),
+            entry("PVG", "CN", "중국", "상하이", 31.1443, 121.8083, Continent.ASIA),
+            entry("SHA", "CN", "중국", "상하이", 31.1983, 121.3363, Continent.ASIA),
+            entry("CAN", "CN", "중국", "광저우", 23.3924, 113.2990, Continent.ASIA),
+            entry("SZX", "CN", "중국", "선전", 22.6390, 113.8103, Continent.ASIA),
+            entry("CTU", "CN", "중국", "청두", 30.5784, 103.9469, Continent.ASIA),
+            entry("CKG", "CN", "중국", "충칭", 29.7192, 106.6417, Continent.ASIA),
+            // ── 대만·홍콩 ─────────────────────────────────────────────────────
+            entry("TPE", "TW", "대만", "타이베이", 25.0777, 121.2328, Continent.ASIA),
+            entry("HKG", "HK", "홍콩", "홍콩", 22.3080, 113.9185, Continent.ASIA),
+            // ── 동남아시아 ────────────────────────────────────────────────────
+            entry("BKK", "TH", "태국", "방콕", 13.6811, 100.7474, Continent.ASIA),
+            entry("DMK", "TH", "태국", "방콕", 13.9126, 100.6069, Continent.ASIA),
+            entry("HKT", "TH", "태국", "푸껫", 8.1132, 98.3169, Continent.ASIA),
+            entry("CNX", "TH", "태국", "치앙마이", 18.7668, 98.9627, Continent.ASIA),
+            entry("SGN", "VN", "베트남", "호치민", 10.8188, 106.6520, Continent.ASIA),
+            entry("HAN", "VN", "베트남", "하노이", 21.2212, 105.8072, Continent.ASIA),
+            entry("DAD", "VN", "베트남", "다낭", 16.0439, 108.1992, Continent.ASIA),
+            entry("SIN", "SG", "싱가포르", "싱가포르", 1.3644, 103.9915, Continent.ASIA),
+            entry("KUL", "MY", "말레이시아", "쿠알라룸푸르", 2.7456, 101.7072, Continent.ASIA),
+            entry("MNL", "PH", "필리핀", "마닐라", 14.5086, 121.0194, Continent.ASIA),
+            entry("CGK", "ID", "인도네시아", "자카르타", -6.1256, 106.6559, Continent.ASIA),
+            entry("DPS", "ID", "인도네시아", "발리", -8.7482, 115.1670, Continent.ASIA),
+            entry("RGN", "MM", "미얀마", "양곤", 16.9073, 96.1332, Continent.ASIA),
+            entry("REP", "KH", "캄보디아", "씨엠립", 13.4107, 103.8129, Continent.ASIA),
+            entry("VTE", "LA", "라오스", "비엔티안", 17.9883, 102.5633, Continent.ASIA),
+            // ── 남아시아 ──────────────────────────────────────────────────────
+            entry("BOM", "IN", "인도", "뭄바이", 19.0896, 72.8656, Continent.ASIA),
+            entry("DEL", "IN", "인도", "델리", 28.5562, 77.0999, Continent.ASIA),
+            entry("BLR", "IN", "인도", "벵갈루루", 13.1986, 77.7066, Continent.ASIA),
+            entry("CMB", "LK", "스리랑카", "콜롬보", 7.1808, 79.8841, Continent.ASIA),
+            entry("KTM", "NP", "네팔", "카트만두", 27.6966, 85.3591, Continent.ASIA),
+            // ── 중동 ──────────────────────────────────────────────────────────
+            entry("DXB", "AE", "아랍에미리트", "두바이", 25.2532, 55.3657, Continent.ASIA),
+            entry("AUH", "AE", "아랍에미리트", "아부다비", 24.4330, 54.6511, Continent.ASIA),
+            entry("DOH", "QA", "카타르", "도하", 25.2609, 51.6138, Continent.ASIA),
+            entry("RUH", "SA", "사우디아라비아", "리야드", 24.9576, 46.6988, Continent.ASIA),
+            entry("AMM", "JO", "요르단", "암만", 31.7226, 35.9932, Continent.ASIA),
+            entry("TLV", "IL", "이스라엘", "텔아비브", 32.0114, 34.8867, Continent.ASIA),
+            // ── 터키 ──────────────────────────────────────────────────────────
+            entry("IST", "TR", "터키", "이스탄불", 41.2753, 28.7519, Continent.EUROPE),
+            entry("SAW", "TR", "터키", "이스탄불", 40.8985, 29.3092, Continent.EUROPE),
+            // ── 유럽 ──────────────────────────────────────────────────────────
+            entry("LHR", "GB", "영국", "런던", 51.4775, -0.4614, Continent.EUROPE),
+            entry("LGW", "GB", "영국", "런던", 51.1537, -0.1821, Continent.EUROPE),
+            entry("CDG", "FR", "프랑스", "파리", 49.0097, 2.5478, Continent.EUROPE),
+            entry("ORY", "FR", "프랑스", "파리", 48.7262, 2.3652, Continent.EUROPE),
+            entry("FRA", "DE", "독일", "프랑크푸르트", 50.0379, 8.5622, Continent.EUROPE),
+            entry("MUC", "DE", "독일", "뮌헨", 48.3537, 11.7750, Continent.EUROPE),
+            entry("AMS", "NL", "네덜란드", "암스테르담", 52.3105, 4.7683, Continent.EUROPE),
+            entry("MAD", "ES", "스페인", "마드리드", 40.4936, -3.5673, Continent.EUROPE),
+            entry("BCN", "ES", "스페인", "바르셀로나", 41.2974, 2.0833, Continent.EUROPE),
+            entry("FCO", "IT", "이탈리아", "로마", 41.7999, 12.2462, Continent.EUROPE),
+            entry("MXP", "IT", "이탈리아", "밀라노", 45.6306, 8.7281, Continent.EUROPE),
+            entry("VCE", "IT", "이탈리아", "베네치아", 45.5053, 12.3519, Continent.EUROPE),
+            entry("VIE", "AT", "오스트리아", "빈", 48.1102, 16.5697, Continent.EUROPE),
+            entry("ZRH", "CH", "스위스", "취리히", 47.4582, 8.5555, Continent.EUROPE),
+            entry("GVA", "CH", "스위스", "제네바", 46.2381, 6.1089, Continent.EUROPE),
+            entry("BRU", "BE", "벨기에", "브뤼셀", 50.9010, 4.4844, Continent.EUROPE),
+            entry("CPH", "DK", "덴마크", "코펜하겐", 55.6180, 12.6561, Continent.EUROPE),
+            entry("ARN", "SE", "스웨덴", "스톡홀름", 59.6519, 17.9186, Continent.EUROPE),
+            entry("OSL", "NO", "노르웨이", "오슬로", 60.1939, 11.0998, Continent.EUROPE),
+            entry("HEL", "FI", "핀란드", "헬싱키", 60.3172, 24.9633, Continent.EUROPE),
+            entry("DUB", "IE", "아일랜드", "더블린", 53.4213, -6.2701, Continent.EUROPE),
+            entry("LIS", "PT", "포르투갈", "리스본", 38.7813, -9.1359, Continent.EUROPE),
+            entry("ATH", "GR", "그리스", "아테네", 37.9364, 23.9445, Continent.EUROPE),
+            entry("PRG", "CZ", "체코", "프라하", 50.1008, 14.2600, Continent.EUROPE),
+            entry("WAW", "PL", "폴란드", "바르샤바", 52.1657, 20.9671, Continent.EUROPE),
+            entry("BUD", "HU", "헝가리", "부다페스트", 47.4298, 19.2611, Continent.EUROPE),
+            entry("SVO", "RU", "러시아", "모스크바", 55.9736, 37.4125, Continent.EUROPE),
+            entry("LED", "RU", "러시아", "상트페테르부르크", 59.8003, 30.2625, Continent.EUROPE),
+            // ── 북아메리카 ────────────────────────────────────────────────────
+            entry("JFK", "US", "미국", "뉴욕", 40.6413, -73.7781, Continent.NORTH_AMERICA),
+            entry("EWR", "US", "미국", "뉴욕", 40.6895, -74.1745, Continent.NORTH_AMERICA),
+            entry("LAX", "US", "미국", "로스앤젤레스", 33.9425, -118.4081, Continent.NORTH_AMERICA),
+            entry("SFO", "US", "미국", "샌프란시스코", 37.6213, -122.3790, Continent.NORTH_AMERICA),
+            entry("ORD", "US", "미국", "시카고", 41.9742, -87.9073, Continent.NORTH_AMERICA),
+            entry("ATL", "US", "미국", "애틀랜타", 33.6407, -84.4277, Continent.NORTH_AMERICA),
+            entry("DFW", "US", "미국", "댈러스", 32.8998, -97.0403, Continent.NORTH_AMERICA),
+            entry("MIA", "US", "미국", "마이애미", 25.7959, -80.2870, Continent.NORTH_AMERICA),
+            entry("SEA", "US", "미국", "시애틀", 47.4502, -122.3088, Continent.NORTH_AMERICA),
+            entry("LAS", "US", "미국", "라스베이거스", 36.0840, -115.1537, Continent.NORTH_AMERICA),
+            entry("HNL", "US", "미국", "호놀룰루", 21.3187, -157.9224, Continent.NORTH_AMERICA),
+            entry("YYZ", "CA", "캐나다", "토론토", 43.6777, -79.6248, Continent.NORTH_AMERICA),
+            entry("YVR", "CA", "캐나다", "밴쿠버", 49.1947, -123.1792, Continent.NORTH_AMERICA),
+            entry("YUL", "CA", "캐나다", "몬트리올", 45.4706, -73.7408, Continent.NORTH_AMERICA),
+            entry("MEX", "MX", "멕시코", "멕시코시티", 19.4363, -99.0721, Continent.NORTH_AMERICA),
+            entry("CUN", "MX", "멕시코", "칸쿤", 21.0365, -86.8771, Continent.NORTH_AMERICA),
+            entry("GUM", "GU", "괌", "괌", 13.4834, 144.7958, Continent.OCEANIA),
+            // ── 남아메리카 ────────────────────────────────────────────────────
+            entry("GRU", "BR", "브라질", "상파울루", -23.4356, -46.4731, Continent.SOUTH_AMERICA),
+            entry("GIG", "BR", "브라질", "리우데자네이루", -22.8100, -43.2506, Continent.SOUTH_AMERICA),
+            entry("BOG", "CO", "콜롬비아", "보고타", 4.7016, -74.1469, Continent.SOUTH_AMERICA),
+            entry("LIM", "PE", "페루", "리마", -12.0219, -77.1143, Continent.SOUTH_AMERICA),
+            entry("SCL", "CL", "칠레", "산티아고", -33.3930, -70.7858, Continent.SOUTH_AMERICA),
+            entry("EZE", "AR", "아르헨티나", "부에노스아이레스", -34.8222, -58.5358, Continent.SOUTH_AMERICA),
+            // ── 아프리카 ──────────────────────────────────────────────────────
+            entry("CAI", "EG", "이집트", "카이로", 30.1219, 31.4056, Continent.AFRICA),
+            entry("NBO", "KE", "케냐", "나이로비", -1.3192, 36.9275, Continent.AFRICA),
+            entry("LOS", "NG", "나이지리아", "라고스", 6.5774, 3.3214, Continent.AFRICA),
+            entry("JNB", "ZA", "남아프리카공화국", "요하네스버그", -26.1392, 28.2460, Continent.AFRICA),
+            entry("CPT", "ZA", "남아프리카공화국", "케이프타운", -33.9648, 18.6017, Continent.AFRICA),
+            entry("CMN", "MA", "모로코", "카사블랑카", 33.3675, -7.5898, Continent.AFRICA),
+            entry("ADD", "ET", "에티오피아", "아디스아바바", 8.9779, 38.7993, Continent.AFRICA),
+            // ── 오세아니아 ────────────────────────────────────────────────────
+            entry("SYD", "AU", "호주", "시드니", -33.9461, 151.1772, Continent.OCEANIA),
+            entry("MEL", "AU", "호주", "멜버른", -37.6690, 144.8410, Continent.OCEANIA),
+            entry("BNE", "AU", "호주", "브리즈번", -27.3842, 153.1175, Continent.OCEANIA),
+            entry("PER", "AU", "호주", "퍼스", -31.9403, 115.9669, Continent.OCEANIA),
+            entry("AKL", "NZ", "뉴질랜드", "오클랜드", -37.0082, 174.7850, Continent.OCEANIA),
+            entry("CHC", "NZ", "뉴질랜드", "크라이스트처치", -43.4894, 172.5320, Continent.OCEANIA)
+    );
+
+    private static Map.Entry<String, AirportInfo> entry(
+            String iata, String countryCode, String countryNameKo,
+            String cityName, double lat, double lng, Continent continent) {
+        return Map.entry(iata, new AirportInfo(iata, countryCode, countryNameKo, cityName, lat, lng, continent));
+    }
+
+    public Optional<AirportInfo> findByIata(String iataCode) {
+        if (iataCode == null) return Optional.empty();
+        return Optional.ofNullable(AIRPORT_MAP.get(iataCode.toUpperCase()));
+    }
+
+    // ── 국가코드 → 대륙 매핑 (수동 등록 시 사용) ──────────────────────────
+    private static final Map<String, Continent> COUNTRY_CONTINENT_MAP = Map.ofEntries(
+            Map.entry("KR", Continent.ASIA), Map.entry("JP", Continent.ASIA),
+            Map.entry("CN", Continent.ASIA), Map.entry("TW", Continent.ASIA),
+            Map.entry("HK", Continent.ASIA), Map.entry("MO", Continent.ASIA),
+            Map.entry("TH", Continent.ASIA), Map.entry("VN", Continent.ASIA),
+            Map.entry("SG", Continent.ASIA), Map.entry("MY", Continent.ASIA),
+            Map.entry("PH", Continent.ASIA), Map.entry("ID", Continent.ASIA),
+            Map.entry("MM", Continent.ASIA), Map.entry("KH", Continent.ASIA),
+            Map.entry("LA", Continent.ASIA), Map.entry("IN", Continent.ASIA),
+            Map.entry("LK", Continent.ASIA), Map.entry("NP", Continent.ASIA),
+            Map.entry("BD", Continent.ASIA), Map.entry("PK", Continent.ASIA),
+            Map.entry("AE", Continent.ASIA), Map.entry("QA", Continent.ASIA),
+            Map.entry("SA", Continent.ASIA), Map.entry("JO", Continent.ASIA),
+            Map.entry("IL", Continent.ASIA), Map.entry("MN", Continent.ASIA),
+            Map.entry("KZ", Continent.ASIA), Map.entry("UZ", Continent.ASIA),
+            Map.entry("TR", Continent.EUROPE), Map.entry("GB", Continent.EUROPE),
+            Map.entry("FR", Continent.EUROPE), Map.entry("DE", Continent.EUROPE),
+            Map.entry("NL", Continent.EUROPE), Map.entry("ES", Continent.EUROPE),
+            Map.entry("IT", Continent.EUROPE), Map.entry("AT", Continent.EUROPE),
+            Map.entry("CH", Continent.EUROPE), Map.entry("BE", Continent.EUROPE),
+            Map.entry("DK", Continent.EUROPE), Map.entry("SE", Continent.EUROPE),
+            Map.entry("NO", Continent.EUROPE), Map.entry("FI", Continent.EUROPE),
+            Map.entry("IE", Continent.EUROPE), Map.entry("PT", Continent.EUROPE),
+            Map.entry("GR", Continent.EUROPE), Map.entry("CZ", Continent.EUROPE),
+            Map.entry("PL", Continent.EUROPE), Map.entry("HU", Continent.EUROPE),
+            Map.entry("RU", Continent.EUROPE), Map.entry("RO", Continent.EUROPE),
+            Map.entry("HR", Continent.EUROPE), Map.entry("RS", Continent.EUROPE),
+            Map.entry("SK", Continent.EUROPE), Map.entry("SI", Continent.EUROPE),
+            Map.entry("UA", Continent.EUROPE), Map.entry("BG", Continent.EUROPE),
+            Map.entry("US", Continent.NORTH_AMERICA), Map.entry("CA", Continent.NORTH_AMERICA),
+            Map.entry("MX", Continent.NORTH_AMERICA), Map.entry("GU", Continent.OCEANIA),
+            Map.entry("BR", Continent.SOUTH_AMERICA), Map.entry("CO", Continent.SOUTH_AMERICA),
+            Map.entry("PE", Continent.SOUTH_AMERICA), Map.entry("CL", Continent.SOUTH_AMERICA),
+            Map.entry("AR", Continent.SOUTH_AMERICA), Map.entry("EC", Continent.SOUTH_AMERICA),
+            Map.entry("VE", Continent.SOUTH_AMERICA), Map.entry("BO", Continent.SOUTH_AMERICA),
+            Map.entry("PY", Continent.SOUTH_AMERICA), Map.entry("UY", Continent.SOUTH_AMERICA),
+            Map.entry("EG", Continent.AFRICA), Map.entry("KE", Continent.AFRICA),
+            Map.entry("NG", Continent.AFRICA), Map.entry("ZA", Continent.AFRICA),
+            Map.entry("MA", Continent.AFRICA), Map.entry("ET", Continent.AFRICA),
+            Map.entry("TZ", Continent.AFRICA), Map.entry("GH", Continent.AFRICA),
+            Map.entry("AU", Continent.OCEANIA), Map.entry("NZ", Continent.OCEANIA)
+    );
+
+    public Continent getContinentByCountryCode(String countryCode) {
+        return COUNTRY_CONTINENT_MAP.getOrDefault(countryCode, Continent.ASIA);
+    }
+
+    // 두 좌표 간 거리 계산 (Haversine formula, km)
+    public double calculateDistanceKm(double lat1, double lng1, double lat2, double lng2) {
+        final double R = 6371.0;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/service/ConquestMapService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/service/ConquestMapService.java
@@ -232,6 +232,7 @@ public class ConquestMapService {
     @Transactional
     public void promotePlannedToVisited() {
         LocalDateTime now = LocalDateTime.now();
+        // TODO: Join Query 성능 개선 필요
         List<VisitedCountry> plannedCountries = visitedCountryRepository.findByStatus(VisitStatus.PLANNED);
 
         for (VisitedCountry plannedCountry : plannedCountries) {

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/service/ConquestMapService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/conquest/service/ConquestMapService.java
@@ -1,0 +1,384 @@
+package com.sofly.core.domain.conquest.service;
+
+import com.sofly.core.domain.conquest.dto.request.BulkImportRequest;
+import com.sofly.core.domain.conquest.dto.request.CityCreateRequest;
+import com.sofly.core.domain.conquest.dto.request.StatusUpdateRequest;
+import com.sofly.core.domain.conquest.dto.response.*;
+import com.sofly.core.domain.conquest.entity.VisitedCity;
+import com.sofly.core.domain.conquest.entity.VisitedCountry;
+import com.sofly.core.domain.conquest.enums.Continent;
+import com.sofly.core.domain.conquest.enums.VisitStatus;
+import com.sofly.core.domain.conquest.event.FlightSavedEvent;
+import com.sofly.core.domain.conquest.repository.VisitedCityRepository;
+import com.sofly.core.domain.conquest.repository.VisitedCountryRepository;
+import com.sofly.core.domain.conquest.service.AirportInfoService.AirportInfo;
+import com.sofly.core.domain.conquest.code.ConquestErrorCode;
+import com.sofly.core.domain.conquest.exception.ConquestException;
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.repository.UserRepository;
+import com.sofly.core.domain.workspace.code.WorkspaceErrorCode;
+import com.sofly.core.domain.workspace.entity.SavedFlight;
+import com.sofly.core.domain.workspace.entity.Workspace;
+import com.sofly.core.domain.workspace.exception.WorkspaceException;
+import com.sofly.core.domain.workspace.repository.SavedFlightRepository;
+import com.sofly.core.domain.workspace.repository.WorkspaceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConquestMapService {
+
+    private final VisitedCountryRepository visitedCountryRepository;
+    private final VisitedCityRepository visitedCityRepository;
+    private final AirportInfoService airportInfoService;
+    private final UserRepository userRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final SavedFlightRepository savedFlightRepository;
+
+    // ── 정복 지도 전체 조회 ─────────────────────────────────────────────
+
+    public ConquestMapResponse getConquestMap(Long userId) {
+        List<VisitedCountryResponse> countries = visitedCountryRepository.findByUserId(userId).stream()
+                .map(VisitedCountryResponse::from)
+                .toList();
+        List<VisitedCityResponse> cities = visitedCityRepository.findByUserId(userId).stream()
+                .map(VisitedCityResponse::from)
+                .toList();
+        return ConquestMapResponse.builder()
+                .countries(countries)
+                .cities(cities)
+                .build();
+    }
+
+    // ── 통계 패널 ───────────────────────────────────────────────────────
+
+    public ConquestStatsResponse getStats(Long userId) {
+        List<VisitedCountry> visitedCountries = visitedCountryRepository
+                .findByUserIdAndStatus(userId, VisitStatus.VISITED);
+        List<VisitedCity> visitedCities = visitedCityRepository
+                .findByUserId(userId).stream()
+                .filter(c -> c.getStatus() == VisitStatus.VISITED)
+                .toList();
+
+        int totalTravelDays = calculateTotalTravelDays(userId);
+        double totalDistanceKm = calculateTotalDistanceKm(userId);
+
+        Map<Continent, Long> continentCountMap = visitedCountries.stream()
+                .collect(Collectors.groupingBy(VisitedCountry::getContinent, Collectors.counting()));
+
+        List<ConquestStatsResponse.ContinentStats> continentStats = Arrays.stream(Continent.values())
+                .map(continent -> ConquestStatsResponse.ContinentStats.builder()
+                        .continent(continent)
+                        .continentName(continent.getDisplayName())
+                        .visitedCountryCount(continentCountMap.getOrDefault(continent, 0L).intValue())
+                        .build())
+                .toList();
+
+        return ConquestStatsResponse.of(
+                visitedCountries.size(),
+                visitedCities.size(),
+                totalTravelDays,
+                Math.round(totalDistanceKm * 10.0) / 10.0,
+                continentStats
+        );
+    }
+
+    // ── 국가 상태 수동 변경 ─────────────────────────────────────────────
+
+    @Transactional
+    public VisitedCountryResponse updateCountryStatus(Long userId, String countryCode, StatusUpdateRequest request) {
+        VisitedCountry visitedCountry = visitedCountryRepository
+                .findByUserIdAndCountryCode(userId, countryCode)
+                .orElseGet(() -> createVisitedCountry(userId, countryCode));
+
+        visitedCountry.updateStatus(request.getStatus());
+        return VisitedCountryResponse.from(visitedCountry);
+    }
+
+    // ── 도시 수동 추가 ──────────────────────────────────────────────────
+
+    @Transactional
+    public VisitedCityResponse addOrUpdateCity(Long userId, CityCreateRequest request) {
+        User user = userRepository.getReferenceById(userId);
+        VisitedCity visitedCity = visitedCityRepository
+                .findByUserIdAndCityNameAndCountryCode(userId, request.getCityName(), request.getCountryCode())
+                .orElseGet(() -> visitedCityRepository.save(VisitedCity.builder()
+                        .user(user)
+                        .cityName(request.getCityName())
+                        .countryCode(request.getCountryCode())
+                        .latitude(request.getLatitude())
+                        .longitude(request.getLongitude())
+                        .build()));
+
+        visitedCity.updateStatus(request.getStatus());
+        return VisitedCityResponse.from(visitedCity);
+    }
+
+    // ── 도시 상태 변경 ──────────────────────────────────────────────────
+
+    @Transactional
+    public VisitedCityResponse updateCityStatus(Long userId, Long cityId, StatusUpdateRequest request) {
+        VisitedCity visitedCity = visitedCityRepository.findById(cityId)
+                .orElseThrow(() -> new ConquestException(ConquestErrorCode.CITY_NOT_FOUND));
+        if (!visitedCity.getUser().getId().equals(userId)) {
+            throw new ConquestException(ConquestErrorCode.CONQUEST_FORBIDDEN);
+        }
+        visitedCity.updateStatus(request.getStatus());
+        return VisitedCityResponse.from(visitedCity);
+    }
+
+    // ── 과거 방문 일괄 등록 ─────────────────────────────────────────────
+
+    @Transactional
+    public void bulkImport(Long userId, BulkImportRequest request) {
+        User user = userRepository.getReferenceById(userId);
+
+        if (request.getCountries() != null) {
+            for (BulkImportRequest.CountryImport ci : request.getCountries()) {
+                VisitedCountry country = visitedCountryRepository
+                        .findByUserIdAndCountryCode(userId, ci.getCountryCode())
+                        .orElseGet(() -> {
+                            Continent continent = airportInfoService.getContinentByCountryCode(ci.getCountryCode());
+                            return visitedCountryRepository.save(VisitedCountry.builder()
+                                    .user(user)
+                                    .countryCode(ci.getCountryCode())
+                                    .countryName(ci.getCountryCode()) // 국가명 미입력 시 코드로 저장
+                                    .continent(continent)
+                                    .build());
+                        });
+                country.updateStatus(ci.getStatus());
+            }
+        }
+
+        if (request.getCities() != null) {
+            for (BulkImportRequest.CityImport ci : request.getCities()) {
+                VisitedCity city = visitedCityRepository
+                        .findByUserIdAndCityNameAndCountryCode(userId, ci.getCityName(), ci.getCountryCode())
+                        .orElseGet(() -> visitedCityRepository.save(VisitedCity.builder()
+                                .user(user)
+                                .cityName(ci.getCityName())
+                                .countryCode(ci.getCountryCode())
+                                .latitude(ci.getLatitude())
+                                .longitude(ci.getLongitude())
+                                .build()));
+                city.updateStatus(ci.getStatus());
+            }
+        }
+    }
+
+    // ── 국가별 연관 워크스페이스 조회 ──────────────────────────────────
+
+    public List<WorkspaceConquestResponse> getWorkspacesByCountry(Long userId, String countryCode) {
+        return workspaceRepository.findAllByUserIdAndCountryCode(userId, countryCode).stream()
+                .map(WorkspaceConquestResponse::from)
+                .toList();
+    }
+
+    // ── 여행 경로(Arc) 조회 ─────────────────────────────────────────────
+
+    public List<TripRouteResponse> getTripRoutes(Long userId) {
+        List<Workspace> workspaces = workspaceRepository.findAllWithOwnerByUserId(userId);
+        List<TripRouteResponse> routes = new ArrayList<>();
+
+        for (Workspace workspace : workspaces) {
+            List<SavedFlight> flights = savedFlightRepository.findAllByWorkspaceId(workspace.getId());
+            for (SavedFlight flight : flights) {
+                buildRoute(flight, workspace).ifPresent(routes::add);
+            }
+        }
+        return routes;
+    }
+
+    public List<TripRouteResponse> getTripRoutesByWorkspace(Long userId, Long workspaceId) {
+        Workspace workspace = workspaceRepository.findWithOwnerById(workspaceId)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
+        return savedFlightRepository.findAllByWorkspaceId(workspaceId).stream()
+                .map(flight -> buildRoute(flight, workspace))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
+    }
+
+    // ── 항공편 저장 이벤트 수신 (PLANNED 자동 반영) ────────────────────
+
+    @EventListener
+    @Transactional
+    public void onFlightSaved(FlightSavedEvent event) {
+        AirportInfo arrivalInfo = airportInfoService.findByIata(event.getArrivalAirport()).orElse(null);
+        if (arrivalInfo == null) {
+            log.warn("알 수 없는 도착 공항 코드: {}", event.getArrivalAirport());
+            return;
+        }
+
+        for (Long userId : event.getMemberUserIds()) {
+            User user = userRepository.getReferenceById(userId);
+            applyPlannedStatus(user, arrivalInfo);
+        }
+    }
+
+    // ── 스케줄러 호출용: PLANNED → VISITED 자동 전환 ──────────────────
+
+    @Transactional
+    public void promotePlannedToVisited() {
+        LocalDateTime now = LocalDateTime.now();
+        List<VisitedCountry> plannedCountries = visitedCountryRepository.findByStatus(VisitStatus.PLANNED);
+
+        for (VisitedCountry plannedCountry : plannedCountries) {
+            Long userId = plannedCountry.getUser().getId();
+            boolean hasDepartedFlight = hasDepartedFlightToCountry(userId, plannedCountry.getCountryCode(), now);
+            if (hasDepartedFlight) {
+                plannedCountry.updateStatus(VisitStatus.VISITED);
+                log.info("PLANNED → VISITED 전환: userId={}, country={}", userId, plannedCountry.getCountryCode());
+            }
+        }
+
+        List<VisitedCity> plannedCities = visitedCityRepository.findByStatus(VisitStatus.PLANNED);
+        for (VisitedCity plannedCity : plannedCities) {
+            Long userId = plannedCity.getUser().getId();
+            boolean hasDepartedFlight = hasDepartedFlightToCountry(userId, plannedCity.getCountryCode(), now);
+            if (hasDepartedFlight) {
+                plannedCity.updateStatus(VisitStatus.VISITED);
+                log.info("PLANNED → VISITED 전환: userId={}, city={}", userId, plannedCity.getCityName());
+            }
+        }
+    }
+
+    // ── 내부 헬퍼 ──────────────────────────────────────────────────────
+
+    private VisitedCountry createVisitedCountry(Long userId, String countryCode) {
+        User user = userRepository.getReferenceById(userId);
+        AirportInfo info = airportInfoService.findByIata(countryCode).orElse(null);
+        Continent continent = airportInfoService.getContinentByCountryCode(countryCode);
+        String countryName = countryCode; // 기본값, 공항 정보로 덮어쓰기
+        return visitedCountryRepository.save(VisitedCountry.builder()
+                .user(user)
+                .countryCode(countryCode)
+                .countryName(countryName)
+                .continent(continent)
+                .build());
+    }
+
+    private void applyPlannedStatus(User user, AirportInfo arrivalInfo) {
+        // 국가 PLANNED 처리
+        visitedCountryRepository
+                .findByUserIdAndCountryCode(user.getId(), arrivalInfo.countryCode())
+                .ifPresentOrElse(
+                        vc -> {
+                            if (vc.getStatus() == VisitStatus.UNVISITED) {
+                                vc.updateStatus(VisitStatus.PLANNED);
+                            }
+                        },
+                        () -> visitedCountryRepository.save(VisitedCountry.builder()
+                                .user(user)
+                                .countryCode(arrivalInfo.countryCode())
+                                .countryName(arrivalInfo.countryNameKo())
+                                .continent(arrivalInfo.continent())
+                                .status(VisitStatus.PLANNED)
+                                .build())
+                );
+
+        // 도시 PLANNED 처리
+        visitedCityRepository
+                .findByUserIdAndCityNameAndCountryCode(user.getId(), arrivalInfo.cityName(), arrivalInfo.countryCode())
+                .ifPresentOrElse(
+                        vc -> {
+                            if (vc.getStatus() == VisitStatus.UNVISITED) {
+                                vc.updateStatus(VisitStatus.PLANNED);
+                            }
+                        },
+                        () -> visitedCityRepository.save(VisitedCity.builder()
+                                .user(user)
+                                .cityName(arrivalInfo.cityName())
+                                .countryCode(arrivalInfo.countryCode())
+                                .latitude(arrivalInfo.latitude())
+                                .longitude(arrivalInfo.longitude())
+                                .status(VisitStatus.PLANNED)
+                                .build())
+                );
+    }
+
+    private boolean hasDepartedFlightToCountry(Long userId, String countryCode, LocalDateTime now) {
+        List<Workspace> workspaces = workspaceRepository.findAllWithOwnerByUserId(userId);
+        for (Workspace workspace : workspaces) {
+            List<SavedFlight> flights = savedFlightRepository.findAllByWorkspaceId(workspace.getId());
+            for (SavedFlight flight : flights) {
+                if (flight.getDepartureTime().isBefore(now)) {
+                    AirportInfo arrivalInfo = airportInfoService.findByIata(flight.getArrivalAirport()).orElse(null);
+                    if (arrivalInfo != null && arrivalInfo.countryCode().equals(countryCode)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private Optional<TripRouteResponse> buildRoute(SavedFlight flight, Workspace workspace) {
+        AirportInfo depInfo = airportInfoService.findByIata(flight.getDepartureAirport()).orElse(null);
+        AirportInfo arrInfo = airportInfoService.findByIata(flight.getArrivalAirport()).orElse(null);
+        if (depInfo == null || arrInfo == null) return Optional.empty();
+
+        double distanceKm = airportInfoService.calculateDistanceKm(
+                depInfo.latitude(), depInfo.longitude(),
+                arrInfo.latitude(), arrInfo.longitude()
+        );
+        TripRouteResponse.RouteType routeType = depInfo.countryCode().equals(arrInfo.countryCode())
+                ? TripRouteResponse.RouteType.DOMESTIC
+                : TripRouteResponse.RouteType.INTERNATIONAL;
+
+        return Optional.of(TripRouteResponse.builder()
+                .flightId(flight.getId())
+                .workspaceId(workspace.getId())
+                .workspaceTitle(workspace.getTitle())
+                .departureAirport(flight.getDepartureAirport())
+                .departureCity(depInfo.cityName())
+                .departureCountryCode(depInfo.countryCode())
+                .departureLat(depInfo.latitude())
+                .departureLng(depInfo.longitude())
+                .arrivalAirport(flight.getArrivalAirport())
+                .arrivalCity(arrInfo.cityName())
+                .arrivalCountryCode(arrInfo.countryCode())
+                .arrivalLat(arrInfo.latitude())
+                .arrivalLng(arrInfo.longitude())
+                .departureTime(flight.getDepartureTime())
+                .arrivalTime(flight.getArrivalTime())
+                .airline(flight.getAirline())
+                .flightNumber(flight.getFlightNumber())
+                .distanceKm(Math.round(distanceKm * 10.0) / 10.0)
+                .routeType(routeType)
+                .build());
+    }
+
+    private int calculateTotalTravelDays(Long userId) {
+        return workspaceRepository.findAllWithOwnerByUserId(userId).stream()
+                .filter(ws -> ws.getEndDate() != null && ws.getStartDate() != null
+                        && !ws.getEndDate().isAfter(LocalDate.now()))
+                .mapToInt(ws -> (int) (ws.getEndDate().toEpochDay() - ws.getStartDate().toEpochDay() + 1))
+                .sum();
+    }
+
+    private double calculateTotalDistanceKm(Long userId) {
+        return workspaceRepository.findAllWithOwnerByUserId(userId).stream()
+                .flatMap(ws -> savedFlightRepository.findAllByWorkspaceId(ws.getId()).stream())
+                .filter(flight -> flight.getDepartureTime().isBefore(LocalDateTime.now()))
+                .mapToDouble(flight -> {
+                    AirportInfo dep = airportInfoService.findByIata(flight.getDepartureAirport()).orElse(null);
+                    AirportInfo arr = airportInfoService.findByIata(flight.getArrivalAirport()).orElse(null);
+                    if (dep == null || arr == null) return 0;
+                    return airportInfoService.calculateDistanceKm(
+                            dep.latitude(), dep.longitude(), arr.latitude(), arr.longitude());
+                })
+                .sum();
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceRepository.java
@@ -21,4 +21,10 @@ public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
            "JOIN FETCH wm.workspace.owner " +
            "WHERE wm.user.id = :userId")
     List<Workspace> findAllWithOwnerByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT DISTINCT wm.workspace FROM WorkspaceMember wm " +
+           "JOIN FETCH wm.workspace.owner " +
+           "WHERE wm.user.id = :userId AND wm.workspace.countryCode = :countryCode")
+    List<Workspace> findAllByUserIdAndCountryCode(@Param("userId") Long userId,
+                                                  @Param("countryCode") String countryCode);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ import com.sofly.core.domain.workspace.exception.WorkspaceException;
 import com.sofly.core.domain.workspace.repository.SavedFlightRepository;
 import com.sofly.core.domain.workspace.repository.WorkspaceMemberRepository;
 import com.sofly.core.domain.workspace.repository.WorkspaceRepository;
+import com.sofly.core.domain.conquest.event.FlightSavedEvent;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,6 +42,7 @@ public class WorkspaceService {
     private final WorkspaceMemberRepository workspaceMemberRepository;
     private final SavedFlightRepository savedFlightRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${sofly.oauth2.redirect-uri}")
     private String baseUrl;
@@ -219,6 +222,19 @@ public class WorkspaceService {
                 .build();
 
         savedFlightRepository.save(flight);
+
+        // 정복 지도: 도착 국가/도시를 PLANNED 상태로 자동 반영
+        List<Long> memberIds = workspace.getMembers().stream()
+                .map(member -> member.getUser().getId())
+                .toList();
+        eventPublisher.publishEvent(new FlightSavedEvent(
+                memberIds,
+                workspace.getId(),
+                request.getDepartureAirport(),
+                request.getArrivalAirport(),
+                request.getDepartureTime()
+        ));
+
         return SavedFlightResponse.from(flight);
     }
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.sofly.core.domain.conquest.exception.ConquestException;
 import com.sofly.core.domain.user.exception.UserException;
 import com.sofly.core.domain.workspace.exception.WorkspaceException;
 import com.sofly.core.global.response.ApiResponse;
@@ -33,6 +34,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(WorkspaceException.class)
     public ResponseEntity<ApiResponse<Void>> handleWorkspaceException(WorkspaceException e) {
         log.warn("WorkspaceException: {}", e.getMessage());
+        BaseErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(ConquestException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConquestException(ConquestException e) {
+        log.warn("ConquestException: {}", e.getMessage());
         BaseErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                         "/",
                         "/index.html",
                         "/user-profile-test.html",
+                        "/conquest-test.html",
                         "/login/oauth2/**",
                         "/oauth2/**",
                         "/api/auth/refresh",

--- a/services/travel-core-service/src/main/resources/static/conquest-test.html
+++ b/services/travel-core-service/src/main/resources/static/conquest-test.html
@@ -474,7 +474,7 @@ function setupLayers() {
   // Country fill (visual)
   map.addLayer({ id: 'c-fill', type: 'fill', source: 'cb', 'source-layer': 'country_boundaries',
     filter: WV_FILTER,
-    paint: { 'fill-color': '#1e293b', 'fill-opacity': 0.55 }
+    paint: { 'fill-color': '#1e293b', 'fill-opacity': 0 }  // opacity 0으로
   });
   // Country outline
   map.addLayer({ id: 'c-line', type: 'line', source: 'cb', 'source-layer': 'country_boundaries',
@@ -630,16 +630,12 @@ async function loadAll() {
 function updateCountryLayer() {
   if (!map || !conquest) return;
   const countries = extract(conquest)?.countries || [];
-  // Mapbox 타일셋의 iso_3166_1_alpha_3 (3자리) 기준으로 색을 매핑한다.
-  // API의 countryCode는 alpha-2 이므로 A2_A3 테이블로 변환.
-  const expr = ['match', ['get', 'iso_3166_1_alpha_3']];
+  const expr = ['match', ['get', 'iso_3166_1']];
   for (const c of countries) {
-    const iso3 = A2_A3[c.countryCode];
-    if (!iso3) continue;
-    if (c.status === 'VISITED') { expr.push(iso3); expr.push('#8b5cf6'); }
-    else if (c.status === 'PLANNED') { expr.push(iso3); expr.push('#f59e0b'); }
+    if (c.status === 'VISITED') { expr.push(c.countryCode); expr.push('#8b5cf6'); }
+    else if (c.status === 'PLANNED') { expr.push(c.countryCode); expr.push('#f59e0b'); }
   }
-  expr.push('#1e293b');
+  expr.push('transparent');  // #1e293b → transparent
   map.setPaintProperty('c-fill', 'fill-color', expr);
   map.setPaintProperty('c-fill', 'fill-opacity', 0.72);
 }

--- a/services/travel-core-service/src/main/resources/static/conquest-test.html
+++ b/services/travel-core-service/src/main/resources/static/conquest-test.html
@@ -339,6 +339,47 @@
 
 <script>
 // =====================================================
+// ISO 3166-1 alpha-2 ↔ alpha-3 lookup tables
+// 백엔드 API는 alpha-2(KR), Mapbox 타일셋은 iso_3166_1_alpha_3(KOR)을 사용하므로
+// 프론트엔드에서 변환한다. 백엔드 코드 변경 불필요.
+// =====================================================
+const A2_A3 = {
+  AF:'AFG',AX:'ALA',AL:'ALB',DZ:'DZA',AS:'ASM',AD:'AND',AO:'AGO',AI:'AIA',
+  AQ:'ATA',AG:'ATG',AR:'ARG',AM:'ARM',AW:'ABW',AU:'AUS',AT:'AUT',AZ:'AZE',
+  BS:'BHS',BH:'BHR',BD:'BGD',BB:'BRB',BY:'BLR',BE:'BEL',BZ:'BLZ',BJ:'BEN',
+  BM:'BMU',BT:'BTN',BO:'BOL',BQ:'BES',BA:'BIH',BW:'BWA',BV:'BVT',BR:'BRA',
+  IO:'IOT',BN:'BRN',BG:'BGR',BF:'BFA',BI:'BDI',CV:'CPV',KH:'KHM',CM:'CMR',
+  CA:'CAN',KY:'CYM',CF:'CAF',TD:'TCD',CL:'CHL',CN:'CHN',CX:'CXR',CC:'CCK',
+  CO:'COL',KM:'COM',CG:'COG',CD:'COD',CK:'COK',CR:'CRI',CI:'CIV',HR:'HRV',
+  CU:'CUB',CW:'CUW',CY:'CYP',CZ:'CZE',DK:'DNK',DJ:'DJI',DM:'DMA',DO:'DOM',
+  EC:'ECU',EG:'EGY',SV:'SLV',GQ:'GNQ',ER:'ERI',EE:'EST',SZ:'SWZ',ET:'ETH',
+  FK:'FLK',FO:'FRO',FJ:'FJI',FI:'FIN',FR:'FRA',GF:'GUF',PF:'PYF',TF:'ATF',
+  GA:'GAB',GM:'GMB',GE:'GEO',DE:'DEU',GH:'GHA',GI:'GIB',GR:'GRC',GL:'GRL',
+  GD:'GRD',GP:'GLP',GU:'GUM',GT:'GTM',GG:'GGY',GN:'GIN',GW:'GNB',GY:'GUY',
+  HT:'HTI',HM:'HMD',VA:'VAT',HN:'HND',HK:'HKG',HU:'HUN',IS:'ISL',IN:'IND',
+  ID:'IDN',IR:'IRN',IQ:'IRQ',IE:'IRL',IM:'IMN',IL:'ISR',IT:'ITA',JM:'JAM',
+  JP:'JPN',JE:'JEY',JO:'JOR',KZ:'KAZ',KE:'KEN',KI:'KIR',KP:'PRK',KR:'KOR',
+  KW:'KWT',KG:'KGZ',LA:'LAO',LV:'LVA',LB:'LBN',LS:'LSO',LR:'LBR',LY:'LBY',
+  LI:'LIE',LT:'LTU',LU:'LUX',MO:'MAC',MG:'MDG',MW:'MWI',MY:'MYS',MV:'MDV',
+  ML:'MLI',MT:'MLT',MH:'MHL',MQ:'MTQ',MR:'MRT',MU:'MUS',YT:'MYT',MX:'MEX',
+  FM:'FSM',MD:'MDA',MC:'MCO',MN:'MNG',ME:'MNE',MS:'MSR',MA:'MAR',MZ:'MOZ',
+  MM:'MMR',NA:'NAM',NR:'NRU',NP:'NPL',NL:'NLD',NC:'NCL',NZ:'NZL',NI:'NIC',
+  NE:'NER',NG:'NGA',NU:'NIU',NF:'NFK',MK:'MKD',MP:'MNP',NO:'NOR',OM:'OMN',
+  PK:'PAK',PW:'PLW',PS:'PSE',PA:'PAN',PG:'PNG',PY:'PRY',PE:'PER',PH:'PHL',
+  PN:'PCN',PL:'POL',PT:'PRT',PR:'PRI',QA:'QAT',RE:'REU',RO:'ROU',RU:'RUS',
+  RW:'RWA',BL:'BLM',SH:'SHN',KN:'KNA',LC:'LCA',MF:'MAF',PM:'SPM',VC:'VCT',
+  WS:'WSM',SM:'SMR',ST:'STP',SA:'SAU',SN:'SEN',RS:'SRB',SC:'SYC',SL:'SLE',
+  SG:'SGP',SX:'SXM',SK:'SVK',SI:'SVN',SB:'SLB',SO:'SOM',ZA:'ZAF',GS:'SGS',
+  SS:'SSD',ES:'ESP',LK:'LKA',SD:'SDN',SR:'SUR',SJ:'SJM',SE:'SWE',CH:'CHE',
+  SY:'SYR',TW:'TWN',TJ:'TJK',TZ:'TZA',TH:'THA',TL:'TLS',TG:'TGO',TK:'TKL',
+  TO:'TON',TT:'TTO',TN:'TUN',TR:'TUR',TM:'TKM',TC:'TCA',TV:'TUV',UG:'UGA',
+  UA:'UKR',AE:'ARE',GB:'GBR',US:'USA',UM:'UMI',UY:'URY',UZ:'UZB',VU:'VUT',
+  VE:'VEN',VN:'VNM',VG:'VGB',VI:'VIR',WF:'WLF',EH:'ESH',YE:'YEM',ZM:'ZMB',
+  ZW:'ZWE'
+};
+const A3_A2 = Object.fromEntries(Object.entries(A2_A3).map(([k,v])=>[v,k]));
+
+// =====================================================
 // STATE
 // =====================================================
 let map = null;
@@ -416,10 +457,21 @@ function setupSources() {
   map.addSource('routes', { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
 }
 
-const WV_FILTER = ['any', ['==', ['get', 'worldview'], 'all'], ['==', ['get', 'worldview'], 'US']];
+// 시각 레이어용 worldview 필터 (Mapbox 공식 권장 방식)
+// 'all' + 'US' worldview를 사용해 분쟁지역 중복 없이 모든 국가를 표시
+const WV_FILTER = ['in', ['get', 'worldview'], ['literal', ['all', 'US']]];
 
 function setupLayers() {
-  // Country fill
+  // ── c-hit: 이벤트 전용 invisible 레이어 ──────────────────────────────
+  // worldview 필터 없이 모든 feature를 커버한다.
+  // 이렇게 하지 않으면 'all' worldview에 없는 분쟁 지역(크림반도, 포클랜드 등)
+  // 경계 근처에서 hover/click 이벤트가 발생하지 않는 "지리적 구멍"이 생긴다.
+  // fill-opacity:0 이어도 Mapbox는 geometry 기반으로 이벤트를 발생시킨다.
+  map.addLayer({ id: 'c-hit', type: 'fill', source: 'cb', 'source-layer': 'country_boundaries',
+    filter: ['has', 'iso_3166_1_alpha_3'],
+    paint: { 'fill-opacity': 0 }
+  });
+  // Country fill (visual)
   map.addLayer({ id: 'c-fill', type: 'fill', source: 'cb', 'source-layer': 'country_boundaries',
     filter: WV_FILTER,
     paint: { 'fill-color': '#1e293b', 'fill-opacity': 0.55 }
@@ -429,12 +481,12 @@ function setupLayers() {
     filter: WV_FILTER,
     paint: { 'line-color': 'rgba(255,255,255,0.07)', 'line-width': 0.5 }
   });
-  // Hover highlight
+  // Hover highlight (alpha-3 기준)
   map.addLayer({ id: 'c-hover', type: 'fill', source: 'cb', 'source-layer': 'country_boundaries',
     filter: ['==', ['get', 'iso_3166_1_alpha_3'], ''],
     paint: { 'fill-color': 'rgba(255,255,255,0.08)', 'fill-opacity': 1 }
   });
-  // Selected outline
+  // Selected outline (alpha-3 기준)
   map.addLayer({ id: 'c-sel', type: 'line', source: 'cb', 'source-layer': 'country_boundaries',
     filter: ['==', ['get', 'iso_3166_1_alpha_3'], ''],
     paint: { 'line-color': '#a78bfa', 'line-width': 2 }
@@ -473,25 +525,30 @@ function setupLayers() {
 }
 
 function setupEvents() {
-  // Country hover
-  map.on('mousemove', 'c-fill', e => {
+  // ── 국가 hover / click은 c-hit 레이어에 달아야 한다 ──────────────────
+  // c-hit은 worldview 필터가 없어서 분쟁지역 경계 근방의 "지리적 구멍"이 없다.
+  // iso_3166_1_alpha_3 (3자리)를 기준으로 동작하며, API 호출은 A3_A2로 변환.
+
+  map.on('mousemove', 'c-hit', e => {
     if (!e.features.length) return;
     map.getCanvas().style.cursor = 'pointer';
-    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1_alpha_3'], e.features[0].properties.iso_3166_1_alpha_3 || '']);
+    const f = e.features.find(f => f.properties?.iso_3166_1_alpha_3?.length === 3);
+    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1_alpha_3'], f?.properties.iso_3166_1_alpha_3 || '']);
   });
-  map.on('mouseleave', 'c-fill', () => {
+  map.on('mouseleave', 'c-hit', () => {
     map.getCanvas().style.cursor = '';
     map.setFilter('c-hover', ['==', ['get', 'iso_3166_1_alpha_3'], '']);
   });
 
-  // Country click → sidebar
-  map.on('click', 'c-fill', async e => {
-    if (!e.features.length) return;
-    const code = e.features[0].properties.iso_3166_1_alpha_3;
-    if (!code) return;
-    selCountry = code;
-    map.setFilter('c-sel', ['==', ['get', 'iso_3166_1_alpha_3'], code]);
-    await openCountrySidebar(code);
+  map.on('click', 'c-hit', async e => {
+    // c-hit feature 에서 alpha-3 코드 추출
+    // 같은 위치에 feature가 여러 개일 수 있으므로 유효한 것을 찾는다
+    const f = e.features.find(f => f.properties?.iso_3166_1_alpha_3?.length === 3);
+    const iso3 = f?.properties.iso_3166_1_alpha_3;
+    if (!iso3) return;
+    selCountry = iso3;
+    map.setFilter('c-sel', ['==', ['get', 'iso_3166_1_alpha_3'], iso3]);
+    await openCountrySidebar(iso3);
   });
 
   // Cluster zoom
@@ -530,7 +587,7 @@ function setupEvents() {
 
   // Click on empty → deselect
   map.on('click', e => {
-    const f = map.queryRenderedFeatures(e.point, { layers: ['c-fill', 'city-pt', 'cl-circle'] });
+    const f = map.queryRenderedFeatures(e.point, { layers: ['c-hit', 'city-pt', 'cl-circle'] });
     if (!f.length) {
       selCountry = null;
       map?.setFilter('c-sel', ['==', ['get', 'iso_3166_1_alpha_3'], '']);
@@ -573,10 +630,14 @@ async function loadAll() {
 function updateCountryLayer() {
   if (!map || !conquest) return;
   const countries = extract(conquest)?.countries || [];
+  // Mapbox 타일셋의 iso_3166_1_alpha_3 (3자리) 기준으로 색을 매핑한다.
+  // API의 countryCode는 alpha-2 이므로 A2_A3 테이블로 변환.
   const expr = ['match', ['get', 'iso_3166_1_alpha_3']];
   for (const c of countries) {
-    if (c.status === 'VISITED') { expr.push(c.countryCode); expr.push('#8b5cf6'); }
-    else if (c.status === 'PLANNED') { expr.push(c.countryCode); expr.push('#f59e0b'); }
+    const iso3 = A2_A3[c.countryCode];
+    if (!iso3) continue;
+    if (c.status === 'VISITED') { expr.push(iso3); expr.push('#8b5cf6'); }
+    else if (c.status === 'PLANNED') { expr.push(iso3); expr.push('#f59e0b'); }
   }
   expr.push('#1e293b');
   map.setPaintProperty('c-fill', 'fill-color', expr);
@@ -690,11 +751,14 @@ function toggleStats() {
 // =====================================================
 // WORKSPACE SIDEBAR
 // =====================================================
-async function openCountrySidebar(code) {
+// iso3: Mapbox의 iso_3166_1_alpha_3 코드 (예: 'KOR')
+// API 호출은 alpha-2(예: 'KR')로 변환한다.
+async function openCountrySidebar(iso3) {
+  const iso2 = A3_A2[iso3] || '';
   const countries = extract(conquest)?.countries || [];
-  const c = countries.find(x => x.countryCode === code);
+  const c = countries.find(x => x.countryCode === iso2);
   const status = c?.status || 'UNVISITED';
-  const name = c?.countryName || code;
+  const name = c?.countryName || iso3;
 
   document.getElementById('wsTitle').textContent = name;
   document.getElementById('wsMeta').innerHTML = `
@@ -702,15 +766,17 @@ async function openCountrySidebar(code) {
     ${c?.continentName ? `<span>${c.continentName}</span>` : ''}
     ${c?.visitCount > 0 ? `<span>${c.visitCount}회 방문</span>` : ''}
   `;
+  // openCountryModal 에는 alpha-2 를 전달 (API PUT 요청에 사용)
   document.getElementById('wsActions').innerHTML = `
-    <button class="btn btn-secondary btn-sm" onclick="openCountryModal('${code}','${status}','${esc(name)}')">상태 변경</button>
+    <button class="btn btn-secondary btn-sm" onclick="openCountryModal('${iso2}','${status}','${esc(name)}')">상태 변경</button>
     <button class="btn btn-secondary btn-sm" onclick="setRouteFilter('all');document.querySelectorAll('.ws-card').forEach(e=>e.classList.remove('hl'))">전체 경로</button>
   `;
   document.getElementById('wsBody').innerHTML = '<div class="empty"><div class="spin"></div></div>';
   document.getElementById('wsSidebar').classList.add('open');
 
   try {
-    const data = await api('GET', `/api/conquest/countries/${code}/workspaces`);
+    // API는 alpha-2 사용
+    const data = await api('GET', `/api/conquest/countries/${iso2}/workspaces`);
     const ws = extract(data) || data || [];
     if (!ws.length) {
       document.getElementById('wsBody').innerHTML = '<div class="empty">이 국가와 연결된 워크스페이스가 없습니다</div>';

--- a/services/travel-core-service/src/main/resources/static/conquest-test.html
+++ b/services/travel-core-service/src/main/resources/static/conquest-test.html
@@ -431,12 +431,12 @@ function setupLayers() {
   });
   // Hover highlight
   map.addLayer({ id: 'c-hover', type: 'fill', source: 'cb', 'source-layer': 'country_boundaries',
-    filter: ['==', ['get', 'iso_3166_1'], ''],
+    filter: ['==', ['get', 'iso_3166_1_alpha_3'], ''],
     paint: { 'fill-color': 'rgba(255,255,255,0.08)', 'fill-opacity': 1 }
   });
   // Selected outline
   map.addLayer({ id: 'c-sel', type: 'line', source: 'cb', 'source-layer': 'country_boundaries',
-    filter: ['==', ['get', 'iso_3166_1'], ''],
+    filter: ['==', ['get', 'iso_3166_1_alpha_3'], ''],
     paint: { 'line-color': '#a78bfa', 'line-width': 2 }
   });
   // Routes
@@ -477,20 +477,20 @@ function setupEvents() {
   map.on('mousemove', 'c-fill', e => {
     if (!e.features.length) return;
     map.getCanvas().style.cursor = 'pointer';
-    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1'], e.features[0].properties.iso_3166_1 || '']);
+    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1_alpha_3'], e.features[0].properties.iso_3166_1_alpha_3 || '']);
   });
   map.on('mouseleave', 'c-fill', () => {
     map.getCanvas().style.cursor = '';
-    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1'], '']);
+    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1_alpha_3'], '']);
   });
 
   // Country click → sidebar
   map.on('click', 'c-fill', async e => {
     if (!e.features.length) return;
-    const code = e.features[0].properties.iso_3166_1;
+    const code = e.features[0].properties.iso_3166_1_alpha_3;
     if (!code) return;
     selCountry = code;
-    map.setFilter('c-sel', ['==', ['get', 'iso_3166_1'], code]);
+    map.setFilter('c-sel', ['==', ['get', 'iso_3166_1_alpha_3'], code]);
     await openCountrySidebar(code);
   });
 
@@ -533,7 +533,7 @@ function setupEvents() {
     const f = map.queryRenderedFeatures(e.point, { layers: ['c-fill', 'city-pt', 'cl-circle'] });
     if (!f.length) {
       selCountry = null;
-      map?.setFilter('c-sel', ['==', ['get', 'iso_3166_1'], '']);
+      map?.setFilter('c-sel', ['==', ['get', 'iso_3166_1_alpha_3'], '']);
     }
   });
 
@@ -573,7 +573,7 @@ async function loadAll() {
 function updateCountryLayer() {
   if (!map || !conquest) return;
   const countries = extract(conquest)?.countries || [];
-  const expr = ['match', ['get', 'iso_3166_1']];
+  const expr = ['match', ['get', 'iso_3166_1_alpha_3']];
   for (const c of countries) {
     if (c.status === 'VISITED') { expr.push(c.countryCode); expr.push('#8b5cf6'); }
     else if (c.status === 'PLANNED') { expr.push(c.countryCode); expr.push('#f59e0b'); }
@@ -731,7 +731,7 @@ async function openCountrySidebar(code) {
 function closeWsSidebar() {
   document.getElementById('wsSidebar').classList.remove('open');
   selCountry = null;
-  map?.setFilter('c-sel', ['==', ['get', 'iso_3166_1'], '']);
+  map?.setFilter('c-sel', ['==', ['get', 'iso_3166_1_alpha_3'], '']);
 }
 
 function hlRoute(wsId) {

--- a/services/travel-core-service/src/main/resources/static/conquest-test.html
+++ b/services/travel-core-service/src/main/resources/static/conquest-test.html
@@ -1,0 +1,888 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Conquest Map — Sofly</title>
+  <link href="https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.css" rel="stylesheet" />
+  <script src="https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0a0c14;
+      --surface: rgba(15, 18, 30, 0.94);
+      --border: rgba(255,255,255,0.08);
+      --text: #e2e8f0;
+      --muted: #718096;
+      --visited: #8b5cf6;
+      --planned: #f59e0b;
+      --accent: #7c3aed;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg); color: var(--text);
+      height: 100vh; overflow: hidden;
+      display: flex; flex-direction: column;
+    }
+
+    /* ── Header ── */
+    .header {
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      padding: 8px 14px; display: flex; align-items: center; gap: 10px;
+      flex-shrink: 0; backdrop-filter: blur(10px); z-index: 200;
+      flex-wrap: wrap;
+    }
+    .header-logo { font-size: 15px; font-weight: 700; color: #a78bfa; white-space: nowrap; display: flex; align-items: center; gap: 6px; }
+    .header-logo svg { width: 18px; height: 18px; }
+    .hdiv { width: 1px; height: 22px; background: var(--border); flex-shrink: 0; }
+    .hfield { display: flex; align-items: center; gap: 6px; }
+    .hfield label { font-size: 11px; color: var(--muted); white-space: nowrap; }
+    .hfield input {
+      background: rgba(255,255,255,0.05); border: 1px solid var(--border);
+      border-radius: 6px; padding: 5px 9px; color: var(--text);
+      font-size: 12px; font-family: monospace;
+    }
+    .hfield input:focus { outline: none; border-color: var(--accent); }
+    .input-url { width: 160px; } .input-mapbox { width: 190px; } .input-jwt { width: 260px; }
+    .btn {
+      padding: 6px 13px; border-radius: 6px; font-size: 12px; font-weight: 600;
+      border: none; cursor: pointer; transition: all 0.15s; white-space: nowrap;
+    }
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: #6d28d9; }
+    .btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+    .btn-secondary { background: rgba(255,255,255,0.06); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { background: rgba(255,255,255,0.1); }
+    .btn-green { background: #059669; color: #fff; }
+    .btn-green:hover { background: #047857; }
+    .btn-green:disabled { opacity: 0.45; cursor: not-allowed; }
+    .btn-sm { padding: 4px 9px; font-size: 11px; }
+
+    /* ── Map wrapper ── */
+    #mapWrap { position: relative; flex: 1; overflow: hidden; }
+    #map { width: 100%; height: 100%; }
+
+    /* ── Init overlay ── */
+    #initOverlay {
+      position: absolute; inset: 0; background: var(--bg); z-index: 5;
+      display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px;
+    }
+    #initOverlay.hidden { display: none; }
+    #initOverlay h2 { font-size: 22px; font-weight: 700; color: #a78bfa; }
+    #initOverlay p { font-size: 13px; color: var(--muted); text-align: center; max-width: 340px; line-height: 1.6; }
+
+    /* ── Floating panels ── */
+    .float-panel {
+      position: absolute; background: var(--surface); border: 1px solid var(--border);
+      border-radius: 12px; backdrop-filter: blur(16px); z-index: 10;
+    }
+    .panel-head {
+      padding: 10px 14px; border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .panel-head h3 { font-size: 12px; font-weight: 700; color: #a78bfa; }
+    .panel-body { padding: 12px 14px; display: flex; flex-direction: column; gap: 10px; }
+
+    /* Stats panel */
+    #statsPanel { top: 14px; left: 14px; width: 252px; transition: transform 0.3s; }
+    #statsPanel.hidden { transform: translateX(-280px); }
+
+    .stat-row { display: flex; justify-content: space-between; align-items: baseline; }
+    .stat-label { font-size: 11px; color: var(--muted); }
+    .stat-val { font-size: 15px; font-weight: 700; }
+    .stat-sub { font-size: 10px; color: var(--muted); font-weight: 400; }
+    .pbar { height: 3px; background: rgba(255,255,255,0.07); border-radius: 2px; margin-top: 4px; overflow: hidden; }
+    .pbar-fill { height: 100%; background: linear-gradient(90deg, var(--accent), #a78bfa); transition: width .5s; }
+    .sec-label { font-size: 10px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin-bottom: 6px; }
+
+    .cont-row { display: flex; align-items: center; gap: 7px; margin-bottom: 5px; }
+    .cont-name { font-size: 11px; color: var(--text); width: 70px; flex-shrink: 0; }
+    .cont-track { flex: 1; height: 5px; background: rgba(255,255,255,0.06); border-radius: 3px; overflow: hidden; }
+    .cont-fill { height: 100%; background: var(--visited); border-radius: 3px; }
+    .cont-num { font-size: 10px; color: var(--muted); width: 18px; text-align: right; }
+
+    /* Legend */
+    #legend {
+      position: absolute; bottom: 60px; left: 14px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; backdrop-filter: blur(16px); z-index: 10;
+      padding: 8px 12px; display: none; flex-direction: column; gap: 5px;
+    }
+    .leg-title { font-size: 9px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin-bottom: 3px; }
+    .leg-item { display: flex; align-items: center; gap: 7px; font-size: 11px; }
+    .leg-dot { width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0; }
+
+    /* Route controls */
+    #routeBar {
+      position: absolute; bottom: 16px; left: 50%; transform: translateX(-50%);
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 20px; backdrop-filter: blur(16px); z-index: 10;
+      display: none; align-items: center; gap: 3px; padding: 4px 6px;
+    }
+    .rbtn {
+      padding: 5px 13px; border-radius: 16px; font-size: 11px; font-weight: 500;
+      border: none; cursor: pointer; transition: all .15s; color: var(--muted); background: transparent;
+    }
+    .rbtn.active { background: rgba(124,58,237,0.2); color: #a78bfa; }
+    .rbtn:hover:not(.active) { color: var(--text); background: rgba(255,255,255,0.05); }
+
+    /* Workspace sidebar */
+    #wsSidebar {
+      position: absolute; top: 0; right: 0; bottom: 0; width: 310px;
+      background: var(--surface); border-left: 1px solid var(--border);
+      backdrop-filter: blur(16px); z-index: 20;
+      transform: translateX(310px); transition: transform .3s ease;
+      display: flex; flex-direction: column; overflow: hidden;
+    }
+    #wsSidebar.open { transform: translateX(0); }
+    .ws-head {
+      padding: 14px 16px; border-bottom: 1px solid var(--border);
+      display: flex; align-items: flex-start; justify-content: space-between; gap: 10px;
+    }
+    .ws-title { font-size: 17px; font-weight: 700; }
+    .ws-meta { font-size: 11px; color: var(--muted); margin-top: 5px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .ws-actions { padding: 10px 14px; border-bottom: 1px solid var(--border); display: flex; gap: 6px; }
+    .ws-body { flex: 1; overflow-y: auto; padding: 10px; }
+
+    .ws-card {
+      background: rgba(255,255,255,0.03); border: 1px solid var(--border);
+      border-radius: 8px; padding: 11px; margin-bottom: 7px; cursor: pointer; transition: all .15s;
+    }
+    .ws-card:hover { background: rgba(255,255,255,0.06); border-color: rgba(139,92,246,.3); }
+    .ws-card.hl { background: rgba(139,92,246,.1); border-color: rgba(139,92,246,.5); }
+    .ws-card-title { font-size: 13px; font-weight: 600; margin-bottom: 3px; }
+    .ws-card-sub { font-size: 11px; color: var(--muted); }
+
+    .closebtn { background: none; border: none; color: var(--muted); cursor: pointer; font-size: 18px; line-height: 1; padding: 4px; flex-shrink: 0; }
+    .closebtn:hover { color: var(--text); }
+
+    /* Badge */
+    .badge { display: inline-flex; align-items: center; padding: 2px 7px; border-radius: 10px; font-size: 10px; font-weight: 600; }
+    .badge-v { background: rgba(139,92,246,.2); color: #a78bfa; border: 1px solid rgba(139,92,246,.3); }
+    .badge-p { background: rgba(245,158,11,.2); color: #fbbf24; border: 1px solid rgba(245,158,11,.3); }
+    .badge-u { background: rgba(107,114,128,.2); color: #9ca3af; border: 1px solid rgba(107,114,128,.2); }
+
+    /* Status modal */
+    .modal-bg {
+      position: fixed; inset: 0; background: rgba(0,0,0,.65); z-index: 100;
+      display: none; align-items: center; justify-content: center;
+    }
+    .modal-bg.open { display: flex; }
+    .modal {
+      background: #1a1d2e; border: 1px solid var(--border); border-radius: 12px;
+      padding: 22px; width: 300px; display: flex; flex-direction: column; gap: 14px;
+    }
+    .modal h3 { font-size: 15px; font-weight: 700; }
+    .modal p { font-size: 12px; color: var(--muted); }
+    .stat-opts { display: flex; flex-direction: column; gap: 7px; }
+    .stat-opt {
+      display: flex; align-items: center; gap: 10px;
+      padding: 9px 12px; border-radius: 8px; border: 2px solid transparent;
+      cursor: pointer; transition: all .15s; background: rgba(255,255,255,0.03);
+    }
+    .stat-opt:hover { background: rgba(255,255,255,0.06); }
+    .stat-opt.sel { border-color: var(--accent); background: rgba(124,58,237,.1); }
+    .sdot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+    .sdot-v { background: var(--visited); } .sdot-p { background: var(--planned); } .sdot-u { background: #374151; }
+    .opt-lbl { font-size: 12px; font-weight: 500; }
+    .opt-desc { font-size: 10px; color: var(--muted); }
+    .modal-foot { display: flex; gap: 7px; justify-content: flex-end; }
+
+    /* Popup */
+    .mapboxgl-popup-content {
+      background: #1a1d2e !important; border: 1px solid var(--border) !important;
+      border-radius: 8px !important; padding: 10px 13px !important;
+      color: var(--text) !important; font-size: 12px !important;
+      box-shadow: 0 4px 20px rgba(0,0,0,.5) !important; min-width: 160px;
+    }
+    .mapboxgl-popup-tip { display: none !important; }
+    .mapboxgl-popup-close-button { color: var(--muted) !important; font-size: 14px !important; top: 6px !important; right: 8px !important; }
+    .pu-title { font-size: 13px; font-weight: 600; margin-bottom: 6px; }
+    .pu-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 3px; }
+    .pu-actions { display: flex; gap: 5px; margin-top: 8px; }
+
+    /* Toast */
+    .toast {
+      position: fixed; bottom: 70px; left: 50%; transform: translateX(-50%) translateY(16px);
+      background: #1e2235; border: 1px solid var(--border);
+      border-radius: 8px; padding: 9px 15px; font-size: 12px;
+      z-index: 300; opacity: 0; transition: all .3s; white-space: nowrap;
+    }
+    .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+    .toast.ok { border-color: rgba(16,185,129,.45); color: #6ee7b7; }
+    .toast.err { border-color: rgba(239,68,68,.4); color: #fca5a5; }
+
+    /* Empty / loading */
+    .empty { text-align: center; padding: 28px 14px; color: var(--muted); font-size: 12px; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .spin { width: 18px; height: 18px; border: 2px solid rgba(255,255,255,.1); border-top-color: var(--accent); border-radius: 50%; animation: spin .7s linear infinite; margin: 0 auto; }
+
+    ::-webkit-scrollbar { width: 4px; }
+    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,.1); border-radius: 2px; }
+  </style>
+</head>
+<body>
+
+<!-- ── Header ── -->
+<header class="header">
+  <div class="header-logo">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="10"/>
+      <line x1="2" y1="12" x2="22" y2="12"/>
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+    </svg>
+    Conquest Map
+  </div>
+  <div class="hdiv"></div>
+  <div class="hfield">
+    <label>Mapbox Token</label>
+    <input id="mapboxToken" class="input-mapbox" type="text" placeholder="pk.eyJ1IjoiLi4uIn0..." />
+  </div>
+  <button class="btn btn-primary" id="loadMapBtn" onclick="initMap()">지도 로드</button>
+  <div class="hdiv"></div>
+  <div class="hfield">
+    <label>Base URL</label>
+    <input id="baseUrl" class="input-url" type="text" value="http://localhost:8080" />
+  </div>
+  <div class="hfield">
+    <label>JWT Token</label>
+    <input id="jwtToken" class="input-jwt" type="text" placeholder="eyJhbGci..." />
+  </div>
+  <button class="btn btn-green" id="loadDataBtn" onclick="loadAll()" disabled>데이터 로드</button>
+</header>
+
+<!-- ── Map ── -->
+<div id="mapWrap">
+  <div id="map"></div>
+
+  <!-- Init overlay -->
+  <div id="initOverlay">
+    <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="#a78bfa" stroke-width="1.5">
+      <circle cx="12" cy="12" r="10"/>
+      <line x1="2" y1="12" x2="22" y2="12"/>
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+    </svg>
+    <h2>Conquest Map</h2>
+    <p>Mapbox 퍼블릭 토큰을 입력하고<br><strong>지도 로드</strong> 버튼을 눌러 시작하세요.</p>
+  </div>
+
+  <!-- Stats panel -->
+  <div class="float-panel" id="statsPanel">
+    <div class="panel-head">
+      <h3>📊 여행 통계</h3>
+      <button class="closebtn" onclick="toggleStats()" title="패널 닫기">✕</button>
+    </div>
+    <div class="panel-body" id="statsBody">
+      <div class="empty">데이터를 로드해주세요</div>
+    </div>
+  </div>
+
+  <!-- Legend -->
+  <div id="legend">
+    <div class="leg-title">방문 상태</div>
+    <div class="leg-item"><div class="leg-dot" style="background:#8b5cf6"></div>방문 완료</div>
+    <div class="leg-item"><div class="leg-dot" style="background:#f59e0b"></div>방문 예정</div>
+    <div class="leg-item"><div class="leg-dot" style="background:#374151"></div>미방문</div>
+    <div class="leg-item" style="margin-top:4px;"><div class="leg-dot" style="background:rgba(167,139,250,.5);height:3px;border-radius:1px;"></div>항공 경로</div>
+  </div>
+
+  <!-- Route bar -->
+  <div id="routeBar">
+    <button class="rbtn active" id="rb-all" onclick="setRouteFilter('all')">전체 경로</button>
+    <button class="rbtn" id="rb-none" onclick="setRouteFilter('none')">경로 숨김</button>
+  </div>
+
+  <!-- Workspace sidebar -->
+  <div id="wsSidebar">
+    <div class="ws-head">
+      <div>
+        <div class="ws-title" id="wsTitle">—</div>
+        <div class="ws-meta" id="wsMeta"></div>
+      </div>
+      <button class="closebtn" onclick="closeWsSidebar()">✕</button>
+    </div>
+    <div class="ws-actions" id="wsActions"></div>
+    <div class="ws-body" id="wsBody"></div>
+  </div>
+</div>
+
+<!-- ── Status Modal ── -->
+<div class="modal-bg" id="statusModal">
+  <div class="modal">
+    <div>
+      <h3 id="modalTitle">상태 변경</h3>
+      <p id="modalSub">방문 상태를 선택하세요</p>
+    </div>
+    <div class="stat-opts">
+      <div class="stat-opt" data-status="VISITED" onclick="selStatus('VISITED')">
+        <div class="sdot sdot-v"></div>
+        <div><div class="opt-lbl">방문 완료</div><div class="opt-desc">이미 방문한 곳</div></div>
+      </div>
+      <div class="stat-opt" data-status="PLANNED" onclick="selStatus('PLANNED')">
+        <div class="sdot sdot-p"></div>
+        <div><div class="opt-lbl">방문 예정</div><div class="opt-desc">항공권 보유 또는 계획 중</div></div>
+      </div>
+      <div class="stat-opt" data-status="UNVISITED" onclick="selStatus('UNVISITED')">
+        <div class="sdot sdot-u"></div>
+        <div><div class="opt-lbl">미방문</div><div class="opt-desc">아직 방문하지 않은 곳</div></div>
+      </div>
+    </div>
+    <div class="modal-foot">
+      <button class="btn btn-secondary" onclick="closeModal()">취소</button>
+      <button class="btn btn-primary" id="modalOkBtn" onclick="confirmStatus()">변경</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Toast ── -->
+<div class="toast" id="toast"></div>
+
+<script>
+// =====================================================
+// STATE
+// =====================================================
+let map = null;
+let conquest = null;   // ConquestMapResponse
+let statsData = null;  // ConquestStatsResponse
+let routes = [];       // TripRouteResponse[]
+let selCountry = null; // currently selected country code
+let curPopup = null;
+let routeFilter = 'all';
+
+// Modal
+let mCtx = null;        // { type: 'country'|'city', id, name }
+let mStatus = null;     // selected status in modal
+
+// =====================================================
+// BOOT
+// =====================================================
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('mapboxToken').value = localStorage.getItem('cq_mb') || '';
+  document.getElementById('jwtToken').value    = localStorage.getItem('cq_jwt') || '';
+  document.getElementById('baseUrl').value     = localStorage.getItem('cq_url') || 'http://localhost:8080';
+  document.getElementById('mapboxToken').addEventListener('input', e => localStorage.setItem('cq_mb', e.target.value));
+  document.getElementById('jwtToken').addEventListener('input',    e => localStorage.setItem('cq_jwt', e.target.value));
+  document.getElementById('baseUrl').addEventListener('input',     e => localStorage.setItem('cq_url', e.target.value));
+});
+
+// =====================================================
+// MAP INIT
+// =====================================================
+function initMap() {
+  const token = document.getElementById('mapboxToken').value.trim();
+  if (!token) { toast('Mapbox 토큰을 입력해주세요', 'err'); return; }
+
+  mapboxgl.accessToken = token;
+  localStorage.setItem('cq_mb', token);
+
+  const btn = document.getElementById('loadMapBtn');
+  btn.disabled = true; btn.textContent = '로딩 중...';
+
+  if (map) { map.remove(); map = null; }
+
+  map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/dark-v11',
+    center: [20, 15], zoom: 1.6, projection: 'mercator'
+  });
+
+  map.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right');
+
+  map.on('load', () => {
+    setupSources();
+    setupLayers();
+    setupEvents();
+    document.getElementById('initOverlay').classList.add('hidden');
+    document.getElementById('loadDataBtn').disabled = false;
+    document.getElementById('legend').style.display = 'flex';
+    document.getElementById('routeBar').style.display = 'flex';
+    btn.disabled = false; btn.textContent = '지도 재로드';
+    toast('지도 로드 완료', 'ok');
+  });
+
+  map.on('error', e => {
+    toast('지도 오류: ' + (e.error?.message || '토큰을 확인하세요'), 'err');
+    btn.disabled = false; btn.textContent = '지도 로드';
+  });
+}
+
+function setupSources() {
+  map.addSource('cb', { type: 'vector', url: 'mapbox://mapbox.country-boundaries-v1' });
+  map.addSource('cities', {
+    type: 'geojson',
+    data: { type: 'FeatureCollection', features: [] },
+    cluster: true, clusterMaxZoom: 8, clusterRadius: 38
+  });
+  map.addSource('routes', { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
+}
+
+const WV_FILTER = ['any', ['==', ['get', 'worldview'], 'all'], ['==', ['get', 'worldview'], 'US']];
+
+function setupLayers() {
+  // Country fill
+  map.addLayer({ id: 'c-fill', type: 'fill', source: 'cb', 'source-layer': 'country_boundaries',
+    filter: WV_FILTER,
+    paint: { 'fill-color': '#1e293b', 'fill-opacity': 0.55 }
+  });
+  // Country outline
+  map.addLayer({ id: 'c-line', type: 'line', source: 'cb', 'source-layer': 'country_boundaries',
+    filter: WV_FILTER,
+    paint: { 'line-color': 'rgba(255,255,255,0.07)', 'line-width': 0.5 }
+  });
+  // Hover highlight
+  map.addLayer({ id: 'c-hover', type: 'fill', source: 'cb', 'source-layer': 'country_boundaries',
+    filter: ['==', ['get', 'iso_3166_1'], ''],
+    paint: { 'fill-color': 'rgba(255,255,255,0.08)', 'fill-opacity': 1 }
+  });
+  // Selected outline
+  map.addLayer({ id: 'c-sel', type: 'line', source: 'cb', 'source-layer': 'country_boundaries',
+    filter: ['==', ['get', 'iso_3166_1'], ''],
+    paint: { 'line-color': '#a78bfa', 'line-width': 2 }
+  });
+  // Routes
+  map.addLayer({ id: 'rt-line', type: 'line', source: 'routes',
+    paint: { 'line-color': ['get', 'color'], 'line-width': 1.5, 'line-opacity': 0.65 },
+    layout: { 'line-cap': 'round', 'line-join': 'round' }
+  });
+  // Route glow
+  map.addLayer({ id: 'rt-glow', type: 'line', source: 'routes',
+    paint: { 'line-color': ['get', 'color'], 'line-width': 4, 'line-opacity': 0.12, 'line-blur': 3 }
+  });
+  // City clusters
+  map.addLayer({ id: 'cl-circle', type: 'circle', source: 'cities',
+    filter: ['has', 'point_count'],
+    paint: {
+      'circle-color': '#7c3aed', 'circle-opacity': 0.85,
+      'circle-radius': ['step', ['get', 'point_count'], 13, 5, 17, 10, 21],
+      'circle-stroke-width': 2, 'circle-stroke-color': 'rgba(167,139,250,0.35)'
+    }
+  });
+  map.addLayer({ id: 'cl-count', type: 'symbol', source: 'cities',
+    filter: ['has', 'point_count'],
+    layout: { 'text-field': '{point_count_abbreviated}', 'text-size': 11, 'text-font': ['DIN Pro Medium', 'Arial Unicode MS Bold'] },
+    paint: { 'text-color': '#fff' }
+  });
+  // Individual city
+  map.addLayer({ id: 'city-pt', type: 'circle', source: 'cities',
+    filter: ['!', ['has', 'point_count']],
+    paint: {
+      'circle-color': ['get', 'color'], 'circle-radius': 6, 'circle-opacity': 0.9,
+      'circle-stroke-width': 2, 'circle-stroke-color': ['get', 'stroke']
+    }
+  });
+}
+
+function setupEvents() {
+  // Country hover
+  map.on('mousemove', 'c-fill', e => {
+    if (!e.features.length) return;
+    map.getCanvas().style.cursor = 'pointer';
+    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1'], e.features[0].properties.iso_3166_1 || '']);
+  });
+  map.on('mouseleave', 'c-fill', () => {
+    map.getCanvas().style.cursor = '';
+    map.setFilter('c-hover', ['==', ['get', 'iso_3166_1'], '']);
+  });
+
+  // Country click → sidebar
+  map.on('click', 'c-fill', async e => {
+    if (!e.features.length) return;
+    const code = e.features[0].properties.iso_3166_1;
+    if (!code) return;
+    selCountry = code;
+    map.setFilter('c-sel', ['==', ['get', 'iso_3166_1'], code]);
+    await openCountrySidebar(code);
+  });
+
+  // Cluster zoom
+  map.on('click', 'cl-circle', e => {
+    const f = map.queryRenderedFeatures(e.point, { layers: ['cl-circle'] });
+    map.getSource('cities').getClusterExpansionZoom(f[0].properties.cluster_id, (err, zoom) => {
+      if (!err) map.easeTo({ center: f[0].geometry.coordinates, zoom });
+    });
+    e.stopPropagation();
+  });
+
+  // City popup
+  map.on('click', 'city-pt', e => {
+    if (!e.features.length) return;
+    e.stopPropagation();
+    const p = e.features[0].properties;
+    const coords = [...e.features[0].geometry.coordinates];
+    if (curPopup) curPopup.remove();
+    const lbl = { VISITED: '방문 완료', PLANNED: '방문 예정', UNVISITED: '미방문' };
+    const cls = { VISITED: 'badge-v', PLANNED: 'badge-p', UNVISITED: 'badge-u' };
+    curPopup = new mapboxgl.Popup({ offset: 10, closeButton: true })
+      .setLngLat(coords)
+      .setHTML(`
+        <div class="pu-title">${esc(p.name)}</div>
+        <div class="pu-row">
+          <span style="color:var(--muted)">${p.cc}</span>
+          <span class="badge ${cls[p.status]}">${lbl[p.status]}</span>
+        </div>
+        ${p.vc > 0 ? `<div style="font-size:10px;color:var(--muted)">${p.vc}회 방문</div>` : ''}
+        <div class="pu-actions">
+          <button class="btn btn-primary btn-sm" onclick="openCityModal(${p.id},'${p.status}','${esc(p.name)}')">상태 변경</button>
+        </div>
+      `)
+      .addTo(map);
+  });
+
+  // Click on empty → deselect
+  map.on('click', e => {
+    const f = map.queryRenderedFeatures(e.point, { layers: ['c-fill', 'city-pt', 'cl-circle'] });
+    if (!f.length) {
+      selCountry = null;
+      map?.setFilter('c-sel', ['==', ['get', 'iso_3166_1'], '']);
+    }
+  });
+
+  ['cl-circle', 'city-pt'].forEach(l => {
+    map.on('mouseenter', l, () => map.getCanvas().style.cursor = 'pointer');
+    map.on('mouseleave', l, () => map.getCanvas().style.cursor = '');
+  });
+}
+
+// =====================================================
+// DATA LOAD
+// =====================================================
+async function loadAll() {
+  const btn = document.getElementById('loadDataBtn');
+  btn.disabled = true; btn.textContent = '로딩 중...';
+  try {
+    [conquest, statsData, routes] = await Promise.all([
+      api('GET', '/api/conquest'),
+      api('GET', '/api/conquest/stats'),
+      api('GET', '/api/conquest/routes')
+    ]);
+    updateCountryLayer();
+    updateCityLayer();
+    updateRouteLayer();
+    updateStatsPanel();
+    toast('데이터 로드 완료', 'ok');
+  } catch (e) {
+    toast('로드 실패: ' + e.message, 'err');
+  } finally {
+    btn.disabled = false; btn.textContent = '데이터 재로드';
+  }
+}
+
+// =====================================================
+// MAP UPDATES
+// =====================================================
+function updateCountryLayer() {
+  if (!map || !conquest) return;
+  const countries = extract(conquest)?.countries || [];
+  const expr = ['match', ['get', 'iso_3166_1']];
+  for (const c of countries) {
+    if (c.status === 'VISITED') { expr.push(c.countryCode); expr.push('#8b5cf6'); }
+    else if (c.status === 'PLANNED') { expr.push(c.countryCode); expr.push('#f59e0b'); }
+  }
+  expr.push('#1e293b');
+  map.setPaintProperty('c-fill', 'fill-color', expr);
+  map.setPaintProperty('c-fill', 'fill-opacity', 0.72);
+}
+
+function updateCityLayer() {
+  if (!map || !conquest) return;
+  const cities = extract(conquest)?.cities || [];
+  const features = cities.map(c => ({
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [c.longitude, c.latitude] },
+    properties: {
+      id: c.id, name: c.cityName, cc: c.countryCode, status: c.status, vc: c.visitCount || 0,
+      color: c.status === 'VISITED' ? '#8b5cf6' : c.status === 'PLANNED' ? '#f59e0b' : '#374151',
+      stroke: c.status === 'VISITED' ? 'rgba(167,139,250,.5)' : c.status === 'PLANNED' ? 'rgba(251,191,36,.5)' : 'rgba(107,114,128,.3)'
+    }
+  }));
+  map.getSource('cities').setData({ type: 'FeatureCollection', features });
+}
+
+function updateRouteLayer() {
+  if (!map) return;
+  const list = extract(routes) || routes || [];
+  if (routeFilter === 'none' || !list.length) {
+    map.getSource('routes').setData({ type: 'FeatureCollection', features: [] });
+    return;
+  }
+  const filtered = routeFilter === 'all' ? list : list.filter(r => r.workspaceId == routeFilter);
+  const features = filtered.map(r => ({
+    type: 'Feature',
+    geometry: { type: 'LineString', coordinates: arc([r.departureLng, r.departureLat], [r.arrivalLng, r.arrivalLat]) },
+    properties: {
+      color: routeFilter === 'all' ? '#a78bfa' : '#f59e0b',
+      wsId: r.workspaceId, wsTitle: r.workspaceTitle || '',
+      dep: r.departureAirport, arr: r.arrivalAirport,
+      airline: r.airline || '', dist: Math.round(r.distanceKm || 0)
+    }
+  }));
+  map.getSource('routes').setData({ type: 'FeatureCollection', features });
+}
+
+function arc(from, to, n = 80) {
+  let [x1, y1] = from, [x2, y2] = to;
+  if (Math.abs(x2 - x1) > 180) x2 += x2 > x1 ? -360 : 360;
+  const mx = (x1 + x2) / 2, my = (y1 + y2) / 2;
+  const d = Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+  const cy = my + d * 0.28;
+  const pts = [];
+  for (let i = 0; i <= n; i++) {
+    const t = i / n, mt = 1 - t;
+    pts.push([mt * mt * x1 + 2 * mt * t * mx + t * t * x2,
+              mt * mt * y1 + 2 * mt * t * cy + t * t * y2]);
+  }
+  return pts;
+}
+
+// =====================================================
+// STATS PANEL
+// =====================================================
+function updateStatsPanel() {
+  const d = extract(statsData) || statsData;
+  if (!d) return;
+  const pct = +(d.visitedCountryPercentage || 0).toFixed(1);
+  const cs = d.continentStats || [];
+  const maxC = Math.max(...cs.map(c => c.visitedCountryCount), 1);
+
+  document.getElementById('statsBody').innerHTML = `
+    <div>
+      <div class="stat-row">
+        <span class="stat-label">방문 국가</span>
+        <span class="stat-val">${d.visitedCountryCount}<span class="stat-sub"> / ${d.totalCountryCount}</span></span>
+      </div>
+      <div class="pbar"><div class="pbar-fill" style="width:${pct}%"></div></div>
+      <div style="font-size:10px;color:var(--muted);text-align:right;margin-top:2px">${pct}%</div>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label">방문 도시</span>
+      <span class="stat-val">${d.visitedCityCount}</span>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label">총 여행일</span>
+      <span class="stat-val">${d.totalTravelDays}<span class="stat-sub">일</span></span>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label">총 이동거리</span>
+      <span class="stat-val">${Math.round(d.totalDistanceKm || 0).toLocaleString()}<span class="stat-sub">km</span></span>
+    </div>
+    ${cs.length ? `
+    <div style="border-top:1px solid var(--border);padding-top:9px">
+      <div class="sec-label">대륙별 방문</div>
+      ${cs.map(c => `
+        <div class="cont-row">
+          <div class="cont-name">${c.continentName}</div>
+          <div class="cont-track"><div class="cont-fill" style="width:${c.visitedCountryCount > 0 ? Math.max((c.visitedCountryCount / maxC) * 100, 6) : 0}%"></div></div>
+          <div class="cont-num">${c.visitedCountryCount}</div>
+        </div>
+      `).join('')}
+    </div>` : ''}
+    <div style="border-top:1px solid var(--border);padding-top:9px;display:flex;gap:5px">
+      <button class="btn btn-secondary btn-sm" style="flex:1" onclick="openBulk()">일괄 등록</button>
+      <button class="btn btn-secondary btn-sm" style="flex:1" onclick="loadAll()">새로고침</button>
+    </div>
+  `;
+}
+
+function toggleStats() {
+  document.getElementById('statsPanel').classList.toggle('hidden');
+}
+
+// =====================================================
+// WORKSPACE SIDEBAR
+// =====================================================
+async function openCountrySidebar(code) {
+  const countries = extract(conquest)?.countries || [];
+  const c = countries.find(x => x.countryCode === code);
+  const status = c?.status || 'UNVISITED';
+  const name = c?.countryName || code;
+
+  document.getElementById('wsTitle').textContent = name;
+  document.getElementById('wsMeta').innerHTML = `
+    <span class="badge ${sBadge(status)}">${sLabel(status)}</span>
+    ${c?.continentName ? `<span>${c.continentName}</span>` : ''}
+    ${c?.visitCount > 0 ? `<span>${c.visitCount}회 방문</span>` : ''}
+  `;
+  document.getElementById('wsActions').innerHTML = `
+    <button class="btn btn-secondary btn-sm" onclick="openCountryModal('${code}','${status}','${esc(name)}')">상태 변경</button>
+    <button class="btn btn-secondary btn-sm" onclick="setRouteFilter('all');document.querySelectorAll('.ws-card').forEach(e=>e.classList.remove('hl'))">전체 경로</button>
+  `;
+  document.getElementById('wsBody').innerHTML = '<div class="empty"><div class="spin"></div></div>';
+  document.getElementById('wsSidebar').classList.add('open');
+
+  try {
+    const data = await api('GET', `/api/conquest/countries/${code}/workspaces`);
+    const ws = extract(data) || data || [];
+    if (!ws.length) {
+      document.getElementById('wsBody').innerHTML = '<div class="empty">이 국가와 연결된 워크스페이스가 없습니다</div>';
+      return;
+    }
+    document.getElementById('wsBody').innerHTML = ws.map(w => `
+      <div class="ws-card" id="wc-${w.id}" onclick="hlRoute(${w.id})">
+        <div class="ws-card-title">${esc(w.title)}</div>
+        <div class="ws-card-sub">${esc(w.destination || '')} · 멤버 ${w.memberCount}명</div>
+        <div class="ws-card-sub">${w.startDate || ''} ~ ${w.endDate || ''}</div>
+      </div>
+    `).join('');
+  } catch (e) {
+    document.getElementById('wsBody').innerHTML = `<div class="empty">로드 실패: ${esc(e.message)}</div>`;
+  }
+}
+
+function closeWsSidebar() {
+  document.getElementById('wsSidebar').classList.remove('open');
+  selCountry = null;
+  map?.setFilter('c-sel', ['==', ['get', 'iso_3166_1'], '']);
+}
+
+function hlRoute(wsId) {
+  setRouteFilter(wsId);
+  document.querySelectorAll('.ws-card').forEach(e => e.classList.remove('hl'));
+  document.getElementById(`wc-${wsId}`)?.classList.add('hl');
+}
+
+// =====================================================
+// ROUTE CONTROLS
+// =====================================================
+function setRouteFilter(f) {
+  routeFilter = f;
+  document.querySelectorAll('.rbtn').forEach(b => b.classList.remove('active'));
+  document.getElementById(`rb-${f}`)?.classList.add('active');
+  updateRouteLayer();
+}
+
+// =====================================================
+// STATUS MODAL
+// =====================================================
+function openCountryModal(code, status, name) {
+  mCtx = { type: 'country', id: code };
+  document.getElementById('modalTitle').textContent = `${name} 상태 변경`;
+  document.getElementById('modalSub').textContent = `현재: ${sLabel(status)}`;
+  selStatus(status);
+  document.getElementById('statusModal').classList.add('open');
+}
+
+function openCityModal(id, status, name) {
+  mCtx = { type: 'city', id };
+  document.getElementById('modalTitle').textContent = `${name} 상태 변경`;
+  document.getElementById('modalSub').textContent = `현재: ${sLabel(status)}`;
+  selStatus(status);
+  document.getElementById('statusModal').classList.add('open');
+  curPopup?.remove(); curPopup = null;
+}
+
+function selStatus(s) {
+  mStatus = s;
+  document.querySelectorAll('.stat-opt').forEach(el => el.classList.toggle('sel', el.dataset.status === s));
+}
+
+function closeModal() {
+  document.getElementById('statusModal').classList.remove('open');
+  mCtx = null; mStatus = null;
+}
+
+async function confirmStatus() {
+  if (!mCtx || !mStatus) return;
+  const btn = document.getElementById('modalOkBtn');
+  btn.disabled = true; btn.textContent = '처리 중...';
+  try {
+    if (mCtx.type === 'country') await api('PUT', `/api/conquest/countries/${mCtx.id}/status`, { status: mStatus });
+    else await api('PUT', `/api/conquest/cities/${mCtx.id}/status`, { status: mStatus });
+    closeModal();
+    toast('상태가 변경되었습니다', 'ok');
+    const savedCountry = selCountry;
+    await loadAll();
+    if (mCtx?.type === 'country' && savedCountry) await openCountrySidebar(savedCountry);
+  } catch (e) {
+    toast('변경 실패: ' + e.message, 'err');
+  } finally {
+    btn.disabled = false; btn.textContent = '변경';
+  }
+}
+
+document.getElementById('statusModal').addEventListener('click', function(e) {
+  if (e.target === this) closeModal();
+});
+
+// =====================================================
+// BULK IMPORT
+// =====================================================
+function openBulk() {
+  document.getElementById('bulkModal')?.remove();
+  const el = document.createElement('div');
+  el.id = 'bulkModal';
+  el.className = 'modal-bg open';
+  el.innerHTML = `
+    <div class="modal" style="width:460px">
+      <div><h3>과거 방문 일괄 등록</h3><p>JSON 형식으로 국가/도시를 한번에 등록합니다</p></div>
+      <textarea id="bulkJson" style="
+        background:rgba(0,0,0,.3);border:1px solid var(--border);border-radius:6px;
+        padding:10px;color:var(--text);font-size:11px;font-family:monospace;
+        resize:vertical;min-height:190px;width:100%;outline:none;
+      ">{
+  "countries": [
+    { "countryCode": "JP", "status": "VISITED" },
+    { "countryCode": "FR", "status": "PLANNED" }
+  ],
+  "cities": [
+    { "cityName": "Tokyo", "countryCode": "JP", "latitude": 35.6762, "longitude": 139.6503, "status": "VISITED" },
+    { "cityName": "Seoul", "countryCode": "KR", "latitude": 37.5665, "longitude": 126.9780, "status": "VISITED" }
+  ]
+}</textarea>
+      <div class="modal-foot">
+        <button class="btn btn-secondary" onclick="document.getElementById('bulkModal').remove()">취소</button>
+        <button class="btn btn-primary" onclick="submitBulk()">등록</button>
+      </div>
+    </div>
+  `;
+  el.addEventListener('click', e => { if (e.target === el) el.remove(); });
+  document.body.appendChild(el);
+}
+
+async function submitBulk() {
+  let body;
+  try { body = JSON.parse(document.getElementById('bulkJson').value); }
+  catch (e) { toast('JSON 오류: ' + e.message, 'err'); return; }
+  try {
+    await api('POST', '/api/conquest/bulk-import', body);
+    document.getElementById('bulkModal')?.remove();
+    toast('일괄 등록 완료', 'ok');
+    await loadAll();
+  } catch (e) { toast('등록 실패: ' + e.message, 'err'); }
+}
+
+// =====================================================
+// API HELPER
+// =====================================================
+async function api(method, path, body) {
+  const base = document.getElementById('baseUrl').value.trim().replace(/\/$/, '');
+  const token = document.getElementById('jwtToken').value.trim();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = 'Bearer ' + token;
+  const opts = { method, headers };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(base + path, opts);
+  if (res.status === 204) return null;
+  const text = await res.text();
+  let data; try { data = JSON.parse(text); } catch { data = text; }
+  if (!res.ok) throw new Error(data?.message || data?.error || text || `HTTP ${res.status}`);
+  return data;
+}
+
+// =====================================================
+// UTILS
+// =====================================================
+function extract(r) {
+  if (r && typeof r === 'object' && 'data' in r) return r.data;
+  return r;
+}
+function sLabel(s) { return { VISITED: '방문 완료', PLANNED: '방문 예정', UNVISITED: '미방문' }[s] || s; }
+function sBadge(s) { return { VISITED: 'badge-v', PLANNED: 'badge-p', UNVISITED: 'badge-u' }[s] || 'badge-u'; }
+function esc(s) { return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+function toast(msg, type) {
+  const el = document.getElementById('toast');
+  el.textContent = msg; el.className = `toast ${type} show`;
+  setTimeout(() => el.classList.remove('show'), 2800);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약

Polarsteps UX를 참고하여 사용자의 여행 발자국을 세계 지도 위에 시각화하는 **정복도(Conquest Map)** 기능을 백엔드/프론트엔드 전체 구현합니다.

국가·도시 방문 상태를 지도에 색칠·핀으로 표현하고, 항공 일정 기반 자동 상태 전환 및 워크스페이스 양방향 연동을 지원합니다.

---

## 🔧 변경 사항

**[Backend] 정복도 도메인 신규 개발**
- `ConquestCountry` / `ConquestCity` 엔티티 및 `VisitStatus` Enum(`UNVISITED` → `PLANNED` → `VISITED`) 설계
- 항공편 저장 이벤트(`FlightSavedEvent`) 구독 → 도착 국가·도시 자동 `PLANNED` 전환 (기존 항공 일정 등록 흐름과 연동)
- Spring Scheduler (매일 자정) → 항공 출발일 경과 시 `PLANNED` → `VISITED` 자동 전환
- PostGIS `ST_Distance` 기반 총 이동거리(km) 집계
- 국가별 연관 워크스페이스 조회, 대륙별 분포 통계, 전체 항공 경로 조회 API
- 과거 방문 이력 일괄 등록(bulk-import) API (`204 No Content`)

**[Frontend] Conquest Map 테스트 페이지 개발**
- Mapbox GL JS v3.4.0 기반 인터랙티브 세계 지도 구현
- `mapbox-country-boundaries-v1` 타일셋 + `match` 표현식으로 국가별 상태 색칠
- GeoJSON 소스 기반 도시 핀 표시 및 내장 클러스터링 (`clusterMaxZoom: 8`)
- Quadratic Bezier 곡선 항공 경로 Arc 시각화 (antimeridian 처리 포함)
- 국가 클릭 → 워크스페이스 사이드바 슬라이드인 연동
- 국가·도시 상태 수동 변경 모달 (공통)
- 여행 통계 패널 (방문 국가·도시·일수·이동거리·대륙별 분포)
- ISO alpha-2 ↔ alpha-3 변환 테이블 (Mapbox ↔ API 코드 불일치 처리)
- JWT + Base URL 헤더 입력 및 `localStorage` 자동 저장

---

## 📋 작업 상세 내용

**Backend**
- [x] `ConquestCountry`, `ConquestCity` 엔티티 및 `VisitStatus` Enum 설계
- [x] `GET /api/conquest` — 전체 국가/도시 방문 현황 조회
- [x] `GET /api/conquest/stats` — 통계 집계 (방문 국가·도시 수, 총 여행일, 이동거리, 대륙별 분포)
- [x] `GET /api/conquest/routes` — 전체 항공 경로 조회 (출발/도착 좌표 포함)
- [x] `GET /api/conquest/routes/workspaces/{workspaceId}` — 워크스페이스별 경로 조회
- [x] `GET /api/conquest/countries/{countryCode}/workspaces` — 국가별 연관 워크스페이스 조회
- [x] `PUT /api/conquest/countries/{countryCode}/status` — 국가 방문 상태 수동 변경
- [x] `PUT /api/conquest/cities/{cityId}/status` — 도시 방문 상태 수동 변경
- [x] `POST /api/conquest/cities` — 도시 추가/업데이트 (upsert, 도시명+국가코드 기준)
- [x] `POST /api/conquest/bulk-import` — 과거 방문 이력 일괄 등록
- [x] `FlightSavedEvent` 구독 → 도착 국가/도시 PLANNED 자동 전환
- [x] Spring Scheduler — 항공 출발일 경과 시 VISITED 자동 전환

**Frontend (테스트 페이지)**
- [x] Mapbox GL JS 지도 초기화 및 레이어 구성 (`c-fill`, `c-line`, `c-hover`, `c-sel`, `rt-line`, `rt-glow`, `city-pt` 등)
- [x] 국가 방문 상태별 동적 색상 표현식 생성
- [x] 도시 핀 GeoJSON 변환 및 클러스터링
- [x] 항공 경로 Bezier Arc 생성 함수
- [x] 국가 클릭 → 워크스페이스 사이드바 슬라이드인
- [x] 워크스페이스 카드 클릭 → 해당 경로 하이라이트
- [x] 상태 변경 모달 (국가/도시 공통)
- [x] 통계 패널 및 대륙별 분포 바 렌더링
- [x] bulk-import JSON 편집기
- [x] ISO alpha-2 ↔ alpha-3 변환 테이블
- [x] JWT + Base URL 헤더 입력 및 localStorage 자동 저장

---

## 🔗 관련 이슈

- closed #45 

---

## 📝 기타

- 테스트 페이지는 `http://localhost:8080/conquest-test.html` 에서 확인 가능합니다. Mapbox 퍼블릭 토큰과 JWT를 헤더에 입력 후 사용하세요.
- **ISO 코드 주의**: Mapbox 타일셋은 `iso_3166_1_alpha_3` (3자리), API는 `iso_3166_1` (alpha-2, 2자리)를 사용합니다. 프론트엔드에서 변환 테이블(`A2_A3` / `A3_A2`)로 처리하며 백엔드 변경은 불필요합니다.
- **`worldview` 필터**: 분쟁지역 경계 중복 렌더링 방지를 위해 이벤트 전용 `c-hit` 레이어는 worldview 필터 없이 구성했습니다. hover/click 이벤트는 `c-hit` 기준으로 처리됩니다.
- **자동 상태 전환**은 백엔드 배치·이벤트로 처리되므로 프론트는 `GET /api/conquest` 재호출만으로 최신 상태를 반영합니다. 폴링/웹소켓은 불필요합니다.
- React 전환 시 항공 경로는 `deck.gl ArcLayer` (`greatCircle: true`) 사용을 권장합니다. antimeridian 처리가 자동으로 됩니다.