### PR TITLE
fix(core): AI 채팅 오류 처리 및 안정성 개선

### DIFF
--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/chat/controller/ChatMessageController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/chat/controller/ChatMessageController.java
@@ -78,6 +78,7 @@ public class ChatMessageController {
         chatService.chatStream(roomId, request)
                 .subscribe(
                         chunk -> {
+                            if (chunk == null) return;
                             try {
                                 emitter.send(SseEmitter.event().data(chunk));
                                 collector.append(chunk);

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/chat/controller/ChatMessageController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/chat/controller/ChatMessageController.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
 
 import java.io.IOException;
 import java.util.concurrent.Executors;
@@ -42,12 +43,14 @@ public class ChatMessageController {
     }
 
     @Operation(summary = "메시지 전송", description = "ChatRoom에 메시지를 보내고 AI 응답을 받습니다.")
-    @PostMapping("/{roomId}")
+    @PostMapping(value = "/{roomId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ChatResponse> chat(
             @PathVariable Long roomId,
             @RequestBody @Valid ChatRequest request
     ) {
-        return ResponseEntity.ok(chatService.chat(roomId, request));
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(chatService.chat(roomId, request));
     }
 
     @Operation(
@@ -73,9 +76,18 @@ public class ChatMessageController {
         }, 15, 15, TimeUnit.SECONDS);
 
         emitter.onCompletion(() -> heartbeat.cancel(true));
+        emitter.onTimeout(() -> heartbeat.cancel(true));
         emitter.onError(t -> heartbeat.cancel(true));
 
-        chatService.chatStream(roomId, request)
+        Flux<String> stream;
+        try {
+            stream = chatService.chatStream(roomId, request);
+        } catch (Exception e) {
+            sendStreamError(emitter, heartbeat, e);
+            return emitter;
+        }
+
+        stream
                 .subscribe(
                         chunk -> {
                             if (chunk == null) return;
@@ -87,18 +99,27 @@ public class ChatMessageController {
                             }
                         },
                         error -> {
-                            try {
-                                emitter.send(SseEmitter.event().name("error").data(error.getMessage()));
-                            } catch (IOException ignored) {}
-                            emitter.completeWithError(error);
+                            sendStreamError(emitter, heartbeat, error);
                         },
                         () -> {
+                            heartbeat.cancel(true);
                             chatService.finalizeStream(roomId, collector.toString());
                             emitter.complete();
                         }
                 );
 
         return emitter;
+    }
+
+    private void sendStreamError(SseEmitter emitter, ScheduledFuture<?> heartbeat, Throwable error) {
+        heartbeat.cancel(true);
+        try {
+            String message = error.getMessage() != null ? error.getMessage() : error.getClass().getSimpleName();
+            emitter.send(SseEmitter.event().name("error").data(message));
+        } catch (IOException ignored) {
+            // Client disconnected or response is already closed.
+        }
+        emitter.complete();
     }
 
     @Operation(

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/place/service/PlaceService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/place/service/PlaceService.java
@@ -9,6 +9,8 @@ import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PlaceService {
@@ -17,7 +19,7 @@ public class PlaceService {
 
     public PlacesResponse searchPlaces(String text) {
         try {
-            return supplyClient.searchPlace(text);
+            return normalizePlacesResponse(supplyClient.searchPlace(text));
         } catch (FeignException e) {
             throw new SoflyException(ErrorCode.SUPPLY_SERVICE_ERROR, e.getMessage());
         }
@@ -29,5 +31,12 @@ public class PlaceService {
         } catch (FeignException e) {
             throw new SoflyException(ErrorCode.SUPPLY_SERVICE_ERROR, e.getMessage());
         }
+    }
+
+    private PlacesResponse normalizePlacesResponse(PlacesResponse response) {
+        if (response == null || response.places() == null) {
+            return new PlacesResponse(List.of());
+        }
+        return response;
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/ai/memory/RdbChatMemory.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/ai/memory/RdbChatMemory.java
@@ -15,6 +15,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -81,11 +82,11 @@ public class RdbChatMemory implements ChatMemory {
                 .getContent();
         Collections.reverse(dbMessages);
 
-        List<Message> messages = dbMessages.stream()
+        List<Message> messages = new ArrayList<>(dbMessages.stream()
                 .map(m -> m.getRole() == ChatMessage.Role.USER
                         ? (Message) new UserMessage(m.getContent())
                         : (Message) new AssistantMessage(m.getContent()))
-                .toList();
+                .toList());
 
         try {
             redisTemplate.opsForValue().set(cacheKey, messages, TTL);

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/ai/memory/RdbChatMemory.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/ai/memory/RdbChatMemory.java
@@ -10,9 +10,9 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -36,50 +36,45 @@ public class RdbChatMemory implements ChatMemory {
         Long chatRoomId = parseRoomId(conversationId);
 
         List<ChatMessage> chatMessages = messages.stream()
-                .map(message -> {
-                    ChatMessage.Role role = message.getMessageType() == MessageType.USER
-                            ? ChatMessage.Role.USER
-                            : ChatMessage.Role.ASSISTANT;
-
-                    return ChatMessage.builder()
-                            .chatRoomId(chatRoomId)
-                            .role(role)
-                            .content(message.getText())
-                            .build();
-                })
+                .filter(this::isPersistableMessage)
+                .map(message -> ChatMessage.builder()
+                        .chatRoomId(chatRoomId)
+                        .role(toChatRole(message.getMessageType()))
+                        .content(textOf(message))
+                        .build())
                 .toList();
 
-        chatMessageRepository.saveAll(chatMessages);
-
-        try{
-            //redisTemplate.delete()가 실패했을 때 예외가 터지면 저장은 됐는데 캐시 삭제가 안 되는 상황 때문
-            redisTemplate.delete(CACHE_PREFIX + conversationId);
+        if (!chatMessages.isEmpty()) {
+            chatMessageRepository.saveAll(chatMessages);
         }
-        catch(Exception e){
+
+        try {
+            // redisTemplate.delete()가 실패했을 때 예외가 터지면 저장은 됐는데 캐시 삭제가 안 되는 상황 때문
+            redisTemplate.delete(CACHE_PREFIX + conversationId);
+        } catch (Exception e) {
             log.warn("Redis 캐시 삭제 실패 - chatRoomId: {}", chatRoomId);
         }
         log.debug("ChatMemory saved - chatRoomId: {}", chatRoomId);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public List<Message> get(String conversationId) {
         String cacheKey = CACHE_PREFIX + conversationId;
         Long chatRoomId = parseRoomId(conversationId);
 
         try {
-            List<Message> cached = (List<Message>) redisTemplate.opsForValue().get(cacheKey);
+            ChatMemoryCache cached = (ChatMemoryCache) redisTemplate.opsForValue().get(cacheKey);
             if (cached != null) {
                 log.debug("ChatMemory cache hit - chatRoomId: {}", chatRoomId);
-                return cached;
+                return cached.toMessages();
             }
-        } catch (RedisSystemException e) {
+        } catch (Exception e) {
             log.warn("Redis 조회 실패, DB로 fallback - chatRoomId: {}", chatRoomId, e);
         }
 
-        List<ChatMessage> dbMessages = chatMessageRepository
+        List<ChatMessage> dbMessages = new ArrayList<>(chatMessageRepository
                 .findByChatRoomIdOrderByCreatedAtDesc(chatRoomId, PageRequest.of(0, WINDOW_SIZE))
-                .getContent();
+                .getContent());
         Collections.reverse(dbMessages);
 
         List<Message> messages = new ArrayList<>(dbMessages.stream()
@@ -89,7 +84,7 @@ public class RdbChatMemory implements ChatMemory {
                 .toList());
 
         try {
-            redisTemplate.opsForValue().set(cacheKey, messages, TTL);
+            redisTemplate.opsForValue().set(cacheKey, ChatMemoryCache.from(messages), TTL);
         } catch (Exception e) {
             log.warn("Redis 저장 실패 - chatRoomId: {}", chatRoomId);
         }
@@ -108,5 +103,49 @@ public class RdbChatMemory implements ChatMemory {
     // "room:1" → 1L
     private Long parseRoomId(String conversationId) {
         return Long.parseLong(conversationId.replace("room:", ""));
+    }
+
+    private boolean isPersistableMessage(Message message) {
+        return (message.getMessageType() == MessageType.USER || message.getMessageType() == MessageType.ASSISTANT)
+                && StringUtils.hasText(textOf(message));
+    }
+
+    private ChatMessage.Role toChatRole(MessageType messageType) {
+        return messageType == MessageType.USER ? ChatMessage.Role.USER : ChatMessage.Role.ASSISTANT;
+    }
+
+    private record ChatMemoryCache(List<ChatMemoryItem> messages) {
+
+        static ChatMemoryCache from(List<Message> messages) {
+            return new ChatMemoryCache(messages.stream()
+                    .filter(message -> message.getMessageType() == MessageType.USER
+                            || message.getMessageType() == MessageType.ASSISTANT)
+                    .filter(message -> StringUtils.hasText(textOf(message)))
+                    .map(message -> new ChatMemoryItem(message.getMessageType(), textOf(message)))
+                    .toList());
+        }
+
+        List<Message> toMessages() {
+            return messages.stream()
+                    .map(ChatMemoryItem::toMessage)
+                    .toList();
+        }
+    }
+
+    private record ChatMemoryItem(MessageType type, String content) {
+
+        Message toMessage() {
+            return type == MessageType.USER
+                    ? new UserMessage(content)
+                    : new AssistantMessage(content);
+        }
+    }
+
+    private static String textOf(Message message) {
+        try {
+            return message.getText();
+        } catch (UnsupportedOperationException e) {
+            return null;
+        }
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/ai/memory/RdbChatMemory.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/ai/memory/RdbChatMemory.java
@@ -126,9 +126,9 @@ public class RdbChatMemory implements ChatMemory {
         }
 
         List<Message> toMessages() {
-            return messages.stream()
+            return new ArrayList<>(messages.stream()
                     .map(ChatMemoryItem::toMessage)
-                    .toList();
+                    .toList());
         }
     }
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/ai/tools/PlaceVerificationTools.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/ai/tools/PlaceVerificationTools.java
@@ -3,10 +3,12 @@ package com.sofly.core.global.ai.tools;
 import com.sofly.core.global.client.SupplyClient;
 import com.sofly.core.global.client.dto.PlacesResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PlaceVerificationTools {
@@ -18,11 +20,13 @@ public class PlaceVerificationTools {
             @ToolParam(description = "검색할 장소명 (예: '경복궁', 'Eiffel Tower')") String placeName
     ) {
         try {
+            log.info("verifyPlace tool called - placeName={}", placeName);
             PlacesResponse response = supplyClient.searchPlace(placeName);
             if (response.places() == null || response.places().isEmpty()) {
                 return "'" + placeName + "'에 해당하는 장소를 찾을 수 없습니다.";
             }
             PlacesResponse.Place place = response.places().get(0);
+            log.info("verifyPlace tool resolved - placeName={}, resolvedName={}", placeName, place.displayName().text());
             return String.format("장소 확인됨: %s | 주소: %s | 유형: %s | 평점: %s",
                     place.displayName().text(),
                     place.formattedAddress(),
@@ -30,6 +34,7 @@ public class PlaceVerificationTools {
                     place.rating() != null ? place.rating() : "없음"
             );
         } catch (Exception e) {
+            log.warn("verifyPlace tool failed - placeName={}", placeName, e);
             return "장소 확인 서비스에 일시적인 오류가 발생했습니다. 장소명: " + placeName;
         }
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthErrorCode.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/auth/exception/code/AuthErrorCode.java
@@ -20,7 +20,8 @@ public enum AuthErrorCode implements BaseErrorCode {
     // 회원가입 시 중복된 아이디가 있을 경우
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "DUPLICATE_LOGIN_ID", "이미 존재하는 아이디입니다."),
     EMPTY_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "EMPTY_AUTHENTICATION", "인증 정보가 존재하지 않습니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 사용자를 찾지 못했습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "해당 사용자를 찾지 못했습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "접근 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/client/SupplyClient.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/client/SupplyClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@FeignClient(name = "supply-service", url = "${sofly.supply.url}")
+@FeignClient(name = "supply-service", url = "${sofly.supply.url:http://supply:8081}")
 public interface SupplyClient {
 
     // ── 항공권 ──────────────────────────────────────────────────────────

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.sofly.core.global.exception;
 
 import java.util.stream.Collectors;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -27,6 +28,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(ApiResponse.fail(errorCode.getMessage()));
     }
 
@@ -37,6 +39,7 @@ public class GlobalExceptionHandler {
         BaseErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(ApiResponse.fail(errorCode.getMessage()));
     }
 
@@ -46,6 +49,7 @@ public class GlobalExceptionHandler {
         BaseErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(ApiResponse.fail(errorCode.getMessage()));
     }
 
@@ -55,6 +59,7 @@ public class GlobalExceptionHandler {
         BaseErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(ApiResponse.fail(errorCode.getMessage()));
     }
 
@@ -68,6 +73,7 @@ public class GlobalExceptionHandler {
         log.warn("Validation 실패: {}", message);
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getStatus())
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(ApiResponse.fail(message));
     }
 
@@ -77,6 +83,7 @@ public class GlobalExceptionHandler {
         log.error("Unexpected error: ", e);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
                         "/",
+                        "/error",
                         "/index.html",
                         "/user-profile-test.html",
                         "/conquest-test.html",

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sofly.core.global.security;
 
 import java.util.List;
 
+import jakarta.servlet.DispatcherType;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -41,6 +42,7 @@ public class SecurityConfig {
         http
             // 요청 권한 설정
             .authorizeHttpRequests(auth -> auth
+                .dispatcherTypeMatchers(DispatcherType.ERROR, DispatcherType.ASYNC).permitAll()
                 .requestMatchers(
                         "/",
                         "/error",
@@ -69,10 +71,13 @@ public class SecurityConfig {
                         new JwtAuthenticationFilter(jwtTokenProvider, filterResponseUtils),
                         UsernamePasswordAuthenticationFilter.class
                 )
-                // 토큰 없이 authenticated() 경로 접근 시 401
+                // 토큰 없이 authenticated() 경로 접근 시 401, 권한 없는 경우 403
                 .exceptionHandling(ex -> ex
                     .authenticationEntryPoint((request, response, authException) -> {
-                        filterResponseUtils.sendUnauthorized(response,AuthErrorCode.EMPTY_AUTHENTICATION);
+                        filterResponseUtils.sendUnauthorized(response, AuthErrorCode.EMPTY_AUTHENTICATION);
+                    })
+                    .accessDeniedHandler((request, response, accessDeniedException) -> {
+                        filterResponseUtils.sendUnauthorized(response, AuthErrorCode.ACCESS_DENIED);
                     })
                 );
 

--- a/services/travel-core-service/src/test/java/com/sofly/core/domain/place/controller/PlaceControllerTest.java
+++ b/services/travel-core-service/src/test/java/com/sofly/core/domain/place/controller/PlaceControllerTest.java
@@ -1,0 +1,66 @@
+package com.sofly.core.domain.place.controller;
+
+import com.sofly.core.domain.place.service.PlaceService;
+import com.sofly.core.global.client.dto.PlacesResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PlaceControllerTest {
+
+    private final PlaceService placeService = mock(PlaceService.class);
+    private final MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new PlaceController(placeService))
+            .build();
+
+    @Test
+    @DisplayName("GET /api/v1/places는 ApiResponse 안에 places 배열을 반환한다")
+    void searchPlaces_returnsWrappedPlacesArray() throws Exception {
+        given(placeService.searchPlaces("경복궁"))
+                .willReturn(new PlacesResponse(List.of(new PlacesResponse.Place(
+                        "place-id",
+                        new PlacesResponse.DisplayName("경복궁", "ko"),
+                        "tourist_attraction",
+                        "서울특별시 종로구 사직로 161",
+                        new PlacesResponse.Location(37.5796, 126.9770),
+                        4.6,
+                        50000,
+                        null,
+                        null,
+                        null,
+                        "https://maps.google.com/?cid=1",
+                        "OPERATIONAL",
+                        null,
+                        List.of()
+                ))));
+
+        mockMvc.perform(get("/api/v1/places").param("text", "경복궁"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.places", hasSize(1)))
+                .andExpect(jsonPath("$.data.places[0].displayName.text").value("경복궁"))
+                .andExpect(jsonPath("$.data.places[0].formattedAddress").value("서울특별시 종로구 사직로 161"));
+    }
+
+    @Test
+    @DisplayName("검색 결과가 없어도 data.places는 빈 배열로 반환한다")
+    void searchPlaces_returnsEmptyPlacesArray() throws Exception {
+        given(placeService.searchPlaces("없는장소"))
+                .willReturn(new PlacesResponse(List.of()));
+
+        mockMvc.perform(get("/api/v1/places").param("text", "없는장소"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.places", hasSize(0)));
+    }
+}

--- a/services/travel-core-service/src/test/java/com/sofly/core/domain/place/service/PlaceServiceTest.java
+++ b/services/travel-core-service/src/test/java/com/sofly/core/domain/place/service/PlaceServiceTest.java
@@ -1,0 +1,87 @@
+package com.sofly.core.domain.place.service;
+
+import com.sofly.core.global.client.SupplyClient;
+import com.sofly.core.global.client.dto.PlacesResponse;
+import com.sofly.core.global.exception.ErrorCode;
+import com.sofly.core.global.exception.SoflyException;
+import feign.FeignException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceServiceTest {
+
+    @Mock
+    SupplyClient supplyClient;
+
+    @InjectMocks
+    PlaceService placeService;
+
+    @Test
+    @DisplayName("장소 검색 응답을 그대로 반환한다")
+    void searchPlaces_returnsSupplyResponse() {
+        PlacesResponse response = new PlacesResponse(List.of(new PlacesResponse.Place(
+                "place-id",
+                new PlacesResponse.DisplayName("경복궁", "ko"),
+                "tourist_attraction",
+                "서울특별시 종로구 사직로 161",
+                new PlacesResponse.Location(37.5796, 126.9770),
+                4.6,
+                50000,
+                null,
+                null,
+                null,
+                "https://maps.google.com/?cid=1",
+                "OPERATIONAL",
+                null,
+                List.of()
+        )));
+        given(supplyClient.searchPlace("경복궁")).willReturn(response);
+
+        PlacesResponse result = placeService.searchPlaces("경복궁");
+
+        assertThat(result.places()).hasSize(1);
+        assertThat(result.places().getFirst().displayName().text()).isEqualTo("경복궁");
+    }
+
+    @Test
+    @DisplayName("supply가 null을 반환해도 빈 places 배열로 정규화한다")
+    void searchPlaces_normalizesNullResponse() {
+        given(supplyClient.searchPlace("없는장소")).willReturn(null);
+
+        PlacesResponse result = placeService.searchPlaces("없는장소");
+
+        assertThat(result.places()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("supply가 places null을 반환해도 빈 places 배열로 정규화한다")
+    void searchPlaces_normalizesNullPlaces() {
+        given(supplyClient.searchPlace("없는장소")).willReturn(new PlacesResponse(null));
+
+        PlacesResponse result = placeService.searchPlaces("없는장소");
+
+        assertThat(result.places()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("supply Feign 오류는 SUPPLY_SERVICE_ERROR로 변환한다")
+    void searchPlaces_wrapsFeignException() {
+        given(supplyClient.searchPlace("경복궁")).willThrow(FeignException.ServiceUnavailable.class);
+
+        assertThatThrownBy(() -> placeService.searchPlaces("경복궁"))
+                .isInstanceOf(SoflyException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SUPPLY_SERVICE_ERROR);
+    }
+}

--- a/services/travel-core-service/src/test/java/com/sofly/core/global/ai/memory/RdbChatMemoryTest.java
+++ b/services/travel-core-service/src/test/java/com/sofly/core/global/ai/memory/RdbChatMemoryTest.java
@@ -1,0 +1,122 @@
+package com.sofly.core.global.ai.memory;
+
+import com.sofly.core.domain.chat.entity.ChatMessage;
+import com.sofly.core.domain.chat.repository.ChatMessageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RdbChatMemoryTest {
+
+    @Mock
+    ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    ValueOperations<String, Object> valueOperations;
+
+    @Test
+    @DisplayName("USER/ASSISTANT 메시지만 DB에 저장하고 Redis 캐시를 무효화한다")
+    @SuppressWarnings("unchecked")
+    void add_persistsOnlyUserAndAssistantMessages() {
+        RdbChatMemory memory = new RdbChatMemory(chatMessageRepository, redisTemplate);
+        ArgumentCaptor<List<ChatMessage>> captor = ArgumentCaptor.forClass(List.class);
+
+        memory.add("room:7", List.of(
+                new SystemMessage("system prompt"),
+                new UserMessage("사용자 질문"),
+                new AssistantMessage("AI 답변")
+        ));
+
+        verify(chatMessageRepository).saveAll(captor.capture());
+        verify(redisTemplate).delete("chat:memory:room:7");
+
+        List<ChatMessage> saved = captor.getValue();
+        assertThat(saved).hasSize(2);
+        assertThat(saved).extracting(ChatMessage::getChatRoomId).containsOnly(7L);
+        assertThat(saved).extracting(ChatMessage::getRole)
+                .containsExactly(ChatMessage.Role.USER, ChatMessage.Role.ASSISTANT);
+        assertThat(saved).extracting(ChatMessage::getContent)
+                .containsExactly("사용자 질문", "AI 답변");
+    }
+
+    @Test
+    @DisplayName("저장 가능한 메시지가 없으면 DB 저장 없이 캐시만 무효화한다")
+    void add_skipsEmptyPersistableMessages() {
+        RdbChatMemory memory = new RdbChatMemory(chatMessageRepository, redisTemplate);
+
+        memory.add("room:7", List.of(new SystemMessage("system prompt")));
+
+        verifyNoInteractions(chatMessageRepository);
+        verify(redisTemplate).delete("chat:memory:room:7");
+    }
+
+    @Test
+    @DisplayName("텍스트를 제공하지 않는 ASSISTANT 메시지는 저장하지 않는다")
+    void add_skipsAssistantMessageWithoutText() {
+        RdbChatMemory memory = new RdbChatMemory(chatMessageRepository, redisTemplate);
+        Message message = mock(Message.class);
+        given(message.getMessageType()).willReturn(org.springframework.ai.chat.messages.MessageType.ASSISTANT);
+        willThrow(new UnsupportedOperationException()).given(message).getText();
+
+        memory.add("room:7", List.of(message));
+
+        verifyNoInteractions(chatMessageRepository);
+        verify(redisTemplate).delete("chat:memory:room:7");
+    }
+
+    @Test
+    @DisplayName("Redis miss면 DB 최근 메시지를 오래된 순서로 복원하고 캐시한다")
+    void get_loadsFromDbAndCachesOnRedisMiss() {
+        RdbChatMemory memory = new RdbChatMemory(chatMessageRepository, redisTemplate);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("chat:memory:room:7")).willReturn(null);
+        given(chatMessageRepository.findByChatRoomIdOrderByCreatedAtDesc(eq(7L), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(
+                        chatMessage(ChatMessage.Role.ASSISTANT, "두 번째"),
+                        chatMessage(ChatMessage.Role.USER, "첫 번째")
+                )));
+
+        List<Message> messages = memory.get("room:7");
+
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(messages.get(0).getText()).isEqualTo("첫 번째");
+        assertThat(messages.get(1)).isInstanceOf(AssistantMessage.class);
+        assertThat(messages.get(1).getText()).isEqualTo("두 번째");
+        verify(valueOperations).set(eq("chat:memory:room:7"), any(), any());
+    }
+
+    private ChatMessage chatMessage(ChatMessage.Role role, String content) {
+        return ChatMessage.builder()
+                .chatRoomId(7L)
+                .role(role)
+                .content(content)
+                .build();
+    }
+}

--- a/services/travel-supply-service/src/test/java/com/sofly/supply/GooglePlacesTest.java
+++ b/services/travel-supply-service/src/test/java/com/sofly/supply/GooglePlacesTest.java
@@ -1,19 +1,58 @@
 package com.sofly.supply;
 
 import com.sofly.supply.adapter.outbound.google.GooglePlacesClient;
-import com.sofly.supply.adapter.outbound.google.PlaceInfo;
+import com.sofly.supply.adapter.outbound.google.GooglePlacesProperties;
+import com.sofly.supply.application.dto.PlacesResponse;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
 
-@SpringBootTest
-public class GooglePlacesTest {
-    @Autowired
-    private GooglePlacesClient googlePlacesClient;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GooglePlacesTest {
 
     @Test
-    void testGooglePlace() {
-        PlaceInfo info = googlePlacesClient.fetchPlaceInfo("Hyatt Regency Paris Etoile", "Paris");
-        System.out.println("result = " + info);
+    void searchTextMapsGooglePlacesResponse() throws IOException {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .setBody("""
+                            {
+                              "places": [
+                                {
+                                  "id": "ChIJ92BD_-2ifDURWdfj5R8TWjs",
+                                  "formattedAddress": "대한민국 서울특별시 중구 을지로 30",
+                                  "rating": 4.5,
+                                  "userRatingCount": 8734,
+                                  "displayName": {
+                                    "text": "롯데호텔 서울",
+                                    "languageCode": "ko"
+                                  }
+                                }
+                              ]
+                            }
+                            """));
+
+            GooglePlacesClient client = new GooglePlacesClient(
+                    WebClient.builder().baseUrl(server.url("/").toString()).build(),
+                    new GooglePlacesProperties("test-api-key", server.url("/").toString())
+            );
+
+            Optional<PlacesResponse> response = client.searchText("Lotte Hotel Seoul");
+
+            assertThat(response).isPresent();
+            assertThat(response.get().places()).hasSize(1);
+            PlacesResponse.Place place = response.get().places().getFirst();
+            assertThat(place.displayName().text()).isEqualTo("롯데호텔 서울");
+            assertThat(place.formattedAddress()).isEqualTo("대한민국 서울특별시 중구 을지로 30");
+            assertThat(place.rating()).isEqualTo(4.5);
+            assertThat(place.userRatingCount()).isEqualTo(8734);
+        }
     }
 }


### PR DESCRIPTION
## 📌 PR 요약   
  - AI 채팅 SSE 스트림의 에러 처리 방식을 개선하고, 채팅 메모리 직렬화 오류를 수정합니다.
  - 전반적인 응답 안정성(Content-Type 누락, 빈 응답 처리, 접근 거부 핸들링)을 보강합니다.

## 🔧 변경 사항                                                                                                                                                       
  - **SSE 스트림 에러 처리**: 스트림 시작 전 예외 및 구독 중 예외를 `error` SSE 이벤트로 클라이언트에 전달하도록 개선. `sendStreamError` 헬퍼로 중복 제거, timeout      
  핸들러 및 null chunk 방어 추가                                                                                                                                           
❯ - **RdbChatMemory UnsupportedOperationException 수정**: `Stream.toList()`가 반환하는 unmodifiable list에 `add()` 호출 시 발생하던 예외를 `ArrayList`로 래핑하여 해결.
  `ChatMemoryCache` 레코드를 도입해 Redis 직렬화 타입을 명확히 하고, TOOL/SYSTEM 메시지 필터링 추가                                                                        
❯ - **PlaceService 빈 응답 정규화**: supply 서비스가 `null` 또는 `places: null`을 반환할 때 빈 리스트로 정규화
  - **GlobalExceptionHandler Content-Type 명시**: 모든 에러 응답에 `Content-Type: application/json` 헤더를 명시적으로 설정                                                 
❯ - **SecurityConfig ASYNC/ERROR dispatcher 및 accessDeniedHandler 추가**: ASYNC·ERROR dispatcher와 `/error` 경로를 허용 처리하고, 403 응답을 위한 `accessDeniedHandler`
   추가

## 📋 작업 상세 내용                                                                                                                                                  
  - [x] `ChatMessageController`: `sendStreamError` 헬퍼 추출, timeout 핸들러, null chunk 방어, 스트림 초기화 예외 처리                                                  
  - [x] `RdbChatMemory`: `ArrayList` 래핑으로 UnsupportedOperationException 수정, `ChatMemoryCache` 레코드 도입, 메시지 필터링 강화
  - [x] `PlaceService`: `normalizePlacesResponse`로 null 응답 정규화                                                                                                    
  - [x] `SupplyClient`: Feign URL 기본값 추가                                                                                                                           
  - [x] `GlobalExceptionHandler`: 모든 응답에 `MediaType.APPLICATION_JSON` 명시                                                                                        [x] `GlobaSecurityConfng`: ASYNC/ERROR dispatcher 허용, `/error` 화이트리스트, `accessDeniedHandler` 추가                                                                
  - [x] 테스트 추가: `RdbChatMemoryTest`, `PlaceControllerTest`, `PlaceServiceTest`, `GooglePlacesTest` 보완                                                            

## 🔗 관련 이슈
- closed #71                                                                                                          

## 📝 기타      
  - `RdbChatMemory`의 Redis 캐시 키에 저장되는 타입이 `List<Message>` → `ChatMemoryCache`로 변경됩니다. 기존 캐시가 남아있을 경우 역직렬화 실패 후 DB fallback이
  발생하고 자연스럽게 교체됩니다. 배포 시 Redis flush는 불필요합니다.
