### PR TITLE
feat: Booking.com 딥링크 및 호텔 상세 조회 엔드포인트 추가

### DIFF
--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/hotel/controller/HotelController.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/hotel/controller/HotelController.java
@@ -3,6 +3,7 @@ package com.sofly.core.domain.hotel.controller;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.core.domain.hotel.service.HotelService;
 import com.sofly.core.global.client.dto.HotelDestination;
+import com.sofly.core.global.client.dto.HotelDetailsRequest;
 import com.sofly.core.global.client.dto.HotelOptionsRequest;
 import com.sofly.core.global.client.dto.HotelSearchRequest;
 import com.sofly.core.global.client.dto.HotelSortOption;
@@ -10,13 +11,16 @@ import com.sofly.core.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springdoc.core.annotations.ParameterObject;
 
+import java.beans.PropertyEditorSupport;
 import java.util.List;
 
 @Tag(name = "Hotel", description = "호텔 검색")
@@ -27,6 +31,30 @@ public class HotelController {
 
     private final HotelService hotelService;
 
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.registerCustomEditor(HotelSearchRequest.Units.class, new PropertyEditorSupport() {
+            @Override
+            public void setAsText(String text) {
+                setValue(text == null || text.isBlank() ? null : HotelSearchRequest.Units.valueOf(text.toUpperCase()));
+            }
+        });
+        binder.registerCustomEditor(HotelSearchRequest.TemperatureUnit.class, new PropertyEditorSupport() {
+            @Override
+            public void setAsText(String text) {
+                if (text == null || text.isBlank()) {
+                    setValue(null);
+                    return;
+                }
+                setValue("c".equalsIgnoreCase(text)
+                        ? HotelSearchRequest.TemperatureUnit.CELSIUS
+                        : "f".equalsIgnoreCase(text)
+                        ? HotelSearchRequest.TemperatureUnit.FAHRENHEIT
+                        : HotelSearchRequest.TemperatureUnit.valueOf(text.toUpperCase()));
+            }
+        });
+    }
+
     @Operation(summary = "호텔 검색")
     @GetMapping("/offers")
     public ResponseEntity<ApiResponse<JsonNode>> searchHotels(
@@ -34,6 +62,15 @@ public class HotelController {
             @ParameterObject HotelSearchRequest request
     ) {
         return ResponseEntity.ok(ApiResponse.success(hotelService.searchHotels(supplier, request)));
+    }
+
+    @Operation(summary = "호텔 상세 조회")
+    @GetMapping("/details")
+    public ResponseEntity<ApiResponse<JsonNode>> getHotelDetails(
+            @RequestParam(required = false) String supplier,
+            @ParameterObject HotelDetailsRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(hotelService.getHotelDetails(supplier, request)));
     }
 
     @Operation(summary = "호텔 목적지 자동완성")

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/hotel/service/HotelService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/hotel/service/HotelService.java
@@ -3,6 +3,7 @@ package com.sofly.core.domain.hotel.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.core.global.client.SupplyClient;
 import com.sofly.core.global.client.dto.HotelDestination;
+import com.sofly.core.global.client.dto.HotelDetailsRequest;
 import com.sofly.core.global.client.dto.HotelOptionsRequest;
 import com.sofly.core.global.client.dto.HotelSearchRequest;
 import com.sofly.core.global.client.dto.HotelSortOption;
