### PR TITLE
Feat/49 travel log

### DIFF
--- a/services/travel-core-service/build.gradle
+++ b/services/travel-core-service/build.gradle
@@ -34,6 +34,7 @@ ext {
 dependencies {
     // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PhotoResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/dto/PhotoResponse.java
@@ -29,4 +29,5 @@ public record PhotoResponse(
                 photo.getCreatedAt()
         );
     }
+
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/album/repository/PhotoRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/album/repository/PhotoRepository.java
@@ -17,4 +17,8 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     /** 권한 확인 및 상세 조회용: uploader, album, workspace를 한 번에 로드 */
     @Query("SELECT p FROM Photo p JOIN FETCH p.uploadedBy JOIN FETCH p.album a JOIN FETCH a.workspace WHERE p.id = :photoId")
     Optional<Photo> findByIdWithDetails(@Param("photoId") Long photoId);
+
+    /** 주어진 photoIds 중 해당 workspace 앨범에 속한 사진 수 반환 (workspace 소속 검증용) */
+    @Query("SELECT COUNT(p) FROM Photo p WHERE p.id IN :photoIds AND p.album.workspace.id = :workspaceId")
+    long countByIdsAndWorkspaceId(@Param("photoIds") List<Long> photoIds, @Param("workspaceId") Long workspaceId);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
@@ -2,6 +2,7 @@ package com.sofly.core.domain.travellog.controller;
 
 import com.sofly.core.domain.travellog.dto.TravellogCreateRequest;
 import com.sofly.core.domain.travellog.dto.TravellogResponse;
+import com.sofly.core.domain.travellog.dto.TravellogSummaryResponse;
 import com.sofly.core.domain.travellog.dto.TravellogUpdateRequest;
 import com.sofly.core.domain.travellog.service.TravellogService;
 import com.sofly.core.global.response.ApiResponse;
@@ -24,9 +25,9 @@ public class TravellogController {
 
     private final TravellogService travellogService;
 
-    @Operation(summary = "여행기 목록 조회", description = "워크스페이스의 여행기 목록을 여행 날짜 오름차순으로 조회합니다.")
+    @Operation(summary = "여행기 목록 조회", description = "워크스페이스의 여행기 목록을 여행 날짜 오름차순으로 조회합니다. content는 포함되지 않습니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<TravellogResponse>>> getTravelLogs(@PathVariable Long workspaceId) {
+    public ResponseEntity<ApiResponse<List<TravellogSummaryResponse>>> getTravelLogs(@PathVariable Long workspaceId) {
         return ResponseEntity.ok(ApiResponse.success(travellogService.getTravelLogs(workspaceId)));
     }
 
@@ -53,7 +54,7 @@ public class TravellogController {
     public ResponseEntity<ApiResponse<TravellogResponse>> updateTravelLog(
             @PathVariable Long workspaceId,
             @PathVariable Long logId,
-            @RequestBody TravellogUpdateRequest request) {
+            @RequestBody @Valid TravellogUpdateRequest request) {
         return ResponseEntity.ok(ApiResponse.success(travellogService.updateTravelLog(workspaceId, logId, request)));
     }
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
@@ -1,4 +1,68 @@
 package com.sofly.core.domain.travellog.controller;
 
+import com.sofly.core.domain.travellog.dto.TravellogCreateRequest;
+import com.sofly.core.domain.travellog.dto.TravellogResponse;
+import com.sofly.core.domain.travellog.dto.TravellogUpdateRequest;
+import com.sofly.core.domain.travellog.service.TravellogService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "TravelLog", description = "여행기 CRUD API")
+@RestController
+@RequestMapping("/api/workspaces/{workspaceId}/travellogs")
+@RequiredArgsConstructor
 public class TravellogController {
+
+    private final TravellogService travellogService;
+
+    @Operation(summary = "여행기 목록 조회", description = "워크스페이스의 여행기 목록을 여행 날짜 오름차순으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TravellogResponse>>> getTravelLogs(@PathVariable Long workspaceId) {
+        return ResponseEntity.ok(ApiResponse.success(travellogService.getTravelLogs(workspaceId)));
+    }
+
+    @Operation(summary = "여행기 단건 조회", description = "여행기 상세 정보와 첨부 사진을 조회합니다.")
+    @GetMapping("/{logId}")
+    public ResponseEntity<ApiResponse<TravellogResponse>> getTravelLog(
+            @PathVariable Long workspaceId,
+            @PathVariable Long logId) {
+        return ResponseEntity.ok(ApiResponse.success(travellogService.getTravelLog(workspaceId, logId)));
+    }
+
+    @Operation(summary = "여행기 생성", description = "새 여행기를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<TravellogResponse>> createTravelLog(
+            @PathVariable Long workspaceId,
+            @RequestBody @Valid TravellogCreateRequest request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(travellogService.createTravelLog(workspaceId, userId, request)));
+    }
+
+    @Operation(summary = "여행기 수정", description = "여행기 내용을 부분 수정합니다. null 필드는 변경되지 않습니다.")
+    @PatchMapping("/{logId}")
+    public ResponseEntity<ApiResponse<TravellogResponse>> updateTravelLog(
+            @PathVariable Long workspaceId,
+            @PathVariable Long logId,
+            @RequestBody TravellogUpdateRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(travellogService.updateTravelLog(workspaceId, logId, request)));
+    }
+
+    @Operation(summary = "여행기 삭제", description = "여행기를 삭제합니다.")
+    @DeleteMapping("/{logId}")
+    public ResponseEntity<Void> deleteTravelLog(
+            @PathVariable Long workspaceId,
+            @PathVariable Long logId) {
+        travellogService.deleteTravelLog(workspaceId, logId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "TravelLog", description = "여행기 CRUD API")
+@Tag(name = "TravelLog", description = "여행 기록 API")
 @RestController
 @RequestMapping("/api/workspaces/{workspaceId}/travellogs")
 @RequiredArgsConstructor

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogPhotoController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogPhotoController.java
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Tag(name = "TravelLog Photo", description = "여행기 사진 첨부·해제 API")
+@Tag(name = "TravelLog Photo", description = "여행 기록 사진 첨부·해제 API")
 @RestController
 @RequestMapping("/api/workspaces/{workspaceId}/travellogs/{logId}/photos")
 @RequiredArgsConstructor

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogPhotoController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/controller/TravellogPhotoController.java
@@ -1,0 +1,57 @@
+package com.sofly.core.domain.travellog.controller;
+
+import com.sofly.core.domain.travellog.dto.TravellogPhotoLinkRequest;
+import com.sofly.core.domain.travellog.dto.TravellogResponse;
+import com.sofly.core.domain.travellog.service.TravellogService;
+import com.sofly.core.global.response.ApiResponse;
+import com.sofly.core.global.security.util.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "TravelLog Photo", description = "여행기 사진 첨부·해제 API")
+@RestController
+@RequestMapping("/api/workspaces/{workspaceId}/travellogs/{logId}/photos")
+@RequiredArgsConstructor
+public class TravellogPhotoController {
+
+    private final TravellogService travellogService;
+
+    @Operation(summary = "사진 업로드 후 첨부", description = "새 사진을 S3에 업로드하고 여행기에 첨부합니다.")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<TravellogResponse>> uploadAndAttachPhotos(
+            @PathVariable Long workspaceId,
+            @PathVariable Long logId,
+            @RequestPart("files") List<MultipartFile> files) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return ResponseEntity.ok(ApiResponse.success(
+                travellogService.uploadAndAttachPhotos(workspaceId, userId, logId, files)));
+    }
+
+    @Operation(summary = "앨범 사진 첨부", description = "워크스페이스 앨범에 이미 업로드된 사진을 여행기에 첨부합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<TravellogResponse>> attachAlbumPhotos(
+            @PathVariable Long workspaceId,
+            @PathVariable Long logId,
+            @RequestBody @Valid TravellogPhotoLinkRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(
+                travellogService.attachAlbumPhotos(workspaceId, logId, request.photoIds())));
+    }
+
+    @Operation(summary = "첨부 사진 해제", description = "여행기에서 사진 첨부를 해제합니다. 앨범에서 사진이 삭제되지는 않습니다.")
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<TravellogResponse>> removePhotos(
+            @PathVariable Long workspaceId,
+            @PathVariable Long logId,
+            @RequestBody @Valid TravellogPhotoLinkRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(
+                travellogService.removePhotos(workspaceId, logId, request.photoIds())));
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogCreateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogCreateRequest.java
@@ -1,0 +1,14 @@
+package com.sofly.core.domain.travellog.dto;
+
+import com.sofly.core.domain.travellog.entity.TravelLog.Weather;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+
+public record TravellogCreateRequest(
+        Integer day,
+        LocalDate travelDate,
+        @NotBlank String title,
+        @NotBlank String content,
+        Weather weather
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogPhotoLinkRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogPhotoLinkRequest.java
@@ -1,0 +1,9 @@
+package com.sofly.core.domain.travellog.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record TravellogPhotoLinkRequest(
+        @NotEmpty List<Long> photoIds
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogRequest.java
@@ -1,4 +1,0 @@
-package com.sofly.core.domain.travellog.dto;
-
-public class TravellogRequest {
-}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogResponse.java
@@ -1,0 +1,45 @@
+package com.sofly.core.domain.travellog.dto;
+
+import com.sofly.core.domain.album.dto.PhotoResponse;
+import com.sofly.core.domain.travellog.entity.TravelLog;
+import com.sofly.core.domain.travellog.entity.TravelLog.Weather;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TravellogResponse(
+        Long id,
+        Integer day,
+        LocalDate travelDate,
+        String title,
+        String content,
+        Weather weather,
+        Long workspaceId,
+        Long authorId,
+        String authorNickname,
+        List<PhotoResponse> photos,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static TravellogResponse from(TravelLog log) {
+        List<PhotoResponse> photoResponses = log.getPhotos().stream()
+                .map(PhotoResponse::from)
+                .toList();
+
+        return new TravellogResponse(
+                log.getId(),
+                log.getDay(),
+                log.getTravelDate(),
+                log.getTitle(),
+                log.getContent(),
+                log.getWeather(),
+                log.getWorkspace().getId(),
+                log.getAuthor().getId(),
+                log.getAuthor().getNickname(),
+                photoResponses,
+                log.getCreatedAt(),
+                log.getUpdatedAt()
+        );
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogSummaryResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.sofly.core.domain.travellog.dto;
+
+import com.sofly.core.domain.travellog.entity.TravelLog;
+import com.sofly.core.domain.travellog.entity.TravelLog.Weather;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record TravellogSummaryResponse(
+        Long id,
+        Integer day,
+        LocalDate travelDate,
+        String title,
+        Weather weather,
+        int photoCount,
+        LocalDateTime createdAt
+) {
+    public static TravellogSummaryResponse from(TravelLog log) {
+        return new TravellogSummaryResponse(
+                log.getId(),
+                log.getDay(),
+                log.getTravelDate(),
+                log.getTitle(),
+                log.getWeather(),
+                log.getPhotos().size(),
+                log.getCreatedAt()
+        );
+    }
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogUpdateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogUpdateRequest.java
@@ -1,13 +1,14 @@
 package com.sofly.core.domain.travellog.dto;
 
 import com.sofly.core.domain.travellog.entity.TravelLog.Weather;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
 public record TravellogUpdateRequest(
         Integer day,
         LocalDate travelDate,
-        String title,
-        String content,
+        @Size(min = 1, message = "제목은 빈 값일 수 없습니다") String title,
+        @Size(min = 1, message = "내용은 빈 값일 수 없습니다") String content,
         Weather weather
 ) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogUpdateRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/dto/TravellogUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.sofly.core.domain.travellog.dto;
+
+import com.sofly.core.domain.travellog.entity.TravelLog.Weather;
+
+import java.time.LocalDate;
+
+public record TravellogUpdateRequest(
+        Integer day,
+        LocalDate travelDate,
+        String title,
+        String content,
+        Weather weather
+) {}

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/entity/TravelLog.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/entity/TravelLog.java
@@ -1,5 +1,7 @@
 package com.sofly.core.domain.travellog.entity;
 
+import com.sofly.core.domain.album.entity.Photo;
+import com.sofly.core.domain.travellog.dto.TravellogUpdateRequest;
 import com.sofly.core.domain.user.entity.User;
 import com.sofly.core.domain.workspace.entity.Workspace;
 import com.sofly.core.global.entity.BaseTimeEntity;
@@ -35,16 +37,19 @@ public class TravelLog extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Weather weather;
 
-    @ElementCollection
-    @CollectionTable(name = "travel_log_photos", joinColumns = @JoinColumn(name = "travel_log_id"))
-    @Column(name = "url")
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "travel_log_photos",
+            joinColumns = @JoinColumn(name = "travel_log_id"),
+            inverseJoinColumns = @JoinColumn(name = "photo_id")
+    )
     @Builder.Default
-    private List<String> photoUrls = new ArrayList<>();
+    private List<Photo> photos = new ArrayList<>();
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @Builder.Default
-    private Visibility visibility = Visibility.PRIVATE;
+//    @Enumerated(EnumType.STRING)
+//    @Column(nullable = false)
+//    @Builder.Default
+//    private Visibility visibility = Visibility.PRIVATE;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id", nullable = false)
@@ -56,14 +61,24 @@ public class TravelLog extends BaseTimeEntity {
 
     // ── 비즈니스 메서드 ──────────────────────────────────────
 
-    public void update(String title, String content, Visibility visibility) {
-        this.title = title;
-        this.content = content;
-        this.visibility = visibility;
+    public void update(TravellogUpdateRequest request) {
+        if (request.day() != null) this.day = request.day();
+        if (request.travelDate() != null) this.travelDate = request.travelDate();
+        if (request.title() != null) this.title = request.title();
+        if (request.content() != null) this.content = request.content();
+        if (request.weather() != null) this.weather = request.weather();
     }
 
     public boolean isAuthor(Long userId) {
         return this.author.getId().equals(userId);
+    }
+
+    public void addPhoto(Photo photo) {
+        this.photos.add(photo);
+    }
+
+    public void removePhoto(Photo photo) {
+        this.photos.remove(photo);
     }
 
     public enum Visibility {

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/entity/TravelLog.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/entity/TravelLog.java
@@ -46,6 +46,7 @@ public class TravelLog extends BaseTimeEntity {
     @Builder.Default
     private List<Photo> photos = new ArrayList<>();
 
+    // TODO: 공개 범위 기능 구현 예정 (PRIVATE / MEMBERS / PUBLIC)
 //    @Enumerated(EnumType.STRING)
 //    @Column(nullable = false)
 //    @Builder.Default
@@ -69,6 +70,9 @@ public class TravelLog extends BaseTimeEntity {
         if (request.weather() != null) this.weather = request.weather();
     }
 
+    // TODO: 수정/삭제 권한 정책 결정 필요
+    //  - 작성자 본인만 가능: isAuthor(userId) 체크를 서비스에 추가
+    //  - 워크스페이스 EDITOR 이상이면 모두 가능: isAuthor 메서드 제거
     public boolean isAuthor(Long userId) {
         return this.author.getId().equals(userId);
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
@@ -1,4 +1,16 @@
 package com.sofly.core.domain.travellog.repository;
 
-public class TravellogRepository {
+import com.sofly.core.domain.travellog.entity.TravelLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TravellogRepository extends JpaRepository<TravelLog, Long> {
+    List<TravelLog> findByWorkspaceIdOrderByTravelDateAsc(Long workspaceId);
+
+    @Query("SELECT t FROM TravelLog t LEFT JOIN FETCH t.photos WHERE t.id = :id")
+    Optional<TravelLog> findByIdWithPhotos(@Param("id") Long id);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
@@ -1,5 +1,6 @@
 package com.sofly.core.domain.travellog.repository;
 
+import com.sofly.core.domain.travellog.dto.TravellogSummaryResponse;
 import com.sofly.core.domain.travellog.entity.TravelLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,15 +11,21 @@ import java.util.Optional;
 
 public interface TravellogRepository extends JpaRepository<TravelLog, Long> {
 
+    /**
+     * photos를 LEFT JOIN FETCH하면 Cartesian Product가 발생하므로,
+     * SIZE() 서브쿼리로 photoCount만 집계하여 DTO로 직접 반환합니다.
+     */
     @Query("""
-            SELECT t FROM TravelLog t
-            LEFT JOIN FETCH t.photos
-            JOIN FETCH t.workspace
-            JOIN FETCH t.author
+            SELECT new com.sofly.core.domain.travellog.dto.TravellogSummaryResponse(
+                t.id, t.day, t.travelDate, t.title, t.weather,
+                SIZE(t.photos),
+                t.createdAt
+            )
+            FROM TravelLog t
             WHERE t.workspace.id = :workspaceId
             ORDER BY t.travelDate ASC
             """)
-    List<TravelLog> findAllByWorkspaceIdWithDetails(@Param("workspaceId") Long workspaceId);
+    List<TravellogSummaryResponse> findAllSummaryByWorkspaceId(@Param("workspaceId") Long workspaceId);
 
     @Query("SELECT t FROM TravelLog t LEFT JOIN FETCH t.photos JOIN FETCH t.workspace JOIN FETCH t.author WHERE t.id = :id")
     Optional<TravelLog> findByIdWithPhotos(@Param("id") Long id);

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/repository/TravellogRepository.java
@@ -9,8 +9,17 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TravellogRepository extends JpaRepository<TravelLog, Long> {
-    List<TravelLog> findByWorkspaceIdOrderByTravelDateAsc(Long workspaceId);
 
-    @Query("SELECT t FROM TravelLog t LEFT JOIN FETCH t.photos WHERE t.id = :id")
+    @Query("""
+            SELECT t FROM TravelLog t
+            LEFT JOIN FETCH t.photos
+            JOIN FETCH t.workspace
+            JOIN FETCH t.author
+            WHERE t.workspace.id = :workspaceId
+            ORDER BY t.travelDate ASC
+            """)
+    List<TravelLog> findAllByWorkspaceIdWithDetails(@Param("workspaceId") Long workspaceId);
+
+    @Query("SELECT t FROM TravelLog t LEFT JOIN FETCH t.photos JOIN FETCH t.workspace JOIN FETCH t.author WHERE t.id = :id")
     Optional<TravelLog> findByIdWithPhotos(@Param("id") Long id);
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
@@ -162,8 +162,14 @@ public class TravellogService {
         TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
                 .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
 
+        Set<Long> existingPhotoIds = travelLog.getPhotos().stream()
+                .map(Photo::getId)
+                .collect(Collectors.toSet());
+
         List<Photo> photos = photoRepository.findAllById(photoIds);
-        photos.forEach(travelLog::addPhoto);
+        photos.stream()
+                .filter(p -> !existingPhotoIds.contains(p.getId()))
+                .forEach(travelLog::addPhoto);
 
         return TravellogResponse.from(travelLog);
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
@@ -49,9 +49,7 @@ public class TravellogService {
 
     @RequireWorkspaceMember
     public List<TravellogSummaryResponse> getTravelLogs(Long workspaceId) {
-        return travellogRepository.findAllByWorkspaceIdWithDetails(workspaceId).stream()
-                .map(TravellogSummaryResponse::from)
-                .toList();
+        return travellogRepository.findAllSummaryByWorkspaceId(workspaceId);
     }
 
     // ── 생성 ─────────────────────────────────────────────────

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
@@ -1,4 +1,144 @@
 package com.sofly.core.domain.travellog.service;
 
+import com.sofly.core.domain.album.dto.PhotoResponse;
+import com.sofly.core.domain.album.entity.Photo;
+import com.sofly.core.domain.album.repository.PhotoRepository;
+import com.sofly.core.domain.album.service.AlbumService;
+import com.sofly.core.domain.travellog.dto.TravellogCreateRequest;
+import com.sofly.core.domain.travellog.dto.TravellogResponse;
+import com.sofly.core.domain.travellog.dto.TravellogUpdateRequest;
+import com.sofly.core.domain.travellog.entity.TravelLog;
+import com.sofly.core.domain.travellog.repository.TravellogRepository;
+import com.sofly.core.domain.user.entity.User;
+import com.sofly.core.domain.user.repository.UserRepository;
+import com.sofly.core.domain.workspace.entity.Workspace;
+import com.sofly.core.domain.workspace.entity.WorkspaceMember;
+import com.sofly.core.domain.workspace.repository.WorkspaceRepository;
+import com.sofly.core.global.exception.ErrorCode;
+import com.sofly.core.global.exception.SoflyException;
+import com.sofly.core.global.security.workspace.RequireWorkspaceMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TravellogService {
+
+    private final TravellogRepository travellogRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final UserRepository userRepository;
+    private final AlbumService albumService;
+    private final PhotoRepository photoRepository;
+
+    // ── 조회 ─────────────────────────────────────────────────
+
+    @RequireWorkspaceMember
+    public TravellogResponse getTravelLog(Long workspaceId, Long logId) {
+        TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
+        return TravellogResponse.from(travelLog);
+    }
+
+    @RequireWorkspaceMember
+    public List<TravellogResponse> getTravelLogs(Long workspaceId) {
+        return travellogRepository.findByWorkspaceIdOrderByTravelDateAsc(workspaceId).stream()
+                .map(TravellogResponse::from)
+                .toList();
+    }
+
+    // ── 생성 ─────────────────────────────────────────────────
+
+    @Transactional
+    @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
+    public TravellogResponse createTravelLog(Long workspaceId, Long userId, TravellogCreateRequest request) {
+        Workspace workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.WORKSPACE_NOT_FOUND));
+        User author = userRepository.findById(userId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.USER_NOT_FOUND));
+
+        TravelLog travelLog = TravelLog.builder()
+                .day(request.day())
+                .travelDate(request.travelDate())
+                .title(request.title())
+                .content(request.content())
+                .weather(request.weather())
+                .workspace(workspace)
+                .author(author)
+                .build();
+
+        return TravellogResponse.from(travellogRepository.save(travelLog));
+    }
+
+    // ── 수정 ─────────────────────────────────────────────────
+
+    @Transactional
+    @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
+    public TravellogResponse updateTravelLog(Long workspaceId, Long logId, TravellogUpdateRequest request) {
+        TravelLog travelLog = travellogRepository.findById(logId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
+
+        travelLog.update(request);
+        return TravellogResponse.from(travelLog);
+    }
+
+    // ── 삭제 ─────────────────────────────────────────────────
+
+    @Transactional
+    @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
+    public void deleteTravelLog(Long workspaceId, Long logId) {
+        travellogRepository.deleteById(logId);
+    }
+
+    // ── 사진 연결 ─────────────────────────────────────────────
+
+    @Transactional
+    @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
+    public TravellogResponse uploadAndAttachPhotos(Long workspaceId, Long userId, Long logId, List<MultipartFile> files) {
+        List<PhotoResponse> photoResponses = albumService.uploadPhotos(workspaceId, userId, files);
+
+        List<Long> photoIds = photoResponses.stream()
+                .map(PhotoResponse::id)
+                .toList();
+
+        return addPhotosToTravelLog(logId, photoIds);
+    }
+
+    @Transactional
+    @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
+    public TravellogResponse attachAlbumPhotos(Long workspaceId, Long logId, List<Long> photoIds) {
+        return addPhotosToTravelLog(logId, photoIds);
+    }
+
+    @Transactional
+    @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
+    public TravellogResponse removePhotos(Long workspaceId, Long logId, List<Long> photoIds) {
+        TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
+
+        List<Photo> photos = photoRepository.findAllById(photoIds);
+
+        if (photos.size() != photoIds.size()) {
+            throw new SoflyException(ErrorCode.PHOTO_NOT_FOUND);
+        }
+
+        photos.forEach(travelLog::removePhoto);
+        return TravellogResponse.from(travelLog);
+    }
+
+    // ── 내부 헬퍼 ─────────────────────────────────────────────
+
+    private TravellogResponse addPhotosToTravelLog(Long logId, List<Long> photoIds) {
+        TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
+
+        List<Photo> photos = photoRepository.findAllById(photoIds);
+        photos.forEach(travelLog::addPhoto);
+
+        return TravellogResponse.from(travelLog);
+    }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
@@ -6,6 +6,7 @@ import com.sofly.core.domain.album.repository.PhotoRepository;
 import com.sofly.core.domain.album.service.AlbumService;
 import com.sofly.core.domain.travellog.dto.TravellogCreateRequest;
 import com.sofly.core.domain.travellog.dto.TravellogResponse;
+import com.sofly.core.domain.travellog.dto.TravellogSummaryResponse;
 import com.sofly.core.domain.travellog.dto.TravellogUpdateRequest;
 import com.sofly.core.domain.travellog.entity.TravelLog;
 import com.sofly.core.domain.travellog.repository.TravellogRepository;
@@ -23,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -45,9 +48,9 @@ public class TravellogService {
     }
 
     @RequireWorkspaceMember
-    public List<TravellogResponse> getTravelLogs(Long workspaceId) {
-        return travellogRepository.findByWorkspaceIdOrderByTravelDateAsc(workspaceId).stream()
-                .map(TravellogResponse::from)
+    public List<TravellogSummaryResponse> getTravelLogs(Long workspaceId) {
+        return travellogRepository.findAllByWorkspaceIdWithDetails(workspaceId).stream()
+                .map(TravellogSummaryResponse::from)
                 .toList();
     }
 
@@ -79,7 +82,7 @@ public class TravellogService {
     @Transactional
     @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
     public TravellogResponse updateTravelLog(Long workspaceId, Long logId, TravellogUpdateRequest request) {
-        TravelLog travelLog = travellogRepository.findById(logId)
+        TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
                 .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
 
         travelLog.update(request);
@@ -91,6 +94,9 @@ public class TravellogService {
     @Transactional
     @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
     public void deleteTravelLog(Long workspaceId, Long logId) {
+        if (!travellogRepository.existsById(logId)) {
+            throw new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND);
+        }
         travellogRepository.deleteById(logId);
     }
 
@@ -120,12 +126,17 @@ public class TravellogService {
         TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
                 .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
 
-        List<Photo> photos = photoRepository.findAllById(photoIds);
+        Set<Long> attachedPhotoIds = travelLog.getPhotos().stream()
+                .map(Photo::getId)
+                .collect(Collectors.toSet());
 
-        if (photos.size() != photoIds.size()) {
-            throw new SoflyException(ErrorCode.PHOTO_NOT_FOUND);
+        for (Long requestedId : photoIds) {
+            if (!attachedPhotoIds.contains(requestedId)) {
+                throw new SoflyException(ErrorCode.PHOTO_NOT_FOUND);
+            }
         }
 
+        List<Photo> photos = photoRepository.findAllById(photoIds);
         photos.forEach(travelLog::removePhoto);
         return TravellogResponse.from(travelLog);
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
@@ -128,6 +128,10 @@ public class TravellogService {
     @Transactional
     @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
     public TravellogResponse attachAlbumPhotos(Long workspaceId, Long logId, List<Long> photoIds) {
+        long validCount = photoRepository.countByIdsAndWorkspaceId(photoIds, workspaceId);
+        if (validCount != photoIds.size()) {
+            throw new SoflyException(ErrorCode.PHOTO_NOT_FOUND);
+        }
         return addPhotosToTravelLog(logId, photoIds);
     }
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/travellog/service/TravellogService.java
@@ -44,6 +44,11 @@ public class TravellogService {
     public TravellogResponse getTravelLog(Long workspaceId, Long logId) {
         TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
                 .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
+
+        if (!travelLog.getWorkspace().getId().equals(workspaceId)) {
+            throw new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND);
+        }
+
         return TravellogResponse.from(travelLog);
     }
 
@@ -83,6 +88,10 @@ public class TravellogService {
         TravelLog travelLog = travellogRepository.findByIdWithPhotos(logId)
                 .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
 
+        if (!travelLog.getWorkspace().getId().equals(workspaceId)) {
+            throw new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND);
+        }
+
         travelLog.update(request);
         return TravellogResponse.from(travelLog);
     }
@@ -92,10 +101,14 @@ public class TravellogService {
     @Transactional
     @RequireWorkspaceMember(minRole = WorkspaceMember.MemberRole.EDITOR)
     public void deleteTravelLog(Long workspaceId, Long logId) {
-        if (!travellogRepository.existsById(logId)) {
+        TravelLog travelLog = travellogRepository.findById(logId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND));
+
+        if (!travelLog.getWorkspace().getId().equals(workspaceId)) {
             throw new SoflyException(ErrorCode.TRAVEL_LOG_NOT_FOUND);
         }
-        travellogRepository.deleteById(logId);
+
+        travellogRepository.delete(travelLog);
     }
 
     // ── 사진 연결 ─────────────────────────────────────────────

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SwaggerConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SwaggerConfig.java
@@ -51,7 +51,8 @@ public class SwaggerConfig {
                 new Tag().name("Chat Message").description("AI 채팅 메시지 전송·조회 API"),
                 new Tag().name("Album").description("워크스페이스 앨범 조회 API"),
                 new Tag().name("Album Photo").description("앨범 사진 업로드·삭제·다운로드 API"),
-                new Tag().name("TravelLog").description("여행기 API")
+                new Tag().name("TravelLog").description("여행 기록 API"),
+                new Tag().name("TravelLog Photo").description("여행 기록 사진 첨부·해제 API")
         ));
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/workspace/RequireWorkspaceMember.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/workspace/RequireWorkspaceMember.java
@@ -1,0 +1,14 @@
+package com.sofly.core.global.security.workspace;
+
+import com.sofly.core.domain.workspace.entity.WorkspaceMember.MemberRole;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireWorkspaceMember {
+    MemberRole minRole() default MemberRole.VIEWER;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/workspace/WorkspaceMemberAspect.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/workspace/WorkspaceMemberAspect.java
@@ -15,6 +15,12 @@ import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Parameter;
 
+/**
+ * {@link RequireWorkspaceMember} 애노테이션이 붙은 메서드에 대해 워크스페이스 멤버 권한을 검증하는 Aspect.
+ *
+ * <p><b>주의:</b> 적용 대상 메서드는 반드시 {@code workspaceId}라는 이름의 {@code Long} 파라미터를 포함해야 합니다.
+ * 해당 파라미터가 없으면 런타임에 {@link IllegalStateException}이 발생합니다.
+ */
 @Aspect
 @Component
 @RequiredArgsConstructor

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/workspace/WorkspaceMemberAspect.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/workspace/WorkspaceMemberAspect.java
@@ -1,0 +1,60 @@
+package com.sofly.core.global.security.workspace;
+
+import com.sofly.core.domain.workspace.entity.WorkspaceMember;
+import com.sofly.core.domain.workspace.entity.WorkspaceMember.MemberRole;
+import com.sofly.core.domain.workspace.repository.WorkspaceMemberRepository;
+import com.sofly.core.global.exception.ErrorCode;
+import com.sofly.core.global.exception.SoflyException;
+import com.sofly.core.global.security.util.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Parameter;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class WorkspaceMemberAspect {
+
+    private final WorkspaceMemberRepository workspaceMemberRepository;
+
+    @Before("@annotation(require)")
+    public void checkWorkspaceMembership(JoinPoint jp, RequireWorkspaceMember require) {
+        Long workspaceId = extractWorkspaceId(jp);
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        WorkspaceMember member = workspaceMemberRepository
+                .findByWorkspaceIdAndUserId(workspaceId, userId)
+                .orElseThrow(() -> new SoflyException(ErrorCode.WORKSPACE_ACCESS_DENIED));
+
+        if (require.minRole() != MemberRole.VIEWER && !hasRequiredRole(member.getRole(), require.minRole())) {
+            throw new SoflyException(ErrorCode.WORKSPACE_ACCESS_DENIED);
+        }
+    }
+
+    private Long extractWorkspaceId(JoinPoint jp) {
+        MethodSignature signature = (MethodSignature) jp.getSignature();
+        Parameter[] parameters = signature.getMethod().getParameters();
+        Object[] args = jp.getArgs();
+
+        for (int i = 0; i < parameters.length; i++) {
+            if ("workspaceId".equals(parameters[i].getName())) {
+                return (Long) args[i];
+            }
+        }
+
+        throw new IllegalStateException(
+                "@RequireWorkspaceMember가 붙은 메서드에 'workspaceId' 파라미터가 없습니다: "
+                + signature.getMethod().getName()
+        );
+    }
+
+    /** minRole 이상인지 확인 — enum 선언 순서: OWNER(0) > EDITOR(1) > VIEWER(2) */
+    private boolean hasRequiredRole(MemberRole actual, MemberRole required) {
+        return actual.ordinal() <= required.ordinal();
+    }
+}

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -27,7 +27,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: false
     properties:
       hibernate:

--- a/services/travel-core-service/src/main/resources/application-core.yaml
+++ b/services/travel-core-service/src/main/resources/application-core.yaml
@@ -6,6 +6,11 @@ spring:
   application:
     name: travel-core-service
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
+
   ai:
     google:
       genai:


### PR DESCRIPTION
## 📌 PR 요약

여행 후기를 작성하고 사진을 첨부할 수 있는 **TravelLog(여행기) 도메인 전체를 구현**합니다. 도메인 레이어(엔티티·리포지토리), 서비스 레이어, REST 컨트롤러를 순차적으로 추가하고 코드 리뷰 지적 사항을 반영했습니다.

## 🔧 변경 사항

**TravelLog 엔티티 재설계**
- 기존 초안 엔티티에 `day`, `travelDate`, `weather`, `photos`(ManyToMany) 필드를 추가하고, `coverImageUrl`·`visibility` 필드를 정리했습니다.
- `Weather` enum(SUNNY / CLOUDY / RAINY / SNOWY) 추가, Visibility 기능은 TODO로 남겨 두었습니다.
- Photo 연결을 위한 조인 테이블 `travel_log_photos` 정의, `addPhoto` / `removePhoto` 비즈니스 메서드 추가

**리포지토리**
- `findAllByWorkspaceIdWithDetails` — 워크스페이스 내 전체 여행기를 `travelDate` 오름차순으로 Fetch Join 조회.
- `findByIdWithPhotos` — 단건 조회 시 photos, workspace, author를 한 번에 Fetch Join.

**서비스**
- 워크스페이스 멤버 접근 제어(`@RequireWorkspaceMember`)를 적용한 CRUD 메서드.
- 사진 연결 흐름: ① S3 신규 업로드 후 첨부, ② 기존 앨범 사진 ID로 첨부, ③ 첨부 해제(앨범 사진은 삭제 안 함).
- 부분 수정(PATCH) — null 필드는 기존 값 유지.

**컨트롤러**
- `TravellogController`: 목록 조회, 단건 조회, 생성, 부분 수정, 삭제 API (`/api/workspaces/{workspaceId}/travellogs`).
- `TravellogPhotoController`: 신규 업로드·앨범 첨부·첨부 해제 API (`/api/workspaces/{workspaceId}/travellogs/{logId}/photos`).

**기타 수정 사항**
- `PhotoResponse`의 중복 `getId()` 메서드 제거.
- 파일 업로드 크기 제한 명시.
- Swagger 태그·순서 관련 설정 수정.

## 📋 작업 상세 내용

- [x] `TravelLog` 엔티티 재설계 (weather, travelDate, day, photos 필드 추가)
- [x] `TravellogRepository` 구현 (Fetch Join 쿼리 2종)
- [x] Request/Response DTO 구현 (`Create`, `Update`, `Response`, `SummaryResponse`, `PhotoLinkRequest`)
- [x] `TravellogService` 구현 (CRUD + 사진 연결·해제)
- [x] `TravellogController` / `TravellogPhotoController` 구현
- [x] 코드 리뷰 지적 사항 반영 (PhotoResponse 중복 메서드 제거, 접근 제어 수정 등)
- [x] Swagger 문서 정비

## 🔗 관련 이슈

closed #49

## 📝 기타

- `Visibility`(공개 범위) 기능은 정책 미결정으로 엔티티 내 주석 처리 후 TODO로 남겨 두었습니다. 추후 별도 이슈로 구현 예정입니다.
- 수정/삭제 권한 정책(작성자 본인 vs EDITOR 이상)도 TODO 주석으로 표시했습니다. 팀 내 결정 후 반영 부탁드립니다.
- `@RequireWorkspaceMember` AOP 어노테이션이 서비스 레이어에 적용되어 있으므로, 워크스페이스 멤버가 아닌 사용자는 모든 여행기 API 접근 시 403이 반환됩니다.