### PR TITLE
fix: core → supply 서비스 간 Docker 네트워크 호출 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,9 @@ services:
       SPRING_DATA_REDIS_HOST: ${REDIS_HOST:-sofly-redis}
       SPRING_DATA_REDIS_PORT: ${REDIS_PORT:-6379}
     networks:
-      - sofly-net
+      sofly-net:
+        aliases:
+          - supply
     restart: unless-stopped
     healthcheck:
       # test: ["CMD-SHELL", "wget -qO- http://localhost:8081/actuator/health || exit 1"]


### PR DESCRIPTION
## 📌 PR 요약
- `sofly-net` external 네트워크 환경에서 core 서비스가 supply를 `http://supply:8081`로 호출할 수 없는 문제를 수정합니다.

## 🔧 변경 사항
- `docker-compose.yml`의 supply 서비스에 네트워크 alias `supply`를 추가했습니다.
- `sofly-net`은 `external: true`로 선언된 외부 네트워크이기 때문에 Docker DNS가 컨테이너명(`supply-blue`) 기준으로만 hostname을 해석합니다. compose 서비스명 `supply`로는 resolve되지 않아 core의 Feign 호출이 실패하는 문제가 있었습니다.
- alias를 추가하면 `supply-blue` 컨테이너가 `supply`라는 이름으로도 동일 네트워크 내에서 resolve됩니다.

## 📋 작업 상세 내용
- [x] supply 서비스 `networks` 블록에 `aliases: [supply]` 추가

## 🔗 관련 이슈
- closed #66

## 📝 기타
- core의 `application-core.yaml`에서 `sofly.supply.url: http://supply:8081` 기본값은 그대로 유효합니다.