### PR TITLE
Feat/57 add CORS configuration for frontend integration

### DIFF
--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.sofly.core.global.security;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,6 +10,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.sofly.core.global.auth.exception.code.AuthErrorCode;
 import com.sofly.core.global.security.jwt.JwtAuthenticationFilter;
@@ -73,10 +78,28 @@ public class SecurityConfig {
 
     }
 
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(
+                "http://localhost:5173",
+                "http://127.0.0.1:5173",
+                "https://sofly.co.kr"
+                // 운영 프론트 도메인 확정 후 추가
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("Authorization", "Refresh-Token", "Content-Type", "Accept", "Origin", "X-Requested-With"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
     private void configureCommonSecurity(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                // .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session


### PR DESCRIPTION
## 📌 PR 요약
프론트엔드 서버 연동을 위한 CORS 설정을 추가합니다.

## 🔧 변경 사항
- 프론트엔드 서버(`localhost:5173`, `sofly.co.kr`)가 백엔드 API를 호출할 수 있도록 CORS 설정이 필요합니다.
- 기존에 주석 처리되어 있던 CORS 설정을 활성화하고 `corsConfigurationSource` Bean을 추가합니다.

## 📋 작업 상세 내용
- [x] `SecurityConfig`에 `corsConfigurationSource` Bean 추가
- [x] `configureCommonSecurity`에서 `.cors()` 주석 해제 및 적용
- [x] 허용 Origin 설정 (`localhost:5173`, `127.0.0.1:5173`, `sofly.co.kr`)
- [x] 허용 메서드 설정 (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`)
- [x] 허용 헤더 설정 (`Authorization`, `Content-Type` 등)

## 🔗 관련 이슈
- closed #57

## 📝 기타
- 운영 프론트 도메인(`sofly.co.kr`) 변경 시 `setAllowedOrigins`에 추가 필요합니다.
- `setAllowCredentials(true)` 설정은 현재 JWT 헤더 방식이라 필수는 아니지만 추후 쿠키 방식 전환을 고려해 포함했습니다.