@@ -23,6 +24,14 @@ public class HotelService {
     public JsonNode searchHotels(String supplier, HotelSearchRequest request) {
         try {
             return supplyClient.searchHotels(supplier, request);
+        } catch (FeignException e) {
+            throw new SoflyException(ErrorCode.SUPPLY_SERVICE_ERROR, e.getMessage());
+        }
+    }
+
+    public JsonNode getHotelDetails(String supplier, HotelDetailsRequest request) {
+        try {
+            return supplyClient.getHotelDetails(supplier, request);
         } catch (FeignException e) {
             throw new SoflyException(ErrorCode.SUPPLY_SERVICE_ERROR, e.getMessage());
         }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/SaveFlightRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/SaveFlightRequest.java
@@ -58,6 +58,7 @@ public class SaveFlightRequest {
 
     private String bookingToken;
     private String offerReference;
+    private String deepLinkUrl;
 
     @NotNull
     private FlightType flightType;

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/UpdateFlightRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/request/UpdateFlightRequest.java
@@ -41,6 +41,7 @@ public class UpdateFlightRequest {
 
     private String bookingToken;
     private String offerReference;
+    private String deepLinkUrl;
 
     private FlightType flightType;
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/SavedFlightResponse.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/dto/response/SavedFlightResponse.java
@@ -53,6 +53,7 @@ public class SavedFlightResponse {
     // 예약
     private String bookingToken;
     private String offerReference;
+    private String deepLinkUrl;
 
     private FlightType flightType;
 
@@ -86,6 +87,7 @@ public class SavedFlightResponse {
                 .personalItemIncluded(flight.getPersonalItemIncluded())
                 .bookingToken(flight.getBookingToken())
                 .offerReference(flight.getOfferReference())
+                .deepLinkUrl(flight.getDeepLinkUrl())
                 .flightType(flight.getFlightType())
                 .build();
     }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/entity/SavedFlight.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/entity/SavedFlight.java
@@ -110,6 +110,9 @@ public class SavedFlight extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String offerReference;      // d6a1f_3212210372
 
+    @Column(columnDefinition = "TEXT")
+    private String deepLinkUrl;         // Booking.com 예약 딥링크
+
     // ── 타입 ──────────────────────────────────────────
     @Enumerated(EnumType.STRING)
     @Builder.Default
@@ -124,7 +127,8 @@ public class SavedFlight extends BaseTimeEntity {
             LocalDateTime departureTime, LocalDateTime arrivalTime, Integer durationMinutes,
             Integer totalPrice, Integer baseFare, Integer tax, Integer platformFee, String currencyCode,
             Integer checkedBaggageKg, Integer checkedBaggagePiece, Integer cabinBaggageKg,
-            Boolean personalItemIncluded, String bookingToken, String offerReference, FlightType flightType) {
+            Boolean personalItemIncluded, String bookingToken, String offerReference,
+            String deepLinkUrl, FlightType flightType) {
         if (flightNumber != null) this.flightNumber = flightNumber;
         if (airline != null) this.airline = airline;
         if (airlineLogo != null) this.airlineLogo = airlineLogo;
@@ -152,6 +156,7 @@ public class SavedFlight extends BaseTimeEntity {
         if (personalItemIncluded != null) this.personalItemIncluded = personalItemIncluded;
         if (bookingToken != null) this.bookingToken = bookingToken;
         if (offerReference != null) this.offerReference = offerReference;
+        if (deepLinkUrl != null) this.deepLinkUrl = deepLinkUrl;
         if (flightType != null) this.flightType = flightType;
     }
 }

--- a/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/domain/workspace/service/WorkspaceService.java
@@ -383,6 +383,7 @@ public class WorkspaceService {
                 .personalItemIncluded(request.getPersonalItemIncluded())
                 .bookingToken(request.getBookingToken())
                 .offerReference(request.getOfferReference())
+                .deepLinkUrl(request.getDeepLinkUrl())
                 .flightType(request.getFlightType())
                 .build();
 
@@ -435,7 +436,7 @@ public class WorkspaceService {
                 request.getTotalPrice(), request.getBaseFare(), request.getTax(), request.getPlatformFee(), request.getCurrencyCode(),
                 request.getCheckedBaggageKg(), request.getCheckedBaggagePiece(), request.getCabinBaggageKg(),
                 request.getPersonalItemIncluded(), request.getBookingToken(), request.getOfferReference(),
-                request.getFlightType()
+                request.getDeepLinkUrl(), request.getFlightType()
         );
 
         return SavedFlightResponse.from(flight);

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/client/SupplyClient.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/client/SupplyClient.java
@@ -42,6 +42,12 @@ public interface SupplyClient {
             @SpringQueryMap HotelSearchRequest request
     );
 
+    @GetMapping("/supply/hotels/details")
+    JsonNode getHotelDetails(
+            @RequestParam(required = false) String supplier,
+            @SpringQueryMap HotelDetailsRequest request
+    );
+
     @GetMapping("/supply/hotels/destinations")
     List<HotelDestination> searchHotelDestinations(@RequestParam String query);
 

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/client/dto/HotelDetailsRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/client/dto/HotelDetailsRequest.java
@@ -1,0 +1,55 @@
+package com.sofly.core.global.client.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class HotelDetailsRequest {
+
+    @Schema(defaultValue = "191605", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String hotelId;
+
+    @Schema(defaultValue = "2026-04-06", requiredMode = Schema.RequiredMode.REQUIRED)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate arrivalDate;
+
+    @Schema(defaultValue = "2026-04-08", requiredMode = Schema.RequiredMode.REQUIRED)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate departureDate;
+
+    @Schema(defaultValue = "1")
+    private Integer adults;
+
+    @Schema(defaultValue = "0")
+    private String childrenAge;
+
+    @Schema(defaultValue = "1")
+    private Integer roomQty;
+
+    @Schema(defaultValue = "METRIC")
+    private HotelSearchRequest.Units units;
+
+    @Schema(defaultValue = "Celsius")
+    private HotelSearchRequest.TemperatureUnit temperatureUnit;
+
+    @Schema(defaultValue = "ko")
+    private String languageCode;
+
+    @Schema(defaultValue = "KRW")
+    private String currencyCode;
+}

--- a/services/travel-core-service/src/main/java/com/sofly/core/global/client/dto/HotelSearchRequest.java
+++ b/services/travel-core-service/src/main/java/com/sofly/core/global/client/dto/HotelSearchRequest.java
@@ -1,5 +1,6 @@
 package com.sofly.core.global.client.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -14,27 +15,56 @@ import java.time.LocalDate;
 @ToString
 public class HotelSearchRequest {
 
+    @Schema(description = "목적지 ID (/api/v1/hotels/destinations 로 조회)", defaultValue = "267199", requiredMode = Schema.RequiredMode.REQUIRED)
     private String destId;
+
+    @Schema(description = "검색 타입 (/api/v1/hotels/destinations 응답의 dest_type)", defaultValue = "LANDMARK", requiredMode = Schema.RequiredMode.REQUIRED)
     private String searchType;
 
+    @Schema(description = "체크인 날짜 (yyyy-MM-dd)", defaultValue = "2026-06-01", requiredMode = Schema.RequiredMode.REQUIRED)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate arrivalDate;
 
+    @Schema(description = "체크아웃 날짜 (yyyy-MM-dd)", defaultValue = "2026-06-03", requiredMode = Schema.RequiredMode.REQUIRED)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate departureDate;
 
+    @Schema(description = "성인 인원 수", defaultValue = "1")
     private Integer adults;
+
+    @Schema(description = "아동 나이 (쉼표 구분, 예: 5,7)", defaultValue = "0")
     private String childrenAge;
+
+    @Schema(description = "객실 수", defaultValue = "1")
     private Integer roomQty;
+
+    @Schema(description = "페이지 번호", defaultValue = "1")
     private Integer pageNumber;
+
+    @Schema(description = "최소 가격", defaultValue = "0")
     private Float priceMin;
+
+    @Schema(description = "최대 가격 (0이면 제한 없음)", defaultValue = "0")
     private Float priceMax;
+
+    @Schema(description = "정렬 기준 (/api/v1/hotels/sort-options 로 목록 조회)", defaultValue = "price")
     private String sortBy;
+
+    @Schema(description = "필터 (/api/v1/hotels/filter-options 로 목록 조회)", defaultValue = "popular")
     private String categoriesFilter;
+
+    @Schema(description = "단위 (METRIC / IMPERIAL)", defaultValue = "METRIC")
     private Units units;
+
+    @Schema(description = "온도 단위 (CELSIUS / FAHRENHEIT)", defaultValue = "CELSIUS")
     private TemperatureUnit temperatureUnit;
+
+    @Schema(description = "언어 코드", defaultValue = "ko")
     private String languageCode;
+
+    @Schema(description = "통화 코드", defaultValue = "KRW")
     private String currencyCode;
+
     private String location;
 
     public enum Units {

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/inbound/rest/HotelSearchController.java
@@ -2,6 +2,7 @@ package com.sofly.supply.adapter.inbound.rest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.application.dto.HotelDestination;
+import com.sofly.supply.application.dto.HotelDetailsRequest;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.dto.HotelSortOption;
@@ -39,7 +40,15 @@ public class HotelSearchController {
         binder.registerCustomEditor(HotelSearchRequest.TemperatureUnit.class, new PropertyEditorSupport() {
             @Override
             public void setAsText(String text) {
-                setValue(text == null || text.isBlank() ? null : HotelSearchRequest.TemperatureUnit.valueOf(text.toUpperCase()));
+                if (text == null || text.isBlank()) {
+                    setValue(null);
+                    return;
+                }
+                setValue("c".equalsIgnoreCase(text)
+                        ? HotelSearchRequest.TemperatureUnit.CELSIUS
+                        : "f".equalsIgnoreCase(text)
+                        ? HotelSearchRequest.TemperatureUnit.FAHRENHEIT
+                        : HotelSearchRequest.TemperatureUnit.valueOf(text.toUpperCase()));
             }
         });
     }
@@ -52,6 +61,16 @@ public class HotelSearchController {
             @ParameterObject @ModelAttribute HotelSearchRequest request
     ) {
         return hotelSearchService.search(supplier, request);
+    }
+
+    @Operation(summary = "호텔 상세 조회", description = "검색 응답의 hotel_id로 호텔 상세/객실/가격 정보를 조회합니다. 기본값: booking")
+    @GetMapping("/details")
+    public JsonNode details(
+            @Parameter(description = "공급자 키 (booking)", example = "booking")
+            @RequestParam(required = false) String supplier,
+            @ParameterObject @ModelAttribute HotelDetailsRequest request
+    ) {
+        return hotelSearchService.getHotelDetails(supplier, request);
     }
 
     @Operation(summary = "호텔 목적지 검색", description = "도시/지역명으로 dest_id와 search_type을 조회합니다. 호텔 검색 전에 먼저 호출하세요. 반환값에서 dest_id와 dest_type을 사용하면 됩니다.")

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/BookingDeepLinkBuilder.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/BookingDeepLinkBuilder.java
@@ -1,0 +1,75 @@
+package com.sofly.supply.adapter.outbound.rapidapi;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class BookingDeepLinkBuilder {
+
+    private BookingDeepLinkBuilder() {}
+
+    /**
+     * Booking.com 항공권 예약 딥링크 생성
+     * <p>예) https://flights.booking.com/flights/ICN.AIRPORT-HND.AIRPORT/{token}/
+     * ?type=ROUNDTRIP&adults=1&cabinClass=ECONOMY&depart=2026-07-06&return=2026-07-09&sort=BEST
+     *
+     * @param token      flightOffers[].token (Booking.com 내부 인코딩 토큰)
+     * @param origin     출발 IATA 코드 (예: ICN)
+     * @param dest       도착 IATA 코드 (예: HND)
+     * @param departDate 출발일 (yyyy-MM-dd)
+     * @param returnDate 귀국일 (yyyy-MM-dd, 편도면 null)
+     * @param tripType   ROUNDTRIP | ONE_WAY
+     * @param cabinClass ECONOMY, BUSINESS 등
+     * @param adults     성인 수
+     */
+    public static String buildFlightUrl(String token, String origin, String dest,
+                                  String departDate, String returnDate,
+                                  String tripType, String cabinClass, int adults) {
+        String route = origin + ".AIRPORT-" + dest + ".AIRPORT";
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl("https://flights.booking.com/flights/" + route + "/" + token + "/")
+                .queryParam("type", tripType)
+                .queryParam("adults", adults)
+                .queryParam("cabinClass", cabinClass != null ? cabinClass : "ECONOMY")
+                .queryParam("from", origin + ".AIRPORT")
+                .queryParam("to", dest + ".AIRPORT")
+                .queryParam("depart", departDate)
+                .queryParam("sort", "BEST");
+        if (returnDate != null && !returnDate.isBlank()) {
+            builder.queryParam("return", returnDate);
+        }
+        return builder.build().toUriString();
+    }
+
+    /**
+     * Booking.com 호텔 예약 딥링크 생성
+     * <p>예) https://www.booking.com/hotel/kr/half-rest-hostel-jongno-insa.html
+     * ?checkin=2026-05-29&checkout=2026-05-30&group_adults=2
+     * <p>API 응답에 slug가 없으므로 property.name을 slugify하여 사용.
+     * slug 불일치 시 Booking.com이 검색 결과 페이지로 fallback 리다이렉트함.
+     *
+     * @param hotelName   property.name (예: Half Rest Hostel Jongno)
+     * @param countryCode property.countryCode (예: kr)
+     * @param checkin     체크인 날짜 (yyyy-MM-dd)
+     * @param checkout    체크아웃 날짜 (yyyy-MM-dd)
+     * @param adults      성인 수
+     */
+    public static String buildHotelUrl(String hotelName, String countryCode,
+                                 String checkin, String checkout, int adults) {
+        String slug = slugify(hotelName);
+        return UriComponentsBuilder
+                .fromHttpUrl("https://www.booking.com/hotel/" + countryCode + "/" + slug + ".html")
+                .queryParam("checkin", checkin)
+                .queryParam("checkout", checkout)
+                .queryParam("group_adults", adults)
+                .build()
+                .toUriString();
+    }
+
+    /** "The Taj Mahal Tower, Mumbai" → "the-taj-mahal-tower-mumbai" */
+    private static String slugify(String name) {
+        if (name == null) return "hotel";
+        return name.toLowerCase()
+                .replaceAll("[^a-z0-9\\s-]", "")
+                .trim()
+                .replaceAll("\\s+", "-");
+    }
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/BookingDeepLinkBuilder.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/BookingDeepLinkBuilder.java
@@ -69,9 +69,10 @@ public class BookingDeepLinkBuilder {
     /** "The Taj Mahal Tower, Mumbai" → "the-taj-mahal-tower-mumbai" */
     private static String slugify(String name) {
         if (name == null) return "hotel";
-        return name.toLowerCase()
+        String slug = name.toLowerCase()
                 .replaceAll("[^a-z0-9\\s-]", "")
                 .trim()
                 .replaceAll("\\s+", "-");
+        return slug.isEmpty() ? "hotel" : slug;
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/BookingDeepLinkBuilder.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/BookingDeepLinkBuilder.java
@@ -7,25 +7,16 @@ public class BookingDeepLinkBuilder {
     private BookingDeepLinkBuilder() {}
 
     /**
-     * Booking.com 항공권 예약 딥링크 생성
-     * <p>예) https://flights.booking.com/flights/ICN.AIRPORT-HND.AIRPORT/{token}/
-     * ?type=ROUNDTRIP&adults=1&cabinClass=ECONOMY&depart=2026-07-06&return=2026-07-09&sort=BEST
-     *
-     * @param token      flightOffers[].token (Booking.com 내부 인코딩 토큰)
-     * @param origin     출발 IATA 코드 (예: ICN)
-     * @param dest       도착 IATA 코드 (예: HND)
-     * @param departDate 출발일 (yyyy-MM-dd)
-     * @param returnDate 귀국일 (yyyy-MM-dd, 편도면 null)
-     * @param tripType   ROUNDTRIP | ONE_WAY
-     * @param cabinClass ECONOMY, BUSINESS 등
-     * @param adults     성인 수
+     * Booking.com 항공권 검색 딥링크 생성.
+     * <p>RapidAPI의 flightOffers[].token은 getFlightDetails API용 토큰이며,
+     * flights.booking.com 웹 경로의 offer token과 항상 호환된다고 볼 수 없다.
      */
-    public static String buildFlightUrl(String token, String origin, String dest,
-                                  String departDate, String returnDate,
-                                  String tripType, String cabinClass, int adults) {
+    public static String buildFlightSearchUrl(String origin, String dest,
+                                              String departDate, String returnDate,
+                                              String tripType, String cabinClass, int adults) {
         String route = origin + ".AIRPORT-" + dest + ".AIRPORT";
         UriComponentsBuilder builder = UriComponentsBuilder
-                .fromHttpUrl("https://flights.booking.com/flights/" + route + "/" + token + "/")
+                .fromHttpUrl("https://flights.booking.com/flights/" + route + "/")
                 .queryParam("type", tripType)
                 .queryParam("adults", adults)
                 .queryParam("cabinClass", cabinClass != null ? cabinClass : "ECONOMY")
@@ -37,6 +28,17 @@ public class BookingDeepLinkBuilder {
             builder.queryParam("return", returnDate);
         }
         return builder.build().toUriString();
+    }
+
+    /**
+     * @deprecated Use {@link #buildFlightSearchUrl(String, String, String, String, String, String, int)}.
+     * The token accepted here is an API token, not a reliable public Booking.com URL token.
+     */
+    @Deprecated
+    public static String buildFlightUrl(String token, String origin, String dest,
+                                  String departDate, String returnDate,
+                                  String tripType, String cabinClass, int adults) {
+        return buildFlightSearchUrl(origin, dest, departDate, returnDate, tripType, cabinClass, adults);
     }
 
     /**

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
@@ -18,7 +18,7 @@ class BookingComFlightResponseFilter {
 
     private BookingComFlightResponseFilter() {}
 
-    static JsonNode filter(JsonNode root, List<String> airlineFilter) {
+    static JsonNode filter(JsonNode root, List<String> airlineFilter, int adults) {
         ObjectNode result = MAPPER.createObjectNode();
         result.put("status", root.path("status").asBoolean());
 
@@ -29,7 +29,7 @@ class BookingComFlightResponseFilter {
         Map<String, ObjectNode> availableAirlines = extractAvailableAirlines(allOffers);
 
         ObjectNode filteredData = MAPPER.createObjectNode();
-        filteredData.set("flightOffers", filterOffers(allOffers, airlineFilter));
+        filteredData.set("flightOffers", filterOffers(allOffers, airlineFilter, adults));
         filteredData.set("aggregation", buildAggregation(data.path("aggregation").path("totalCount").asLong(), availableAirlines, null));
         result.set("data", filteredData);
         return result;
@@ -83,7 +83,11 @@ class BookingComFlightResponseFilter {
     }
 
     static ObjectNode mapOffer(JsonNode offer) {
-        return filterOffer(offer);
+        return mapOffer(offer, 1);
+    }
+
+    static ObjectNode mapOffer(JsonNode offer, int adults) {
+        return filterOffer(offer, adults);
     }
 
     private static ObjectNode buildAggregation(long totalCount, Map<String, ObjectNode> availableAirlines,
@@ -97,20 +101,20 @@ class BookingComFlightResponseFilter {
         return node;
     }
 
-    private static ArrayNode filterOffers(JsonNode offers, List<String> airlineFilter) {
+    private static ArrayNode filterOffers(JsonNode offers, List<String> airlineFilter, int adults) {
         ArrayNode result = MAPPER.createArrayNode();
         Set<String> filterSet = airlineFilter != null && !airlineFilter.isEmpty()
                 ? new java.util.HashSet<>(airlineFilter)
                 : null;
         for (JsonNode offer : offers) {
             if (filterSet == null || matchesAirlineFilter(offer, filterSet)) {
-                result.add(filterOffer(offer));
+                result.add(filterOffer(offer, adults));
             }
         }
         return result;
     }
 
-    private static ObjectNode filterOffer(JsonNode offer) {
+    private static ObjectNode filterOffer(JsonNode offer, int adults) {
         ObjectNode node = MAPPER.createObjectNode();
 
         String token = offer.path("token").asText();
@@ -120,7 +124,8 @@ class BookingComFlightResponseFilter {
         node.put("tripType", tripType);
         node.put("offerKeyToHighlight", offer.path("offerKeyToHighlight").asText());
 
-        // 예약 딥링크 생성
+        // Public Booking.com links use a different, session-sensitive token than RapidAPI details.
+        // Send users to the matching search result page instead of constructing a tokenized offer URL.
         JsonNode segments = offer.path("segments");
         if (!segments.isEmpty()) {
             JsonNode firstSeg = segments.get(0);
@@ -134,9 +139,9 @@ class BookingComFlightResponseFilter {
                     : null;
             String cabinClass = extractCabinClass(offer);
 
-            if (!token.isEmpty() && !origin.isEmpty() && !dest.isEmpty() && departDate != null) {
-                String bookingUrl = BookingDeepLinkBuilder.buildFlightUrl(
-                        token, origin, dest, departDate, returnDate, tripType, cabinClass, 1);
+            if (!origin.isEmpty() && !dest.isEmpty() && departDate != null) {
+                String bookingUrl = BookingDeepLinkBuilder.buildFlightSearchUrl(
+                        origin, dest, departDate, returnDate, tripType, cabinClass, adults);
                 node.put("bookingUrl", bookingUrl);
             }
         }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
@@ -127,7 +127,7 @@ class BookingComFlightResponseFilter {
         // Public Booking.com links use a different, session-sensitive token than RapidAPI details.
         // Send users to the matching search result page instead of constructing a tokenized offer URL.
         JsonNode segments = offer.path("segments");
-        if (!segments.isEmpty()) {
+        if (segments.isArray() && !segments.isEmpty()) {
             JsonNode firstSeg = segments.get(0);
             JsonNode lastSeg = segments.get(segments.size() - 1);
 
@@ -219,7 +219,7 @@ class BookingComFlightResponseFilter {
     /** 첫 번째 leg의 cabinClass 반환, 없으면 "ECONOMY" */
     private static String extractCabinClass(JsonNode offer) {
         JsonNode legs = offer.path("segments").path(0).path("legs");
-        if (!legs.isEmpty()) {
+        if (legs.isArray() && !legs.isEmpty()) {
             String cabin = legs.get(0).path("cabinClass").asText();
             if (!cabin.isEmpty()) return cabin;
         }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightResponseFilter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sofly.supply.adapter.outbound.rapidapi.BookingDeepLinkBuilder;
 
 import java.util.List;
 import java.util.Set;
@@ -111,9 +112,34 @@ class BookingComFlightResponseFilter {
 
     private static ObjectNode filterOffer(JsonNode offer) {
         ObjectNode node = MAPPER.createObjectNode();
-        node.put("token", offer.path("token").asText());
-        node.put("tripType", offer.path("tripType").asText());
+
+        String token = offer.path("token").asText();
+        String tripType = offer.path("tripType").asText();
+
+        node.put("token", token);
+        node.put("tripType", tripType);
         node.put("offerKeyToHighlight", offer.path("offerKeyToHighlight").asText());
+
+        // 예약 딥링크 생성
+        JsonNode segments = offer.path("segments");
+        if (!segments.isEmpty()) {
+            JsonNode firstSeg = segments.get(0);
+            JsonNode lastSeg = segments.get(segments.size() - 1);
+
+            String origin = firstSeg.path("departureAirport").path("code").asText();
+            String dest = firstSeg.path("arrivalAirport").path("code").asText();
+            String departDate = extractDate(firstSeg.path("departureTime").asText());
+            String returnDate = "ROUNDTRIP".equalsIgnoreCase(tripType)
+                    ? extractDate(lastSeg.path("departureTime").asText())
+                    : null;
+            String cabinClass = extractCabinClass(offer);
+
+            if (!token.isEmpty() && !origin.isEmpty() && !dest.isEmpty() && departDate != null) {
+                String bookingUrl = BookingDeepLinkBuilder.buildFlightUrl(
+                        token, origin, dest, departDate, returnDate, tripType, cabinClass, 1);
+                node.put("bookingUrl", bookingUrl);
+            }
+        }
 
         JsonNode seat = offer.path("seatAvailability");
         if (!seat.isMissingNode()) node.set("seatAvailability", seat);
@@ -177,6 +203,22 @@ class BookingComFlightResponseFilter {
         String terminal = airport.path("terminal").asText(null);
         if (terminal != null && !terminal.isEmpty()) node.put("terminal", terminal);
         return node;
+    }
+
+    /** "2026-07-06T10:30:00" → "2026-07-06", 파싱 실패 시 null */
+    private static String extractDate(String dateTime) {
+        if (dateTime == null || dateTime.length() < 10) return null;
+        return dateTime.substring(0, 10);
+    }
+
+    /** 첫 번째 leg의 cabinClass 반환, 없으면 "ECONOMY" */
+    private static String extractCabinClass(JsonNode offer) {
+        JsonNode legs = offer.path("segments").path(0).path("legs");
+        if (!legs.isEmpty()) {
+            String cabin = legs.get(0).path("cabinClass").asText();
+            if (!cabin.isEmpty()) return cabin;
+        }
+        return "ECONOMY";
     }
 
     private static ArrayNode filterLegs(JsonNode legs) {

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
@@ -44,7 +44,11 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
         if (airlineFilter.isEmpty()) {
             String response = fetchPage(request, request.getPageNo());
             if (response == null) return RapidApiJsonUtils.nullNode();
-            return BookingComFlightResponseFilter.filter(RapidApiJsonUtils.parseJson(response), List.of());
+            return BookingComFlightResponseFilter.filter(
+                    RapidApiJsonUtils.parseJson(response),
+                    List.of(),
+                    request.getAdults()
+            );
         }
 
         return fetchFilteredUntilFull(request, airlineFilter);
@@ -94,7 +98,7 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
             int offsetInPage = (pageNo == startPage) ? startOffset : 0;
             for (int i = offsetInPage; i < offers.size(); i++) {
                 if (BookingComFlightResponseFilter.matchesAirlineFilter(offers.get(i), filterSet)) {
-                    collected.add(BookingComFlightResponseFilter.mapOffer(offers.get(i)));
+                    collected.add(BookingComFlightResponseFilter.mapOffer(offers.get(i), request.getAdults()));
                     if (collected.size() >= BookingComFlightResponseFilter.PAGE_SIZE) {
                         nextPageCursor = (i + 1 < offers.size())
                                 ? pageNo + ":" + (i + 1)

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/flights/BookingComFlightSupplierAdapter.java
@@ -47,7 +47,7 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
             return BookingComFlightResponseFilter.filter(
                     RapidApiJsonUtils.parseJson(response),
                     List.of(),
-                    request.getAdults()
+                    request.getAdults() != null ? request.getAdults() : 1
             );
         }
 
@@ -98,7 +98,7 @@ public class BookingComFlightSupplierAdapter implements FlightSupplierPort {
             int offsetInPage = (pageNo == startPage) ? startOffset : 0;
             for (int i = offsetInPage; i < offers.size(); i++) {
                 if (BookingComFlightResponseFilter.matchesAirlineFilter(offers.get(i), filterSet)) {
-                    collected.add(BookingComFlightResponseFilter.mapOffer(offers.get(i), request.getAdults()));
+                    collected.add(BookingComFlightResponseFilter.mapOffer(offers.get(i), request.getAdults() != null ? request.getAdults() : 1));
                     if (collected.size() >= BookingComFlightResponseFilter.PAGE_SIZE) {
                         nextPageCursor = (i + 1 < offers.size())
                                 ? pageNo + ":" + (i + 1)

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sofly.supply.adapter.outbound.rapidapi.BookingDeepLinkBuilder;
 import com.sofly.supply.adapter.outbound.rapidapi.RapidApiJsonUtils;
+import com.sofly.supply.application.dto.HotelDetailsRequest;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.port.outbound.HotelSupplierPort;
 import lombok.RequiredArgsConstructor;
@@ -73,6 +74,46 @@ public class BookingComHotelAdapter implements HotelSupplierPort {
         JsonNode root = RapidApiJsonUtils.parseJson(response);
         injectHotelDeepLinks(root, request);
         return root;
+    }
+
+    @Cacheable(
+            value = "bookingHotelDetails",
+            key = "#request",
+            unless = "#result == null || #result.path('status').asBoolean() == false || #result.path('data').isMissingNode()"
+    )
+    @Override
+    public JsonNode getHotelDetails(HotelDetailsRequest request) {
+        String response = rapidApiWebClient.get()
+                .uri(urlBuilder -> {
+                    var builder = urlBuilder
+                            .path("/api/v1/hotels/getHotelDetails")
+                            .queryParam("hotel_id", request.getHotelId())
+                            .queryParam("arrival_date", request.getArrivalDate())
+                            .queryParam("departure_date", request.getDepartureDate());
+
+                    if (request.getAdults() != null)
+                        builder.queryParam("adults", request.getAdults());
+                    if (request.getChildrenAge() != null)
+                        builder.queryParam("children_age", request.getChildrenAge());
+                    if (request.getRoomQty() != null)
+                        builder.queryParam("room_qty", request.getRoomQty());
+                    if (request.getUnits() != null)
+                        builder.queryParam("units", request.getUnits().name().toLowerCase());
+                    if (request.getTemperatureUnit() != null)
+                        builder.queryParam("temperature_unit", request.getTemperatureUnit().getValue());
+                    if (request.getLanguageCode() != null)
+                        builder.queryParam("languagecode", request.getLanguageCode());
+                    if (request.getCurrencyCode() != null)
+                        builder.queryParam("currency_code", request.getCurrencyCode());
+
+                    return builder.build();
+                })
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        if (response == null) return RapidApiJsonUtils.nullNode();
+        return RapidApiJsonUtils.parseJson(response);
     }
 
     /**

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/adapter/outbound/rapidapi/hotels/BookingComHotelAdapter.java
@@ -1,6 +1,8 @@
 package com.sofly.supply.adapter.outbound.rapidapi.hotels;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sofly.supply.adapter.outbound.rapidapi.BookingDeepLinkBuilder;
 import com.sofly.supply.adapter.outbound.rapidapi.RapidApiJsonUtils;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.port.outbound.HotelSupplierPort;
@@ -67,6 +69,36 @@ public class BookingComHotelAdapter implements HotelSupplierPort {
                 .block();
 
         if (response == null) return RapidApiJsonUtils.nullNode();
-        return RapidApiJsonUtils.parseJson(response);
+
+        JsonNode root = RapidApiJsonUtils.parseJson(response);
+        injectHotelDeepLinks(root, request);
+        return root;
+    }
+
+    /**
+     * 각 호텔의 property 노드에 bookingUrl 필드를 추가한다.
+     * 호텔 slug는 API가 제공하지 않으므로 property.name을 slugify하여 사용.
+     */
+    private void injectHotelDeepLinks(JsonNode root, HotelSearchRequest request) {
+        JsonNode hotels = root.path("data").path("hotels");
+        if (!hotels.isArray()) return;
+
+        int adults = request.getAdults() != null ? request.getAdults() : 1;
+        String checkin = request.getArrivalDate() != null ? request.getArrivalDate().toString() : null;
+        String checkout = request.getDepartureDate() != null ? request.getDepartureDate().toString() : null;
+
+        for (JsonNode hotel : hotels) {
+            JsonNode property = hotel.path("property");
+            if (!property.isObject()) continue;
+
+            String name = property.path("name").asText(null);
+            String countryCode = property.path("countryCode").asText(null);
+
+            if (name != null && countryCode != null && checkin != null && checkout != null) {
+                String bookingUrl = BookingDeepLinkBuilder.buildHotelUrl(
+                        name, countryCode, checkin, checkout, adults);
+                ((ObjectNode) property).put("bookingUrl", bookingUrl);
+            }
+        }
     }
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelDetailsRequest.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/dto/HotelDetailsRequest.java
@@ -1,0 +1,55 @@
+package com.sofly.supply.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class HotelDetailsRequest {
+
+    @Schema(defaultValue = "191605", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String hotelId;
+
+    @Schema(defaultValue = "2026-04-06", requiredMode = Schema.RequiredMode.REQUIRED)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate arrivalDate;
+
+    @Schema(defaultValue = "2026-04-08", requiredMode = Schema.RequiredMode.REQUIRED)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate departureDate;
+
+    @Schema(defaultValue = "1")
+    private Integer adults;
+
+    @Schema(defaultValue = "0")
+    private String childrenAge;
+
+    @Schema(defaultValue = "1")
+    private Integer roomQty;
+
+    @Schema(defaultValue = "METRIC")
+    private HotelSearchRequest.Units units;
+
+    @Schema(defaultValue = "Celsius")
+    private HotelSearchRequest.TemperatureUnit temperatureUnit;
+
+    @Schema(defaultValue = "ko")
+    private String languageCode;
+
+    @Schema(defaultValue = "KRW")
+    private String currencyCode;
+}

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/HotelSupplierPort.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/port/outbound/HotelSupplierPort.java
@@ -1,6 +1,7 @@
 package com.sofly.supply.application.port.outbound;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sofly.supply.application.dto.HotelDetailsRequest;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 
 public interface HotelSupplierPort {
@@ -9,4 +10,6 @@ public interface HotelSupplierPort {
     String supplierKey();
 
     JsonNode searchHotelsByCity(HotelSearchRequest request);
+
+    JsonNode getHotelDetails(HotelDetailsRequest request);
 }

--- a/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
+++ b/services/travel-supply-service/src/main/java/com/sofly/supply/application/service/HotelSearchService.java
@@ -2,6 +2,7 @@ package com.sofly.supply.application.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sofly.supply.application.dto.HotelDestination;
+import com.sofly.supply.application.dto.HotelDetailsRequest;
 import com.sofly.supply.application.dto.HotelOptionsRequest;
 import com.sofly.supply.application.dto.HotelSearchRequest;
 import com.sofly.supply.application.dto.HotelSortOption;
@@ -23,6 +24,10 @@ public class HotelSearchService {
 
     public JsonNode search(String supplier, HotelSearchRequest request) {
         return router.selectHotelSupplier(supplier).searchHotelsByCity(request);
+    }
+
+    public JsonNode getHotelDetails(String supplier, HotelDetailsRequest request) {
+        return router.selectHotelSupplier(supplier).getHotelDetails(request);
     }
 
     public List<HotelDestination> searchDestination(String query) {


### PR DESCRIPTION
## 📌 PR 요약
Booking.com 딥링크 URL 생성 및 호텔 상세 조회 기능을 추가합니다. 항공편·호텔 검색 결과에 Booking.com 예약 페이지로 이동할 수 있는 `bookingUrl`을 함께 제공하고, 저장된 항공편에도 딥링크 URL을 기록할 수 있도록 합니다.

## 🔧 변경 사항

### supply-service
- `BookingDeepLinkBuilder` 신규 추가: 항공편 검색 결과 페이지 URL 및 호텔 페이지 URL 빌드 유틸리티
  - 항공편: Booking.com 공개 링크는 RapidAPI 세션 토큰과 달라 토큰 기반 URL 구성이 불가하므로, 출발/도착/날짜/좌석등급 파라미터로 검색 결과 페이지 URL을 생성
  - 호텔: property name을 slugify하여 호텔 페이지 URL 생성
- `BookingComFlightResponseFilter`: `filterOffer` / `mapOffer`에 `adults` 파라미터 추가, 각 offer에 `bookingUrl` 필드 주입
- `BookingComHotelAdapter`: 호텔 검색 응답의 각 property에 `bookingUrl` 주입 (`injectHotelDeepLinks`)
- `BookingComHotelAdapter.getHotelDetails()` 구현 및 캐싱 적용 (`bookingHotelDetails`)
- `HotelSupplierPort`에 `getHotelDetails(HotelDetailsRequest)` 메서드 추가
- `HotelDetailsRequest` DTO 추가 (supply-service)
- `HotelSearchService.getHotelDetails()` 추가
- `HotelSearchController`에 `/api/v1/hotels/details` GET 엔드포인트 추가

### core-service
- `HotelDetailsRequest` DTO 추가 (core-service, Feign 전달용)
- `SupplyClient`에 `getHotelDetails()` Feign 메서드 추가
- `HotelService.getHotelDetails()` 추가
- `HotelController`에 `GET /hotels/details` 엔드포인트 추가 및 enum `@InitBinder` 등록
- `SavedFlight` 엔티티에 `deepLinkUrl` 컬럼(TEXT) 추가
- `SaveFlightRequest`, `UpdateFlightRequest`, `SavedFlightResponse`에 `deepLinkUrl` 필드 반영

## 📋 작업 상세 내용
- [x] `BookingDeepLinkBuilder` 구현 (항공편 검색 URL / 호텔 URL)
- [x] 항공편 검색 응답 각 offer에 `bookingUrl` 필드 추가
- [x] 호텔 검색 응답 각 property에 `bookingUrl` 필드 추가
- [x] 호텔 상세 조회 엔드포인트 추가 (supply / core 양쪽)
- [x] `SavedFlight.deepLinkUrl` 컬럼 추가 및 저장/수정/조회 DTO 반영

## 🔗 관련 이슈
- closed #80

## 📝 기타
- 호텔 딥링크는 Booking.com이 slug를 API로 제공하지 않아 name을 소문자+하이픈으로 변환하는 방식을 사용합니다. 실제 slug와 다를 수 있어 UI에서 fallback 처리가 필요할 수 있습니다.
- `SavedFlight.deepLinkUrl` 추가로 DB 마이그레이션(컬럼 추가)이 필요합니다.