### PR TITLE
Bug/37 oauth2 login error

### DIFF
--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/user/repository/UserRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndProviderId(User.Provider provider, String providerId);
 
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/service/AuthService.java
@@ -1,17 +1,21 @@
 package com.sofly.core.global.auth.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.sofly.core.global.auth.dto.RefreshTokenRequest;
 import com.sofly.core.global.auth.dto.TokenResponse;
-import com.sofly.core.global.exception.SoflyException;
 import com.sofly.core.global.exception.ErrorCode;
+import com.sofly.core.global.exception.SoflyException;
 import com.sofly.core.global.security.jwt.JwtProperties;
 import com.sofly.core.global.security.jwt.JwtTokenProvider;
 import com.sofly.core.global.security.oauth2.RefreshToken;
 import com.sofly.core.global.security.oauth2.RefreshTokenRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -62,5 +66,6 @@ public class AuthService {
     @Transactional
     public void logout(Long userId) {
         refreshTokenRepository.deleteById(String.valueOf(userId));
+        log.info("OAuth2 로그아웃 - userId: {}", userId);
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
@@ -51,17 +51,20 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     // ── 신규 가입 or 기존 회원 반환 ──────────────────────
     private User saveOrUpdate(String registrationId, OAuth2UserInfo userInfo) {
         User.Provider provider = User.Provider.valueOf(registrationId.toUpperCase());
-
+        
         return userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
-                .orElseGet(() -> userRepository.save(
-                        User.builder()
-                                .email(userInfo.getEmail())
-                                .nickname(userInfo.getNickname())
-                                .profileImageUrl(userInfo.getProfileImageUrl())
-                                .provider(provider)
-                                .providerId(userInfo.getProviderId())
-                                .role(User.Role.USER)
-                                .build()
-                ));
+                .orElseGet(() -> {
+                    if (userRepository.existsByEmail(userInfo.getEmail())) {
+                        throw new OAuth2AuthenticationException("이미 다른 소셜 계정으로 가입된 이메일입니다.");
+                    }
+                    return userRepository.save(User.builder()
+                            .email(userInfo.getEmail())
+                            .nickname(userInfo.getNickname())
+                            .profileImageUrl(userInfo.getProfileImageUrl())
+                            .provider(provider)
+                            .providerId(userInfo.getProviderId())
+                            .role(User.Role.USER)
+                            .build());
+                });
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
@@ -57,13 +57,19 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         
         return userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
                 .orElseGet(() -> {
-                    if (userRepository.existsByEmail(userInfo.getEmail())) {
+                    String email = userInfo.getEmail();
+                    if(email == null || email.isBlank()){
+                        throw new OAuth2AuthenticationException(
+                            new OAuth2Error("missing_email", "소셜 계정에서 이메일 정보를 가져올 수 없습니다.", null)
+                        );
+                    }
+                    if (userRepository.existsByEmail(email)) {
                         throw new OAuth2AuthenticationException(
                             new OAuth2Error("duplicate_email", "이미 다른 소셜 계정으로 가입된 이메일입니다.", null)
                         );
                     }
                     return userRepository.save(User.builder()
-                            .email(userInfo.getEmail())
+                            .email(email)
                             .nickname(userInfo.getNickname())
                             .profileImageUrl(userInfo.getProfileImageUrl())
                             .provider(provider)

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/CustomOAuth2UserService.java
@@ -1,19 +1,22 @@
 package com.sofly.core.global.security.oauth2;
 
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.sofly.core.domain.user.entity.User;
 import com.sofly.core.domain.user.repository.UserRepository;
 import com.sofly.core.global.security.oauth2.userinfo.GoogleUserInfo;
 import com.sofly.core.global.security.oauth2.userinfo.KakaoUserInfo;
 import com.sofly.core.global.security.oauth2.userinfo.NaverUserInfo;
 import com.sofly.core.global.security.oauth2.userinfo.OAuth2UserInfo;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -55,7 +58,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return userRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
                 .orElseGet(() -> {
                     if (userRepository.existsByEmail(userInfo.getEmail())) {
-                        throw new OAuth2AuthenticationException("이미 다른 소셜 계정으로 가입된 이메일입니다.");
+                        throw new OAuth2AuthenticationException(
+                            new OAuth2Error("duplicate_email", "이미 다른 소셜 계정으로 가입된 이메일입니다.", null)
+                        );
                     }
                     return userRepository.save(User.builder()
                             .email(userInfo.getEmail())

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,15 +1,17 @@
 package com.sofly.core.global.security.oauth2;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.IOException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -22,13 +24,16 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
+        String errorMessage = (exception instanceof OAuth2AuthenticationException oauthEx)
+                ? oauthEx.getError().getDescription()
+                : exception.getMessage();
 
-        log.error("OAuth2 로그인 실패: {}", exception.getMessage());
-
+        log.error("OAuth2 로그인 실패: {}", errorMessage);
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
-                .queryParam("error", exception.getMessage())
-                .build().toUriString();
-
+                .queryParam("error", errorMessage)
+                .build()
+                .encode()
+                .toUriString();
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -26,7 +26,8 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
                                         AuthenticationException exception) throws IOException {
         String errorMessage = (exception instanceof OAuth2AuthenticationException oauthEx)
                 ? oauthEx.getError().getDescription()
-                : exception.getMessage();
+                : "인증 처리 중 오류가 발생했습니다.";
+        if (errorMessage == null) errorMessage = "알 수 없는 인증 오류가 발생했습니다.";
 
         log.error("OAuth2 로그인 실패: {}", errorMessage);
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)

--- a/services/travel-core-service/src/main/resources/static/index.html
+++ b/services/travel-core-service/src/main/resources/static/index.html
@@ -638,7 +638,9 @@
 
     if (error) {
       panel.className = 'response-panel error';
-      panel.textContent = '로그인 실패: ' + error;
+      panel.textContent = '로그인 실패: ' + decodeURIComponent(error);
+      window.history.replaceState({}, '', '/');
+      setTimeout(() => toast('로그인 실패: ' + decodeURIComponent(error)), 100);
       return;
     }
 


### PR DESCRIPTION
## 📌 PR 요약
OAuth2 소셜 로그인 시 중복 이메일 검증 및 에러 처리를 추가합니다.

## 🔧 변경 사항
- 동일 이메일로 다른 소셜 provider 가입 시도 시 duplicate key 에러가 발생하는 문제를 수정합니다.
- OAuth2 로그인 실패 시 에러 메시지가 프론트로 전달되지 않던 문제를 수정합니다.

## 📋 작업 상세 내용
- [x] `CustomOAuth2UserService`: 동일 이메일로 다른 provider 가입 시도 시 `OAuth2Error`로 예외 처리
- [x] `OAuth2AuthenticationFailureHandler`: `OAuth2Error.getDescription()`으로 에러 메시지 추출
- [x] `OAuth2AuthenticationFailureHandler`: 한글 에러 메시지 URL 인코딩 처리
- [x] `UserRepository`: `existsByEmail()` 메서드 추가

## 🔗 관련 이슈
- closed #37

## 📝 기타
- 실무 표준에 따라 동일 이메일은 단일 계정으로 관리합니다. 이미 다른 소셜 계정으로 가입된 이메일로 로그인 시도 시 에러 메시지를 프론트로 전달합니다.
- 에러 메시지는 `/?error=메시지` 형태로 리다이렉트됩니다.