### PR TITLE
Add architecture images to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@
 
 이 프로젝트는 두 개의 독립적으로 배포되는 Spring Boot 서비스로 구성된 **멀티 모듈 모노레포**입니다.
 
+V1
 <img width="1892" height="1698" alt="Sofly_Back_Architecture" src="docs/images/Sofly_Back_Architecture.jpg" />
+
+V2
+<img width="3062" height="1698" alt="sofly-v2 drawio (1)" src="https://github.com/user-attachments/assets/d364ba95-20c1-40bf-a177-1b125f509af6" />
 
 ---
 


### PR DESCRIPTION
This pull request updates the `README.md` to include architecture diagrams for both V1 and V2 of the project. This helps clarify the structure and evolution of the system for contributors and stakeholders.

Documentation updates:

* Added an architecture diagram for V1 (`docs/images/Sofly_Back_Architecture.jpg`) to visually represent the initial system design.
* Added an architecture diagram for V2 (linked via external URL) to illustrate the updated or planned system architecture.Added architecture images for V1 and V2 of the project.

