### PR TITLE
feat: Booking.com 항공편 응답 필터링 및 앨범 도메인 S3 전환

### DIFF
--- a/services/travel-core-service/build.gradle
+++ b/services/travel-core-service/build.gradle
@@ -76,6 +76,10 @@ dependencies {
 
     //Gemini (Google AI)
     implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
+
+    // AWS S3
+    implementation platform('software.amazon.awssdk:bom:2.25.0')
+    implementation 'software.amazon.awssdk:s3'
 }
 
 dependencyManagement {

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/controller/AlbumController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/controller/AlbumController.java
@@ -1,0 +1,65 @@
+package com.sofly.core.domain.album.controller;
+
+import com.sofly.core.domain.album.dto.*;
+import com.sofly.core.domain.album.service.AlbumService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Album", description = "워크스페이스 공유 앨범 API")
+@RestController
+@RequestMapping("/api/workspaces/{workspaceId}/album")
+@RequiredArgsConstructor
+public class AlbumController {
+
+    private final AlbumService albumService;
+
+    @Operation(summary = "앨범 조회", description = "워크스페이스 앨범과 사진 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<AlbumResponse>> getAlbum(@PathVariable Long workspaceId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(albumService.getAlbum(workspaceId, userId)));
+    }
+
+    @Operation(summary = "업로드 URL 발급", description = "S3 직접 업로드를 위한 Presigned PUT URL을 발급합니다.")
+    @PostMapping("/photos/presigned")
+    public ResponseEntity<ApiResponse<PresignedUrlResponse>> generateUploadUrl(
+            @PathVariable Long workspaceId,
+            @Valid @RequestBody PresignedUrlRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(albumService.generateUploadUrl(workspaceId, userId, request)));
+    }
+
+    @Operation(summary = "사진 저장", description = "S3 업로드 완료 후 사진 정보를 DB에 저장합니다.")
+    @PostMapping("/photos")
+    public ResponseEntity<ApiResponse<PhotoResponse>> savePhoto(
+            @PathVariable Long workspaceId,
+            @Valid @RequestBody PhotoSaveRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(albumService.savePhoto(workspaceId, userId, request)));
+    }
+
+    @Operation(summary = "사진 삭제", description = "사진을 S3와 DB에서 삭제합니다.")
+    @DeleteMapping("/photos/{photoId}")
+    public ResponseEntity<ApiResponse<Void>> deletePhoto(
+            @PathVariable Long workspaceId,
+            @PathVariable Long photoId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        albumService.deletePhoto(workspaceId, userId, photoId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "다운로드 URL 발급", description = "사진 다운로드를 위한 Presigned GET URL을 발급합니다. (5분 유효)")
+    @GetMapping("/photos/{photoId}/download")
+    public ResponseEntity<ApiResponse<DownloadUrlResponse>> generateDownloadUrl(
+            @PathVariable Long workspaceId,
+            @PathVariable Long photoId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(albumService.generateDownloadUrl(workspaceId, userId, photoId)));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/AlbumResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/AlbumResponse.java
@@ -1,0 +1,9 @@
+package com.sofly.core.domain.album.dto;
+
+import java.util.List;
+
+public record AlbumResponse(
+        Long albumId,
+        Long workspaceId,
+        List<PhotoResponse> photos
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/DownloadUrlResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/DownloadUrlResponse.java
@@ -1,0 +1,5 @@
+package com.sofly.core.domain.album.dto;
+
+public record DownloadUrlResponse(
+        String downloadUrl
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PhotoResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PhotoResponse.java
@@ -1,0 +1,32 @@
+package com.sofly.core.domain.album.dto;
+
+import com.sofly.core.domain.album.entity.Photo;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record PhotoResponse(
+        Long id,
+        String url,
+        Long uploadedById,
+        String uploadedByNickname,
+        LocalDate takenAt,
+        Double latitude,
+        Double longitude,
+        Integer matchedDay,
+        LocalDateTime createdAt
+) {
+    public static PhotoResponse from(Photo photo) {
+        return new PhotoResponse(
+                photo.getId(),
+                photo.getUrl(),
+                photo.getUploadedBy().getId(),
+                photo.getUploadedBy().getNickname(),
+                photo.getTakenAt(),
+                photo.getLatitude(),
+                photo.getLongitude(),
+                photo.getMatchedDay(),
+                photo.getCreatedAt()
+        );
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PhotoSaveRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PhotoSaveRequest.java
@@ -1,0 +1,12 @@
+package com.sofly.core.domain.album.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+
+public record PhotoSaveRequest(
+        @NotBlank String s3Key,
+        LocalDate takenAt,
+        Double latitude,
+        Double longitude
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PresignedUrlRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PresignedUrlRequest.java
@@ -1,0 +1,8 @@
+package com.sofly.core.domain.album.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUrlRequest(
+        @NotBlank String fileName,
+        @NotBlank String contentType
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PresignedUrlResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PresignedUrlResponse.java
@@ -1,0 +1,6 @@
+package com.sofly.core.domain.album.dto;
+
+public record PresignedUrlResponse(
+        String presignedUrl,
+        String s3Key
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/entity/Album.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/entity/Album.java
@@ -24,20 +24,13 @@ public class Album extends BaseTimeEntity {
     @JoinColumn(name = "workspace_id", nullable = false, unique = true)
     private Workspace workspace;
 
-    // Google Drive 연동 정보
-    private String driveFolderId;       // 연동된 Drive 폴더 ID
-    private String driveFolderName;     // 폴더 이름
-
     @OneToMany(mappedBy = "album", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Photo> photos = new ArrayList<>();
 
-    public void connectDrive(String folderId, String folderName) {
-        this.driveFolderId = folderId;
-        this.driveFolderName = folderName;
-    }
-
-    public boolean isDriveConnected() {
-        return this.driveFolderId != null;
+    public static Album of(Workspace workspace) {
+        return Album.builder()
+                .workspace(workspace)
+                .build();
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/entity/Photo.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/entity/Photo.java
@@ -28,17 +28,28 @@ public class Photo extends BaseTimeEntity {
     private User uploadedBy;
 
     @Column(nullable = false)
-    private String thumbnailUrl;        // 썸네일 URL
+    private String s3Key;           // S3 객체 키 (삭제 시 사용)
 
     @Column(nullable = false)
-    private String originalUrl;         // 원본 URL (Drive 링크)
-
-    private String driveFileId;         // Google Drive 파일 ID
+    private String url;             // S3 접근 URL (또는 CloudFront URL)
 
     // EXIF 정보 (선택)
-    private LocalDate takenAt;          // 촬영 날짜
-    private Double latitude;            // 촬영 위치
+    private LocalDate takenAt;
+    private Double latitude;
     private Double longitude;
 
-    private Integer matchedDay;         // EXIF 기반 매칭된 여행 일차
+    private Integer matchedDay;     // EXIF 기반 매칭된 여행 일차
+
+    public static Photo of(Album album, User uploadedBy, String s3Key, String url,
+                           LocalDate takenAt, Double latitude, Double longitude) {
+        return Photo.builder()
+                .album(album)
+                .uploadedBy(uploadedBy)
+                .s3Key(s3Key)
+                .url(url)
+                .takenAt(takenAt)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/repository/AlbumRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/repository/AlbumRepository.java
@@ -1,0 +1,10 @@
+package com.sofly.core.domain.album.repository;
+
+import com.sofly.core.domain.album.entity.Album;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AlbumRepository extends JpaRepository<Album, Long> {
+    Optional<Album> findByWorkspaceId(Long workspaceId);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/repository/PhotoRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/repository/PhotoRepository.java
@@ -1,0 +1,10 @@
+package com.sofly.core.domain.album.repository;
+
+import com.sofly.core.domain.album.entity.Photo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    List<Photo> findByAlbumIdOrderByCreatedAtDesc(Long albumId);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/AlbumService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/AlbumService.java
@@ -33,6 +33,7 @@ public class AlbumService {
     private final S3Service s3Service;
 
     /** 앨범 + 사진 목록 조회 */
+    @Transactional
     public AlbumResponse getAlbum(Long workspaceId, Long userId) {
         validateMember(workspaceId, userId);
         Album album = getOrCreateAlbum(workspaceId);
@@ -74,6 +75,10 @@ public class AlbumService {
         Photo photo = photoRepository.findById(photoId)
                 .orElseThrow(() -> new SoflyException(ErrorCode.PHOTO_NOT_FOUND));
 
+        if (!photo.getAlbum().getWorkspace().getId().equals(workspaceId)) {
+            throw new SoflyException(ErrorCode.PHOTO_NOT_FOUND);
+        }
+
         boolean isOwnerOrEditor = member.getRole() == MemberRole.OWNER || member.getRole() == MemberRole.EDITOR;
         boolean isUploader = photo.getUploadedBy().getId().equals(userId);
 
@@ -90,6 +95,11 @@ public class AlbumService {
         validateMember(workspaceId, userId);
         Photo photo = photoRepository.findById(photoId)
                 .orElseThrow(() -> new SoflyException(ErrorCode.PHOTO_NOT_FOUND));
+
+        if (!photo.getAlbum().getWorkspace().getId().equals(workspaceId)) {
+            throw new SoflyException(ErrorCode.PHOTO_NOT_FOUND);
+        }
+
         String downloadUrl = s3Service.generatePresignedDownloadUrl(photo.getS3Key());
         return new DownloadUrlResponse(downloadUrl);
     }
@@ -111,7 +121,6 @@ public class AlbumService {
         }
     }
 
-    @Transactional
     private Album getOrCreateAlbum(Long workspaceId) {
         return albumRepository.findByWorkspaceId(workspaceId)
                 .orElseGet(() -> {

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/AlbumService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/AlbumService.java
@@ -1,0 +1,128 @@
+package com.sofly.core.domain.album.service;
+
+import com.sofly.core.domain.album.dto.*;
+import com.sofly.core.domain.album.entity.Album;
+import com.sofly.core.domain.album.entity.Photo;
+import com.sofly.core.domain.album.repository.AlbumRepository;
+import com.sofly.core.domain.album.repository.PhotoRepository;
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.repository.UserRepository;
+import com.sofly.core.domain.workspace.entity.WorkspaceMember;
+import com.sofly.core.domain.workspace.entity.WorkspaceMember.MemberRole;
+import com.sofly.core.domain.workspace.repository.WorkspaceMemberRepository;
+import com.sofly.core.domain.workspace.repository.WorkspaceRepository;
+import com.sofly.core.global.exception.ErrorCode;
+import com.sofly.core.global.exception.SoflyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AlbumService {
+
+    private final AlbumRepository albumRepository;
+    private final PhotoRepository photoRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final WorkspaceMemberRepository workspaceMemberRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    /** 앨범 + 사진 목록 조회 */
+    public AlbumResponse getAlbum(Long workspaceId, Long userId) {
+        validateMember(workspaceId, userId);
+        Album album = getOrCreateAlbum(workspaceId);
+        List<PhotoResponse> photos = photoRepository.findByAlbumIdOrderByCreatedAtDesc(album.getId())
+                .stream()
+                .map(PhotoResponse::from)
+                .toList();
+        return new AlbumResponse(album.getId(), workspaceId, photos);
+    }
+
+    /** Presigned Upload URL 발급 */
+    public PresignedUrlResponse generateUploadUrl(Long workspaceId, Long userId, PresignedUrlRequest request) {
+        validateUploadPermission(workspaceId, userId);
+        String ext = extractExtension(request.fileName());
+        String s3Key = String.format("albums/%d/%s.%s", workspaceId, UUID.randomUUID(), ext);
+        String presignedUrl = s3Service.generatePresignedUploadUrl(s3Key, request.contentType());
+        return new PresignedUrlResponse(presignedUrl, s3Key);
+    }
+
+    /** 업로드 완료 후 DB 저장 */
+    @Transactional
+    public PhotoResponse savePhoto(Long workspaceId, Long userId, PhotoSaveRequest request) {
+        validateUploadPermission(workspaceId, userId);
+        Album album = getOrCreateAlbum(workspaceId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.USER_NOT_FOUND));
+
+        String url = s3Service.buildObjectUrl(request.s3Key());
+        Photo photo = Photo.of(album, user, request.s3Key(), url,
+                request.takenAt(), request.latitude(), request.longitude());
+        photoRepository.save(photo);
+        return PhotoResponse.from(photo);
+    }
+
+    /** 사진 삭제 (S3 + DB) */
+    @Transactional
+    public void deletePhoto(Long workspaceId, Long userId, Long photoId) {
+        WorkspaceMember member = validateMember(workspaceId, userId);
+        Photo photo = photoRepository.findById(photoId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.PHOTO_NOT_FOUND));
+
+        boolean isOwnerOrEditor = member.getRole() == MemberRole.OWNER || member.getRole() == MemberRole.EDITOR;
+        boolean isUploader = photo.getUploadedBy().getId().equals(userId);
+
+        if (!isOwnerOrEditor && !isUploader) {
+            throw new SoflyException(ErrorCode.DELETE_PERMISSION_DENIED);
+        }
+
+        s3Service.deleteObject(photo.getS3Key());
+        photoRepository.delete(photo);
+    }
+
+    /** 다운로드 Presigned URL 발급 */
+    public DownloadUrlResponse generateDownloadUrl(Long workspaceId, Long userId, Long photoId) {
+        validateMember(workspaceId, userId);
+        Photo photo = photoRepository.findById(photoId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.PHOTO_NOT_FOUND));
+        String downloadUrl = s3Service.generatePresignedDownloadUrl(photo.getS3Key());
+        return new DownloadUrlResponse(downloadUrl);
+    }
+
+    // ── 내부 헬퍼 ────────────────────────────────────────────
+
+    private WorkspaceMember validateMember(Long workspaceId, Long userId) {
+        if (!workspaceRepository.existsById(workspaceId)) {
+            throw new SoflyException(ErrorCode.WORKSPACE_NOT_FOUND);
+        }
+        return workspaceMemberRepository.findByWorkspaceIdAndUserId(workspaceId, userId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.WORKSPACE_ACCESS_DENIED));
+    }
+
+    private void validateUploadPermission(Long workspaceId, Long userId) {
+        WorkspaceMember member = validateMember(workspaceId, userId);
+        if (member.getRole() == MemberRole.VIEWER) {
+            throw new SoflyException(ErrorCode.UPLOAD_PERMISSION_DENIED);
+        }
+    }
+
+    @Transactional
+    private Album getOrCreateAlbum(Long workspaceId) {
+        return albumRepository.findByWorkspaceId(workspaceId)
+                .orElseGet(() -> {
+                    var workspace = workspaceRepository.findById(workspaceId)
+                            .orElseThrow(() -> new SoflyException(ErrorCode.WORKSPACE_NOT_FOUND));
+                    return albumRepository.save(Album.of(workspace));
+                });
+    }
+
+    private String extractExtension(String fileName) {
+        int idx = fileName.lastIndexOf('.');
+        return idx >= 0 ? fileName.substring(idx + 1).toLowerCase() : "jpg";
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/S3Service.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/S3Service.java
@@ -1,0 +1,76 @@
+package com.sofly.core.domain.album.service;
+
+import com.sofly.core.global.config.S3Config;
+import com.sofly.core.global.exception.ErrorCode;
+import com.sofly.core.global.exception.SoflyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final S3Config s3Config;
+
+    /** 업로드용 Presigned PUT URL 발급 (10분) */
+    public String generatePresignedUploadUrl(String s3Key, String contentType) {
+        try {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(s3Config.getS3().getBucket())
+                    .key(s3Key)
+                    .contentType(contentType)
+                    .build();
+
+            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(10))
+                    .putObjectRequest(putRequest)
+                    .build();
+
+            return s3Presigner.presignPutObject(presignRequest).url().toString();
+        } catch (Exception e) {
+            throw new SoflyException(ErrorCode.S3_UPLOAD_FAILED);
+        }
+    }
+
+    /** 다운로드용 Presigned GET URL 발급 (5분) */
+    public String generatePresignedDownloadUrl(String s3Key) {
+        GetObjectRequest getRequest = GetObjectRequest.builder()
+                .bucket(s3Config.getS3().getBucket())
+                .key(s3Key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .getObjectRequest(getRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+    /** S3 객체 삭제 */
+    public void deleteObject(String s3Key) {
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(s3Config.getS3().getBucket())
+                .key(s3Key)
+                .build());
+    }
+
+    /** S3 URL 생성 (업로드 완료 후 저장할 public URL) */
+    public String buildObjectUrl(String s3Key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                s3Config.getS3().getBucket(),
+                s3Config.getS3().getRegion(),
+                s3Key);
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/S3Service.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/S3Service.java
@@ -4,9 +4,12 @@ import com.sofly.core.global.config.S3Config;
 import com.sofly.core.global.exception.ErrorCode;
 import com.sofly.core.global.exception.SoflyException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -15,6 +18,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.time.Duration;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Service {
@@ -38,7 +42,7 @@ public class S3Service {
                     .build();
 
             return s3Presigner.presignPutObject(presignRequest).url().toString();
-        } catch (Exception e) {
+        } catch (SdkException e) {
             throw new SoflyException(ErrorCode.S3_UPLOAD_FAILED);
         }
     }
@@ -57,7 +61,7 @@ public class S3Service {
                     .build();
 
             return s3Presigner.presignGetObject(presignRequest).url().toString();
-        } catch (Exception e) {
+        } catch (SdkException e) {
             throw new SoflyException(ErrorCode.S3_DOWNLOAD_FAILED);
         }
     }
@@ -69,7 +73,9 @@ public class S3Service {
                     .bucket(s3Config.getS3().getBucket())
                     .key(s3Key)
                     .build());
-        } catch (Exception e) {
+        } catch (NoSuchKeyException e) {
+            log.warn("S3 객체가 이미 존재하지 않습니다: {}", s3Key);
+        } catch (SdkException e) {
             throw new SoflyException(ErrorCode.S3_DELETE_FAILED);
         }
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/S3Service.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/service/S3Service.java
@@ -45,25 +45,33 @@ public class S3Service {
 
     /** 다운로드용 Presigned GET URL 발급 (5분) */
     public String generatePresignedDownloadUrl(String s3Key) {
-        GetObjectRequest getRequest = GetObjectRequest.builder()
-                .bucket(s3Config.getS3().getBucket())
-                .key(s3Key)
-                .build();
+        try {
+            GetObjectRequest getRequest = GetObjectRequest.builder()
+                    .bucket(s3Config.getS3().getBucket())
+                    .key(s3Key)
+                    .build();
 
-        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(5))
-                .getObjectRequest(getRequest)
-                .build();
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(5))
+                    .getObjectRequest(getRequest)
+                    .build();
 
-        return s3Presigner.presignGetObject(presignRequest).url().toString();
+            return s3Presigner.presignGetObject(presignRequest).url().toString();
+        } catch (Exception e) {
+            throw new SoflyException(ErrorCode.S3_DOWNLOAD_FAILED);
+        }
     }
 
     /** S3 객체 삭제 */
     public void deleteObject(String s3Key) {
-        s3Client.deleteObject(DeleteObjectRequest.builder()
-                .bucket(s3Config.getS3().getBucket())
-                .key(s3Key)
-                .build());
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(s3Config.getS3().getBucket())
+                    .key(s3Key)
+                    .build());
+        } catch (Exception e) {
+            throw new SoflyException(ErrorCode.S3_DELETE_FAILED);
+        }
     }
 
     /** S3 URL 생성 (업로드 완료 후 저장할 public URL) */

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.travellog.controller;
+
+public class TravellogController {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogRequest.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.travellog.dto;
+
+public class TravellogRequest {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/entity/TravelLog.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/entity/TravelLog.java
@@ -6,6 +6,10 @@ import com.sofly.core.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "travel_logs")
 @Getter
@@ -18,6 +22,30 @@ public class TravelLog extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private Integer day;
+
+    private LocalDate travelDate;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;             // Markdown
+
+    @Enumerated(EnumType.STRING)
+    private Weather weather;
+
+    @ElementCollection
+    @CollectionTable(name = "travel_log_photos", joinColumns = @JoinColumn(name = "travel_log_id"))
+    @Column(name = "url")
+    @Builder.Default
+    private List<String> photoUrls = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Visibility visibility = Visibility.PRIVATE;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id", nullable = false)
     private Workspace workspace;
@@ -26,25 +54,11 @@ public class TravelLog extends BaseTimeEntity {
     @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
-    @Column(nullable = false)
-    private String title;
-
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String content;             // Markdown
-
-    private String coverImageUrl;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @Builder.Default
-    private Visibility visibility = Visibility.PRIVATE;
-
     // ── 비즈니스 메서드 ──────────────────────────────────────
 
-    public void update(String title, String content, String coverImageUrl, Visibility visibility) {
+    public void update(String title, String content, Visibility visibility) {
         this.title = title;
         this.content = content;
-        this.coverImageUrl = coverImageUrl;
         this.visibility = visibility;
     }
 
@@ -56,5 +70,12 @@ public class TravelLog extends BaseTimeEntity {
         PRIVATE,    // 비공개
         MEMBERS,    // 멤버 공개
         PUBLIC      // 전체 공개
+    }
+
+    public enum Weather {
+        SUNNY,
+        CLOUDY,
+        RAINY,
+        SNOWY
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.travellog.repository;
+
+public class TravellogRepository {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
@@ -1,0 +1,4 @@
+package com.sofly.core.domain.travellog.service;
+
+public class TravellogService {
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
 
     boolean existsByWorkspaceIdAndUserId(Long workspaceId, Long userId);
+
+    Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
 
     // 기존 findAllByWorkspaceId 삭제하고 아래로 교체
     @Query("SELECT wm FROM WorkspaceMember wm JOIN FETCH wm.user WHERE wm.workspace.id = :workspaceId")

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/repository/WorkspaceMemberRepository.java
@@ -1,0 +1,10 @@
+package com.sofly.core.domain.workspace.repository;
+
+import com.sofly.core.domain.workspace.entity.WorkspaceMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
+    Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/config/S3Config.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/config/S3Config.java
@@ -1,0 +1,58 @@
+package com.sofly.core.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@ConfigurationProperties(prefix = "cloud.aws")
+@Getter
+@Setter
+public class S3Config {
+
+    private S3Properties s3 = new S3Properties();
+    private CredentialsProperties credentials = new CredentialsProperties();
+
+    @Getter
+    @Setter
+    public static class S3Properties {
+        private String bucket;
+        private String region;
+    }
+
+    @Getter
+    @Setter
+    public static class CredentialsProperties {
+        private String accessKey;
+        private String secretKey;
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(s3.getRegion()))
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(s3.getRegion()))
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+
+    private StaticCredentialsProvider credentialsProvider() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(credentials.getAccessKey(), credentials.getSecretKey())
+        );
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/ErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
     UPLOAD_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "사진 업로드 권한이 없습니다."),
     DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "사진 삭제 권한이 없습니다."),
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 처리 중 오류가 발생했습니다."),
+    S3_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 다운로드 URL 생성 중 오류가 발생했습니다."),
+    S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 삭제 중 오류가 발생했습니다."),
 
     // ── TravelLog ────────────────────────────────────────
     TRAVEL_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "여행기를 찾을 수 없습니다."),

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/ErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
     // ── Album ────────────────────────────────────────────
     ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "앨범을 찾을 수 없습니다."),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "사진을 찾을 수 없습니다."),
+    UPLOAD_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "사진 업로드 권한이 없습니다."),
+    DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "사진 삭제 권한이 없습니다."),
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 처리 중 오류가 발생했습니다."),
 
     // ── TravelLog ────────────────────────────────────────
     TRAVEL_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "여행기를 찾을 수 없습니다."),

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -104,11 +104,11 @@ springdoc:
 cloud:
   aws:
     s3:
-      bucket: ${sofly-bucket}
+      bucket: ${S3_BUCKET:sofly-bucket}
       region: ${AWS_REGION:ap-northeast-2}
     credentials:
-      access-key: ${AWS_ACCESS_KEY_ID}
-      secret-key: ${AWS_SECRET_ACCESS_KEY}
+      access-key: ${AWS_S3_ACCESS_KEY_ID}
+      secret-key: ${AWS_S3_SECRET_ACCESS_KEY}
 
 logging:
   exception-conversion-word: "%wEx{0}"

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -99,5 +99,14 @@ springdoc:
   api-docs:
     path: /core/v3/api-docs
 
+cloud:
+  aws:
+    s3:
+      bucket: ${sofly-bucket}
+      region: ${AWS_REGION:ap-northeast-2}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+
 logging:
   exception-conversion-word: "%wEx{0}"

--- a/services/travel-supply-service/build.gradle
+++ b/services/travel-supply-service/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0' //swagger
+
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightMetaClient.java
@@ -7,6 +7,7 @@ import com.sofly.supply.application.port.outbound.FlightMetaPort;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -21,6 +22,7 @@ public class BookingComFlightMetaClient implements FlightMetaPort {
 
     private final WebClient rapidApiWebClient;
 
+    @Cacheable(value = "flightDestinations", key = "#query + ':' + #languageCode")
     public List<FlightDestination> searchDestinations(String query, String languageCode){
         try{
             JsonNode response = rapidApiWebClient.get()

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
@@ -1,0 +1,148 @@
+package com.sofly.supply.adapter.outbound.rapidapi.flights;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class BookingComFlightResponseFilter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private BookingComFlightResponseFilter() {}
+
+    static JsonNode filter(JsonNode root) {
+        ObjectNode result = MAPPER.createObjectNode();
+        result.put("status", root.path("status").asBoolean());
+
+        JsonNode data = root.path("data");
+        if (data.isMissingNode()) return result;
+
+        ObjectNode filteredData = MAPPER.createObjectNode();
+        filteredData.set("flightOffers", filterOffers(data.path("flightOffers")));
+        result.set("data", filteredData);
+        return result;
+    }
+
+    private static ArrayNode filterOffers(JsonNode offers) {
+        ArrayNode result = MAPPER.createArrayNode();
+        for (JsonNode offer : offers) {
+            result.add(filterOffer(offer));
+        }
+        return result;
+    }
+
+    private static ObjectNode filterOffer(JsonNode offer) {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("token", offer.path("token").asText());
+        node.put("tripType", offer.path("tripType").asText());
+        node.put("offerKeyToHighlight", offer.path("offerKeyToHighlight").asText());
+
+        JsonNode seat = offer.path("seatAvailability");
+        if (!seat.isMissingNode()) node.set("seatAvailability", seat);
+
+        JsonNode price = offer.path("priceBreakdown");
+        if (!price.isMissingNode()) node.set("price", filterPrice(price));
+
+        JsonNode fareInfo = offer.path("brandedFareInfo");
+        if (!fareInfo.isMissingNode() && fareInfo.hasNonNull("fareName")) {
+            ObjectNode fare = MAPPER.createObjectNode();
+            fare.put("fareName", fareInfo.path("fareName").asText());
+            fare.put("cabinClass", fareInfo.path("cabinClass").asText());
+            node.set("brandedFareInfo", fare);
+        }
+
+        node.set("segments", filterSegments(offer.path("segments")));
+        return node;
+    }
+
+    private static ObjectNode filterPrice(JsonNode priceBreakdown) {
+        ObjectNode node = MAPPER.createObjectNode();
+        copyMoneyField(node, "total", priceBreakdown.path("total"));
+        copyMoneyField(node, "baseFare", priceBreakdown.path("baseFare"));
+        copyMoneyField(node, "tax", priceBreakdown.path("tax"));
+        return node;
+    }
+
+    private static void copyMoneyField(ObjectNode target, String key, JsonNode money) {
+        if (money.isMissingNode()) return;
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("currencyCode", money.path("currencyCode").asText());
+        node.put("units", money.path("units").asLong());
+        node.put("nanos", money.path("nanos").asLong());
+        target.set(key, node);
+    }
+
+    private static ArrayNode filterSegments(JsonNode segments) {
+        ArrayNode result = MAPPER.createArrayNode();
+        for (JsonNode segment : segments) {
+            result.add(filterSegment(segment));
+        }
+        return result;
+    }
+
+    private static ObjectNode filterSegment(JsonNode segment) {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("departureAirport", filterAirport(segment.path("departureAirport")));
+        node.set("arrivalAirport", filterAirport(segment.path("arrivalAirport")));
+        node.put("departureTime", segment.path("departureTime").asText());
+        node.put("arrivalTime", segment.path("arrivalTime").asText());
+        node.put("totalTime", segment.path("totalTime").asInt());
+        node.set("legs", filterLegs(segment.path("legs")));
+        return node;
+    }
+
+    private static ObjectNode filterAirport(JsonNode airport) {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("code", airport.path("code").asText());
+        node.put("cityName", airport.path("cityName").asText());
+        node.put("countryName", airport.path("countryName").asText());
+        String terminal = airport.path("terminal").asText(null);
+        if (terminal != null && !terminal.isEmpty()) node.put("terminal", terminal);
+        return node;
+    }
+
+    private static ArrayNode filterLegs(JsonNode legs) {
+        ArrayNode result = MAPPER.createArrayNode();
+        for (JsonNode leg : legs) {
+            ObjectNode node = MAPPER.createObjectNode();
+            node.put("departureTime", leg.path("departureTime").asText());
+            node.put("arrivalTime", leg.path("arrivalTime").asText());
+            node.put("totalTime", leg.path("totalTime").asInt());
+            node.put("cabinClass", leg.path("cabinClass").asText());
+
+            JsonNode flightInfo = leg.path("flightInfo");
+            node.put("flightNumber", flightInfo.path("flightNumber").asInt());
+            node.put("planeType", flightInfo.path("planeType").asText());
+
+            JsonNode carrierInfo = flightInfo.path("carrierInfo");
+            node.put("operatingCarrier", carrierInfo.path("operatingCarrier").asText());
+            node.put("marketingCarrier", carrierInfo.path("marketingCarrier").asText());
+
+            // carriersData 중복 제거 (code 기준)
+            JsonNode carriersData = leg.path("carriersData");
+            ArrayNode uniqueCarriers = MAPPER.createArrayNode();
+            java.util.Set<String> seen = new java.util.LinkedHashSet<>();
+            for (JsonNode c : carriersData) {
+                String code = c.path("code").asText();
+                if (seen.add(code)) {
+                    ObjectNode carrier = MAPPER.createObjectNode();
+                    carrier.put("name", c.path("name").asText());
+                    carrier.put("code", code);
+                    carrier.put("logo", c.path("logo").asText());
+                    uniqueCarriers.add(carrier);
+                }
+            }
+            node.set("carriersData", uniqueCarriers);
+            node.set("flightStops", leg.path("flightStops"));
+
+            String depTerminal = leg.path("departureTerminal").asText(null);
+            String arrTerminal = leg.path("arrivalTerminal").asText(null);
+            if (depTerminal != null && !depTerminal.isEmpty()) node.put("departureTerminal", depTerminal);
+            if (arrTerminal != null && !arrTerminal.isEmpty()) node.put("arrivalTerminal", arrTerminal);
+
+            result.add(node);
+        }
+        return result;
+    }
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
@@ -6,6 +6,7 @@ import com.sofly.supply.application.dto.FlightSearchRequest;
 import com.sofly.supply.application.port.outbound.FlightSupplierPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -21,6 +22,7 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
         return "booking";
     }
 
+    @Cacheable(value = "bookingFlights", key = "#request")
     @Override
     public JsonNode searchFlightOffers(FlightSearchRequest request) {
         String response = rapidApiWebClient.get()
@@ -54,6 +56,6 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
                 .block();
 
         if (response == null) return RapidApiJsonUtils.nullNode();
-        return RapidApiJsonUtils.parseJson(response);
+        return BookingComFlightResponseFilter.filter(RapidApiJsonUtils.parseJson(response));
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
@@ -5,6 +5,7 @@ import com.sofly.supply.adapter.outbound.rapidapi.RapidApiJsonUtils;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.port.outbound.HotelSupplierPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -19,6 +20,7 @@ public class BookingComHotelAdapter implements HotelSupplierPort {
         return "booking";
     }
 
+    @Cacheable(value = "bookingHotels", key = "#request")
     @Override
     public JsonNode searchHotelsByCity(HotelSearchRequest request){
 

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelMetaClient.java
@@ -9,6 +9,7 @@ import com.sofly.supply.application.port.outbound.HotelMetaPort;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -27,6 +28,7 @@ public class BookingComHotelMetaClient implements HotelMetaPort {
 
     private final WebClient rapidApiWebClient;
 
+    @Cacheable(value = "hotelDestinations", key = "#query")
     public List<HotelDestination> searchDestination(String query) {
         try {
             JsonNode response = rapidApiWebClient.get()
@@ -68,6 +70,7 @@ public class BookingComHotelMetaClient implements HotelMetaPort {
         }
     }
 
+    @Cacheable(value = "hotelSortBy", key = "#request")
     public List<HotelSortOption> getSortBy(HotelOptionsRequest request) {
         try {
             JsonNode response = rapidApiWebClient.get()
@@ -97,6 +100,7 @@ public class BookingComHotelMetaClient implements HotelMetaPort {
         }
     }
 
+    @Cacheable(value = "hotelFilter", key = "#request")
     public JsonNode getFilter(HotelOptionsRequest request) {
         try {
             JsonNode response = rapidApiWebClient.get()

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/FlightSearchRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/FlightSearchRequest.java
@@ -3,9 +3,11 @@ package com.sofly.supply.application.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
@@ -15,6 +17,8 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
+@ToString
 public class FlightSearchRequest {
 
     // 공통 필수

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelOptionsRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelOptionsRequest.java
@@ -11,6 +11,8 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
+@ToString
 public class HotelOptionsRequest {
 
     @Schema(defaultValue = "-2092174", required = true)

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelSearchRequest.java
@@ -11,6 +11,8 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
+@ToString
 public class HotelSearchRequest {
 
     @Schema(defaultValue = "267199", required = true)

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/config/RedisCacheConfig.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/config/RedisCacheConfig.java
@@ -1,0 +1,64 @@
+package com.sofly.supply.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Map;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+        // 항공/호텔 검색 결과: JsonNode, TTL 5분
+        RedisCacheConfiguration searchConfig = jsonNodeCacheConfig(Duration.ofMinutes(5));
+
+        // 목적지/정렬/필터 메타 데이터: POJO, TTL 24시간
+        RedisCacheConfiguration pojoMetaConfig = pojoCacheConfig(Duration.ofHours(24));
+
+        // getFilter는 JsonNode 반환, TTL 24시간
+        RedisCacheConfiguration jsonNodeMetaConfig = jsonNodeCacheConfig(Duration.ofHours(24));
+
+        return RedisCacheManager.builder(factory)
+                .cacheDefaults(searchConfig)
+                .withInitialCacheConfigurations(Map.of(
+                        "flightDestinations", pojoMetaConfig,
+                        "hotelDestinations",  pojoMetaConfig,
+                        "hotelSortBy",        pojoMetaConfig,
+                        "hotelFilter",        jsonNodeMetaConfig
+                ))
+                .build();
+    }
+
+    private RedisCacheConfiguration jsonNodeCacheConfig(Duration ttl) {
+        Jackson2JsonRedisSerializer<JsonNode> serializer =
+                new Jackson2JsonRedisSerializer<>(new ObjectMapper(), JsonNode.class);
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(ttl)
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(serializer));
+    }
+
+    private RedisCacheConfiguration pojoCacheConfig(Duration ttl) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(ttl)
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+    }
+}

--- a/services/travel-supply-service/src/main/resources/application.yaml
+++ b/services/travel-supply-service/src/main/resources/application.yaml
@@ -8,6 +8,10 @@ logging:
 spring:
   application:
     name: travel-supply-service
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   jackson:
     serialization:
       indent_output: true


### PR DESCRIPTION
## 📌 PR 요약
- Booking.com 항공편 응답 필터링 추가 및 앨범 도메인을 Google Drive에서 AWS S3 기반으로 전환, TravelLog 엔티티 초기 구현

## 🔧 변경 사항
- **항공편 응답 필터링**: Booking.com RapidAPI 응답에서 불필요한 필드를 제거하고 프론트엔드에 필요한 데이터만 추려서 반환 (`BookingComFlightResponseFilter`)
- **앨범 도메인 S3 전환**: Google Drive 기반에서 AWS S3 Presigned URL 방식으로 전환. 클라이언트가 직접 S3에 업로드 후 메타데이터만 서버에 저장하는 구조로 구현
- **Redis 캐시**: 항공/호텔 검색 결과 및 목적지/정렬/필터 메타 API에 Redis 캐시 적용
- **TravelLog**: 마크다운 기반 여행기 엔티티 및 초기 파일 생성
- **버그 수정**: 앨범 서비스 readOnly 트랜잭션 내 write 버그, 타 워크스페이스 photo 접근 가능한 보안 취약점 수정

## 📋 작업 상세 내용
- [x] `BookingComFlightResponseFilter` — 항공편 응답 필드 필터링
- [x] `S3Config` + `S3Service` — AWS S3 인프라 및 Presigned URL 발급
- [x] `AlbumController` / `AlbumService` — 앨범 CRUD API (조회, 업로드, 저장, 삭제, 다운로드)
- [x] Redis 캐시 인프라 설정 및 검색 결과 캐싱
- [x] `TravelLog` 엔티티 초기 생성
- [x] 앨범 서비스 트랜잭션·보안 버그 수정

## 🔗 관련 이슈
- closed #44

## 📝 기타
- S3 업로드는 클라이언트 → Presigned URL → S3 직접 업로드 → 서버 DB 저장 순서로 동작
- 사진 삭제/다운로드 시 photo가 해당 workspace 소속인지 검증 로직 포함